### PR TITLE
Fix #935: provenance at commit time; restart recovery preserves accepted commits

### DIFF
--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -256,10 +256,17 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `awf workspace show <workspace_id>`
 **Docs Link:** [docs/REASON_CATALOG.md#comment_repair_unpublished_abandoned](#comment_repair_unpublished_abandoned)
 
+### COMMENT_REPAIR_UNPUBLISHED_PRESERVED
+**Problem:** AWF resumed an interrupted PR-comment repair from its unpushed local commits.
+**Likely Cause:** A restart interrupted the repair batch mid-way. The local commits ahead of the PR head carry comment-repair provenance, so AWF kept them and continued the batch instead of discarding accepted review fixes.
+**Operator Fix:** No action is required. The commits are pushed with the next monitor cycle; watch the PR for the repair push.
+**Related Command:** `awf workspace show <workspace_id>`
+**Docs Link:** [docs/REASON_CATALOG.md#comment_repair_unpublished_preserved](#comment_repair_unpublished_preserved)
+
 ### COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING
-**Problem:** AWF blocked comment repair because unpushed local commits lack comment-repair provenance.
-**Likely Cause:** Local HEAD advanced past the remote PR head without a matching comment-repair operation fingerprint, or with conflicting non-comment repair provenance. AWF refused to reset or push those commits.
-**Operator Fix:** Inspect the worktree for unrelated local commits, preserve or reset them manually if needed, then remonitor the workspace.
+**Problem:** AWF parked comment repair for a human: unpushed local commits could not be attributed to this repair batch. The commits are preserved.
+**Likely Cause:** Local HEAD advanced past the remote PR head without matching comment-repair provenance, or with conflicting non-comment repair provenance. AWF refused to reset or push those commits and left the worktree untouched instead of failing the workspace.
+**Operator Fix:** Inspect the named commits in the workspace worktree, then either keep them (push or let AWF resume) or drop them manually, and remonitor the workspace.
 **Related Command:** `awf workspace logs <workspace_id>`
 **Docs Link:** [docs/REASON_CATALOG.md#comment_repair_unpublished_provenance_missing](#comment_repair_unpublished_provenance_missing)
 

--- a/src/awf/runtime/monitor_state_keys.py
+++ b/src/awf/runtime/monitor_state_keys.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+# Reserved ``MonitorState.threads_addressed_ids`` key holding the commit-time
+# comment-repair provenance chain (#935). Value is a JSON list of
+# ``{item_id, item_start_head, head_sha, operation_id}`` records that link the
+# remote PR head to local HEAD, one per review item accepted with a commit. Like
+# the other ``__awf_…`` reserved keys it is inert to ``decide()``: nothing
+# iterates that map's values, and no review item can collide with the name.
+_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY = "__awf_comment_repair_unpublished_provenance__"
+
 
 def _non_check_reviewer_settle_started_key(
     *,

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -260,8 +260,9 @@ class MonitorState:
     # One accepted comment-repair item whose end-HEAD probe failed, as opaque JSON
     # owned by ``pr_monitor_runner.comment_repair_provenance`` (#937). Deliberately
     # transient and never persisted: the next item of the same batch completes the
-    # record from its own start head — which IS the previous item's end head — and
-    # after a restart there is no live batch left to complete it against.
+    # record from its own start head — which IS the previous item's end head — the
+    # batch re-probes HEAD before pushing to settle its last item, and after a
+    # restart there is no live batch left to complete it against.
     pending_item_commit_provenance: str | None = field(
         default=None,
         init=False,

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -32,13 +32,14 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Literal
 
-from awf.runtime._docker_pull_detection import _log_shows_docker_registry_timeout
+from awf.runtime._docker_pull_detection import (
+    _log_shows_docker_registry_timeout as _log_shows_docker_registry_timeout,
+)
 from awf.runtime.feedback_policy import (
     CLOSED_OUTDATED_THREAD_VERDICTS,
     canonical_unresolved_inline_threads,
@@ -70,6 +71,42 @@ from awf.runtime.pr_monitor_actions import (
     SyncBase,
     WaitForCI,
     WaitForTransientCI,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _CI_CODE_FAILURE_MARKERS as _CI_CODE_FAILURE_MARKERS,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _CI_FAILED_JOB_RERUN_CONCLUSIONS as _CI_FAILED_JOB_RERUN_CONCLUSIONS,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _CI_TRANSIENT_FAILURE_MARKERS as _CI_TRANSIENT_FAILURE_MARKERS,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _ci_candidate_failures as _ci_candidate_failures,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _ci_failure_identity as _ci_failure_identity,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _ci_failure_is_rerun_candidate as _ci_failure_is_rerun_candidate,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _ci_non_candidate_failures as _ci_non_candidate_failures,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _failure_has_actionable_ci_evidence as _failure_has_actionable_ci_evidence,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _failure_has_parsed_code_evidence as _failure_has_parsed_code_evidence,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _log_shows_code_failure as _log_shows_code_failure,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _looks_like_transient_ci_failure as _looks_like_transient_ci_failure,
+)
+from awf.runtime.pr_monitor_ci_classification import (
+    _non_candidate_carries_fixable_code_evidence as _non_candidate_carries_fixable_code_evidence,
 )
 from awf.runtime.pr_monitor_models import (
     DEFAULT_NON_CHECK_REVIEWER_LOGINS,
@@ -654,119 +691,6 @@ def _sync_base_no_progress_exhausted(
 _CI_TRANSIENT_RERUN_KEY_PREFIX = "__awf_ci_rerun:"
 _CI_TRANSIENT_INFRA_WAIT_KEY_PREFIX = "__awf_ci_infra_wait:"
 
-_CI_FAILED_JOB_RERUN_CONCLUSIONS = frozenset({"FAILURE", "TIMED_OUT"})
-
-_CI_TRANSIENT_FAILURE_MARKERS = (
-    "timed_out",
-    "http status server error",
-    "http 500",
-    "http 502",
-    "http 503",
-    "http 504",
-    "500 internal server",
-    "502 bad gateway",
-    "503 service unavailable",
-    "504 gateway timeout",
-    "bad gateway",
-    "gateway timeout",
-    "internal server error",
-    "service unavailable",
-    "temporarily unavailable",
-    "try again",
-    "timed out waiting for",
-    "timeout awaiting",
-    "connection reset",
-    "connection refused",
-    "connection aborted",
-    "recv failure",
-    "tls handshake timeout",
-    "failed to download",
-    "network is unreachable",
-    "runner has received a shutdown signal",
-    "lost communication with the server",
-)
-
-_CI_CODE_FAILURE_MARKERS = (
-    "would reformat:",
-    "would be reformatted",
-    "fail-under",
-    "coverage failure",
-    "required test coverage",
-    "coverage below required threshold",
-    "traceback (most recent call last):",
-    "assertionerror",
-    "assertionfailederror",
-    "=== short test summary info ===",
-    "found type errors",
-    "found lint errors",
-    "syntaxerror",
-    "expect(received)",
-    "test result: failed",
-    "panicked at",
-    "--- fail:",
-    "panic:",
-)
-
-_RUFF_DIAGNOSTIC_RE = re.compile(r"\S+\.py:\d+:\d+:\s+[a-z]{1,4}\d{3,4}\b", re.IGNORECASE)
-_LINT_TOOL_FAILURE_RE = re.compile(
-    r"\b(?:ruff|mypy|eslint)\b[^\n]*\b(?:failed|found|would reformat|errors?)\b",
-    re.IGNORECASE,
-)
-
-
-def _log_shows_code_failure(log_text: str) -> bool:
-    """Return whether CI log text contains markers of a code-level test or lint failure."""
-    if any(marker in log_text for marker in _CI_CODE_FAILURE_MARKERS):
-        return True
-    if _LINT_TOOL_FAILURE_RE.search(log_text):
-        return True
-    for line in log_text.splitlines():
-        stripped = line.lstrip()
-        if stripped.startswith("failed ") and "::" in stripped:
-            return True
-        if ".py:" in stripped and ": error:" in stripped:
-            return True
-        if _RUFF_DIAGNOSTIC_RE.search(stripped):
-            return True
-    return False
-
-
-def _failure_has_parsed_code_evidence(failure: CheckFailure) -> bool:
-    """Return whether structured CI failure evidence points to a code defect."""
-    if failure.test_node_ids or failure.assertion_snippets:
-        return True
-    if failure.error_summaries:
-        return _log_shows_code_failure("\n".join(failure.error_summaries).lower())
-    return False
-
-
-def _failure_has_actionable_ci_evidence(failure: CheckFailure) -> bool:
-    """Return whether a CI failure row gives the repair agent something to work with."""
-    if failure.log_excerpt.strip():
-        return True
-    if _failure_has_parsed_code_evidence(failure):
-        return True
-    return bool(failure.evidence_warnings)
-
-
-def _ci_failure_identity(failure: CheckFailure) -> tuple[str, str, str]:
-    """Stable identity for one failing check inside a retry-budget key.
-
-    When a workflow ``run_id`` is available it *is* the stable identity for the
-    failing run, so the free-form check ``name`` and ``conclusion`` are dropped:
-    the same persistent run can otherwise present different names/conclusions
-    across polls (e.g. one poll records the workflow run name from
-    ``gh run list``, while a fallback poll records the rollup check name and a
-    defaulted conclusion). Keying on those drifting fields would mint a fresh
-    key for the same failure and silently reset the rerun/infra-wait budget,
-    granting extra reruns past ``ci_transient_rerun_max_attempts``. Without a
-    ``run_id`` we fall back to the name/conclusion pair as the only identity.
-    """
-
-    if failure.run_id:
-        return (failure.run_id, "", "")
-    return ("", failure.name, failure.conclusion)
-
 
 def _ci_transient_rerun_state_key(
     head_sha: str,
@@ -924,56 +848,6 @@ def _ci_transient_infra_wait_seconds(
     if cap <= 0:
         return wait_seconds
     return wait_seconds if wait_seconds < cap else cap
-
-
-def _looks_like_transient_ci_failure(failure: CheckFailure) -> bool:
-    """True for retryable infrastructure flakes."""
-
-    if _failure_has_parsed_code_evidence(failure):
-        return False
-    log_text = failure.log_excerpt.lower()
-    if not log_text.strip():
-        return bool(failure.run_id) and failure.conclusion.upper() == "TIMED_OUT"
-    shows_code_failure = _log_shows_code_failure(log_text)
-    if not shows_code_failure and any(
-        marker in log_text for marker in _CI_TRANSIENT_FAILURE_MARKERS
-    ):
-        return True
-    return not shows_code_failure and _log_shows_docker_registry_timeout(log_text)
-
-
-def _ci_failure_is_rerun_candidate(failure: CheckFailure) -> bool:
-    """Return whether a failure can participate in transient CI rerun/wait logic."""
-    return bool(failure.run_id)
-
-
-def _ci_candidate_failures(status: PRStatus) -> tuple[CheckFailure, ...]:
-    """Return CI failures eligible for transient rerun/wait.
-
-    Synthesized rollup/status rows (no ``run_id``) are kept on ``status.ci_failures``
-    for reporting but excluded here so they do not block rerunning retryable Actions
-    failures on the same PR head.
-    """
-    return tuple(
-        failure for failure in status.ci_failures if _ci_failure_is_rerun_candidate(failure)
-    )
-
-
-def _ci_non_candidate_failures(status: PRStatus) -> tuple[CheckFailure, ...]:
-    """Return CI failures excluded from transient rerun/wait (no ``run_id``)."""
-    return tuple(
-        failure for failure in status.ci_failures if not _ci_failure_is_rerun_candidate(failure)
-    )
-
-
-def _non_candidate_carries_fixable_code_evidence(status: PRStatus) -> bool:
-    """True when a synthesized/external row still carries repairable code evidence."""
-    for failure in _ci_non_candidate_failures(status):
-        if _failure_has_parsed_code_evidence(failure):
-            return True
-        if _log_shows_code_failure(failure.log_excerpt.lower()):
-            return True
-    return False
 
 
 _BASE_REF_DRIFT_HUMAN_MESSAGE_PREFIX = (

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -156,6 +156,19 @@ runner keep the awaiting-human attention flag set across those requeued polls
 instead of nulling it at the top-of-poll resume clear."""
 
 
+_PARKED_UNPUBLISHED_REPAIR_STATE_KEY = "__awf_parked_unpublished_repair__"
+"""Reserved ``MonitorState.threads_addressed_ids`` key flagging that recovery
+parked unattributable unpushed commits for a human (#935). Its value is the park
+signature (disposition + local/remote heads) so a re-park of the SAME situation
+on a later poll is recognised as the ongoing episode instead of a new one.
+
+Like the workflow-scope key this is inert to ``decide`` (which only looks up real
+thread/comment IDs). It exists so the parked wait survives across polls: the
+runner keeps the awaiting-human attention flag set at the top-of-poll resume
+clear, and the recovery path appends its operator-facing park event once per
+distinct situation rather than once per poll."""
+
+
 _MERGE_BLOCK_ATTENTION_STATE_KEY = "__awf_merge_block_attention__"
 """Reserved ``MonitorState.threads_addressed_ids`` key flagging that the merge
 loop's branch-protection fallback set the awaiting-human attention flag for an
@@ -253,6 +266,26 @@ class MonitorState:
     def clear_awaiting_workflow_scope(self) -> None:
         """Drop the workflow-scope wait marker (idempotent)."""
         self.threads_addressed_ids.pop(_AWAITING_WORKFLOW_SCOPE_STATE_KEY, None)
+
+    @property
+    def parked_unpublished_repair(self) -> str | None:
+        """Signature of the parked unattributable-commits episode, if any (#935).
+
+        Set when recovery preserved unpushed commits it could not attribute to the
+        comment-repair batch and handed them to a human. The monitor keeps polling
+        while parked, so the marker is what tells a later poll that the same
+        situation is still waiting instead of newly discovered.
+        """
+        value = self.threads_addressed_ids.get(_PARKED_UNPUBLISHED_REPAIR_STATE_KEY)
+        return value or None
+
+    def mark_parked_unpublished_repair(self, signature: str) -> None:
+        """Record the parked episode's signature."""
+        self.threads_addressed_ids[_PARKED_UNPUBLISHED_REPAIR_STATE_KEY] = signature
+
+    def clear_parked_unpublished_repair(self) -> None:
+        """Drop the parked-repair marker (idempotent)."""
+        self.threads_addressed_ids.pop(_PARKED_UNPUBLISHED_REPAIR_STATE_KEY, None)
 
     def merge_block_attention_active(
         self,

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -220,6 +220,17 @@ class MonitorState:
         repr=False,
         compare=False,
     )
+    # One accepted comment-repair item whose end-HEAD probe failed, as opaque JSON
+    # owned by ``pr_monitor_runner.comment_repair_provenance`` (#937). Deliberately
+    # transient and never persisted: the next item of the same batch completes the
+    # record from its own start head — which IS the previous item's end head — and
+    # after a restart there is no live batch left to complete it against.
+    pending_item_commit_provenance: str | None = field(
+        default=None,
+        init=False,
+        repr=False,
+        compare=False,
+    )
     sync_base_no_progress_signature: str | None = None
     sync_base_no_progress_count: int = 0
     # thread/comment id → one of:

--- a/src/awf/runtime/pr_monitor_ci_classification.py
+++ b/src/awf/runtime/pr_monitor_ci_classification.py
@@ -1,0 +1,182 @@
+"""CI-failure classification primitives for the PR-monitor decision core.
+
+Extracted from :mod:`awf.runtime.pr_monitor` so that module stays within the
+first-party file-line guardrail
+(``tests/unit/test_core_decomposition_maintainability.py``). Behavior is
+unchanged: these are pure predicates over :class:`CheckFailure` / :class:`PRStatus`
+wire shapes with no dependency on ``MonitorState`` or ``MonitorConfig``, and the
+symbols are re-exported from ``pr_monitor`` for existing import sites.
+"""
+
+from __future__ import annotations
+
+import re
+
+from awf.runtime._docker_pull_detection import _log_shows_docker_registry_timeout
+from awf.runtime.pr_monitor_models import (
+    CheckFailure,
+    PRStatus,
+)
+
+_CI_FAILED_JOB_RERUN_CONCLUSIONS = frozenset({"FAILURE", "TIMED_OUT"})
+
+_CI_TRANSIENT_FAILURE_MARKERS = (
+    "timed_out",
+    "http status server error",
+    "http 500",
+    "http 502",
+    "http 503",
+    "http 504",
+    "500 internal server",
+    "502 bad gateway",
+    "503 service unavailable",
+    "504 gateway timeout",
+    "bad gateway",
+    "gateway timeout",
+    "internal server error",
+    "service unavailable",
+    "temporarily unavailable",
+    "try again",
+    "timed out waiting for",
+    "timeout awaiting",
+    "connection reset",
+    "connection refused",
+    "connection aborted",
+    "recv failure",
+    "tls handshake timeout",
+    "failed to download",
+    "network is unreachable",
+    "runner has received a shutdown signal",
+    "lost communication with the server",
+)
+
+_CI_CODE_FAILURE_MARKERS = (
+    "would reformat:",
+    "would be reformatted",
+    "fail-under",
+    "coverage failure",
+    "required test coverage",
+    "coverage below required threshold",
+    "traceback (most recent call last):",
+    "assertionerror",
+    "assertionfailederror",
+    "=== short test summary info ===",
+    "found type errors",
+    "found lint errors",
+    "syntaxerror",
+    "expect(received)",
+    "test result: failed",
+    "panicked at",
+    "--- fail:",
+    "panic:",
+)
+
+_RUFF_DIAGNOSTIC_RE = re.compile(r"\S+\.py:\d+:\d+:\s+[a-z]{1,4}\d{3,4}\b", re.IGNORECASE)
+_LINT_TOOL_FAILURE_RE = re.compile(
+    r"\b(?:ruff|mypy|eslint)\b[^\n]*\b(?:failed|found|would reformat|errors?)\b",
+    re.IGNORECASE,
+)
+
+
+def _log_shows_code_failure(log_text: str) -> bool:
+    """Return whether CI log text contains markers of a code-level test or lint failure."""
+    if any(marker in log_text for marker in _CI_CODE_FAILURE_MARKERS):
+        return True
+    if _LINT_TOOL_FAILURE_RE.search(log_text):
+        return True
+    for line in log_text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("failed ") and "::" in stripped:
+            return True
+        if ".py:" in stripped and ": error:" in stripped:
+            return True
+        if _RUFF_DIAGNOSTIC_RE.search(stripped):
+            return True
+    return False
+
+
+def _failure_has_parsed_code_evidence(failure: CheckFailure) -> bool:
+    """Return whether structured CI failure evidence points to a code defect."""
+    if failure.test_node_ids or failure.assertion_snippets:
+        return True
+    if failure.error_summaries:
+        return _log_shows_code_failure("\n".join(failure.error_summaries).lower())
+    return False
+
+
+def _failure_has_actionable_ci_evidence(failure: CheckFailure) -> bool:
+    """Return whether a CI failure row gives the repair agent something to work with."""
+    if failure.log_excerpt.strip():
+        return True
+    if _failure_has_parsed_code_evidence(failure):
+        return True
+    return bool(failure.evidence_warnings)
+
+
+def _ci_failure_identity(failure: CheckFailure) -> tuple[str, str, str]:
+    """Stable identity for one failing check inside a retry-budget key.
+
+    When a workflow ``run_id`` is available it *is* the stable identity for the
+    failing run, so the free-form check ``name`` and ``conclusion`` are dropped:
+    the same persistent run can otherwise present different names/conclusions
+    across polls (e.g. one poll records the workflow run name from
+    ``gh run list``, while a fallback poll records the rollup check name and a
+    defaulted conclusion). Keying on those drifting fields would mint a fresh
+    key for the same failure and silently reset the rerun/infra-wait budget,
+    granting extra reruns past ``ci_transient_rerun_max_attempts``. Without a
+    ``run_id`` we fall back to the name/conclusion pair as the only identity.
+    """
+
+    if failure.run_id:
+        return (failure.run_id, "", "")
+    return ("", failure.name, failure.conclusion)
+
+
+def _looks_like_transient_ci_failure(failure: CheckFailure) -> bool:
+    """True for retryable infrastructure flakes."""
+
+    if _failure_has_parsed_code_evidence(failure):
+        return False
+    log_text = failure.log_excerpt.lower()
+    if not log_text.strip():
+        return bool(failure.run_id) and failure.conclusion.upper() == "TIMED_OUT"
+    shows_code_failure = _log_shows_code_failure(log_text)
+    if not shows_code_failure and any(
+        marker in log_text for marker in _CI_TRANSIENT_FAILURE_MARKERS
+    ):
+        return True
+    return not shows_code_failure and _log_shows_docker_registry_timeout(log_text)
+
+
+def _ci_failure_is_rerun_candidate(failure: CheckFailure) -> bool:
+    """Return whether a failure can participate in transient CI rerun/wait logic."""
+    return bool(failure.run_id)
+
+
+def _ci_candidate_failures(status: PRStatus) -> tuple[CheckFailure, ...]:
+    """Return CI failures eligible for transient rerun/wait.
+
+    Synthesized rollup/status rows (no ``run_id``) are kept on ``status.ci_failures``
+    for reporting but excluded here so they do not block rerunning retryable Actions
+    failures on the same PR head.
+    """
+    return tuple(
+        failure for failure in status.ci_failures if _ci_failure_is_rerun_candidate(failure)
+    )
+
+
+def _ci_non_candidate_failures(status: PRStatus) -> tuple[CheckFailure, ...]:
+    """Return CI failures excluded from transient rerun/wait (no ``run_id``)."""
+    return tuple(
+        failure for failure in status.ci_failures if not _ci_failure_is_rerun_candidate(failure)
+    )
+
+
+def _non_candidate_carries_fixable_code_evidence(status: PRStatus) -> bool:
+    """True when a synthesized/external row still carries repairable code evidence."""
+    for failure in _ci_non_candidate_failures(status):
+        if _failure_has_parsed_code_evidence(failure):
+            return True
+        if _log_shows_code_failure(failure.log_excerpt.lower()):
+            return True
+    return False

--- a/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
@@ -1,0 +1,235 @@
+"""Commit-time provenance for accepted comment-repair item commits (#935).
+
+An ``AddressComments`` batch addresses review items one at a time, committing each
+accepted fix locally, and pushes once when the comment burst settles. The
+``comment_repair`` ``Operation`` row is only finalised at batch end, so a worker
+restart, crash or timeout *between* items used to leave every already-accepted
+commit with no durable audit trail — and post-restart recovery then had nothing to
+recognise that work by.
+
+This module records provenance the moment an item's commit is accepted: a chain of
+``{item_id, item_start_head, head_sha, operation_id}`` records, merged onto the
+workspace row under a single reserved ``MonitorState`` key together with an audit
+event, in one transaction. The chain links the remote PR head to local HEAD, so
+recovery can prove that ``remote..HEAD`` is exactly AWF's own repair work.
+
+The write deliberately does NOT flush the whole ``MonitorState``: that would
+durably publish half-batch ``fix_committed`` verdicts which a later push failure
+only rolls back in memory.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from awf.db.repositories import WorkspaceEventCreate, WorkspaceRepository
+from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
+from awf.runtime.pr_monitor import MonitorState
+from awf.runtime.pr_monitor_runner.logging import _log
+
+COMMENT_REPAIR_ITEM_COMMIT_RECORDED = "COMMENT_REPAIR_ITEM_COMMIT_RECORDED"
+COMMENT_REPAIR_ITEM_PROVENANCE_RECORD_FAILED = "COMMENT_REPAIR_ITEM_PROVENANCE_RECORD_FAILED"
+ITEM_COMMIT_RECORDED_EVENT = "monitor.comment_repair_item_commit_recorded"
+
+# One batch's items. The chain-restart rule below already bounds growth to a single
+# batch; this is a belt-and-braces cap so a pathological settle loop cannot grow the
+# marker without limit.
+_MAX_CHAIN_RECORDS = 200
+
+
+@dataclass(frozen=True)
+class ItemCommitProvenance:
+    """One review item whose verdict was accepted together with a local commit."""
+
+    item_id: str
+    item_start_head: str
+    head_sha: str
+    operation_id: str | None = None
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "item_id": self.item_id,
+            "item_start_head": self.item_start_head,
+            "head_sha": self.head_sha,
+            "operation_id": self.operation_id,
+        }
+
+
+def _record_from_mapping(entry: object) -> ItemCommitProvenance | None:
+    if not isinstance(entry, Mapping):
+        return None
+    item_id = entry.get("item_id")
+    item_start_head = entry.get("item_start_head")
+    head_sha = entry.get("head_sha")
+    operation_id = entry.get("operation_id")
+    if not all(isinstance(value, str) and value.strip() for value in (item_start_head, head_sha)):
+        return None
+    if not isinstance(item_id, str) or not item_id.strip():
+        return None
+    return ItemCommitProvenance(
+        item_id=item_id,
+        item_start_head=str(item_start_head).strip(),
+        head_sha=str(head_sha).strip(),
+        operation_id=operation_id if isinstance(operation_id, str) and operation_id else None,
+    )
+
+
+def decode_item_commit_provenance_chain(raw: object) -> tuple[ItemCommitProvenance, ...]:
+    """Decode the persisted chain, failing closed on anything malformed."""
+    if not isinstance(raw, str) or not raw.strip():
+        return ()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return ()
+    if not isinstance(parsed, list):
+        return ()
+    records: list[ItemCommitProvenance] = []
+    for entry in parsed:
+        record = _record_from_mapping(entry)
+        if record is None:
+            return ()
+        records.append(record)
+    return tuple(records)
+
+
+def encode_item_commit_provenance_chain(records: Sequence[ItemCommitProvenance]) -> str:
+    return json.dumps(
+        [record.as_payload() for record in records],
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def appended_item_commit_provenance_chain(
+    existing: Sequence[ItemCommitProvenance],
+    record: ItemCommitProvenance,
+) -> tuple[ItemCommitProvenance, ...]:
+    """Link a new record onto the chain, restarting when it does not continue it.
+
+    A record whose ``item_start_head`` is not the current chain tip belongs to a
+    different batch (or follows a reset / force-move), so the stale records are
+    dropped rather than kept as a chain that no longer describes ``remote..HEAD``.
+    """
+    if existing and existing[-1].head_sha.lower() == record.item_start_head.lower():
+        return (*existing, record)[-_MAX_CHAIN_RECORDS:]
+    return (record,)
+
+
+def chain_from_state(state: MonitorState) -> tuple[ItemCommitProvenance, ...]:
+    return decode_item_commit_provenance_chain(
+        state.threads_addressed_ids.get(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY)
+    )
+
+
+async def _persist_item_commit_provenance_durably(
+    runner: Any,
+    *,
+    workspace_id: str,
+    encoded_chain: str,
+    record: ItemCommitProvenance,
+) -> None:
+    """Merge the chain onto the workspace row and append its audit event atomically."""
+    session_factory = getattr(getattr(runner, "_deps", None), "session_factory", None)
+    if not callable(session_factory):
+        return
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        ws = await repo.get_for_update(workspace_id)
+        if ws is None:
+            return
+        threads_addressed = dict(ws.monitor_threads_addressed or {})
+        threads_addressed[_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY] = encoded_chain
+        ws.monitor_threads_addressed = threads_addressed
+        await repo.add_events(
+            ws,
+            events=[
+                WorkspaceEventCreate(
+                    event_type=ITEM_COMMIT_RECORDED_EVENT,
+                    reason_code=COMMENT_REPAIR_ITEM_COMMIT_RECORDED,
+                    payload=record.as_payload(),
+                )
+            ],
+        )
+        await session.commit()
+
+
+async def _record_accepted_item_commit_provenance(
+    runner: Any,
+    *,
+    workspace_id: str,
+    state: MonitorState | None,
+    item_id: str,
+    item_start_head: str | None,
+    operation_id: str | None,
+) -> None:
+    """Record provenance when a review item's verdict kept a local commit.
+
+    "Accepted with a commit" is read mechanically: HEAD advanced past the item's
+    start head and survived the item's own verdict rollback. That covers
+    ``fix_committed`` and every #925/#928/#931 correction outcome that preserves a
+    commit, without re-deriving the verdict taxonomy here.
+
+    Best-effort by design: a DB/OS failure warns and lets the batch continue (the
+    commit still exists, and recovery's legacy subject fallback still preserves it).
+    Programming errors propagate.
+    """
+    if state is None:
+        return
+    start_head = (item_start_head or "").strip()
+    if not start_head:
+        return
+    worktrees_root = getattr(runner, "_worktrees_root", None)
+    if not isinstance(worktrees_root, Path):
+        # Hosted execution and unit seams legitimately run without a local worktree;
+        # there is no local HEAD to fingerprint.
+        return
+    worktree_path = worktrees_root / workspace_id
+    if not worktree_path.exists():
+        return
+    head_sha = await runner._rev_parse_head(worktree_path)
+    if not head_sha or head_sha.strip().lower() == start_head.lower():
+        return
+    record = ItemCommitProvenance(
+        item_id=str(item_id),
+        item_start_head=start_head,
+        head_sha=head_sha.strip(),
+        operation_id=operation_id,
+    )
+    chain = appended_item_commit_provenance_chain(chain_from_state(state), record)
+    encoded_chain = encode_item_commit_provenance_chain(chain)
+    # Mark in memory first so the next item links onto this commit even when the
+    # durable write below fails and the outer ``_persist_state`` flushes it later.
+    state.mark_addressed(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY, encoded_chain)
+    try:
+        await _persist_item_commit_provenance_durably(
+            runner,
+            workspace_id=workspace_id,
+            encoded_chain=encoded_chain,
+            record=record,
+        )
+    except (SQLAlchemyError, OSError) as exc:
+        _log.warning(
+            "monitor.comment_repair_item_provenance_record_failed",
+            workspace_id=workspace_id,
+            item_id=record.item_id,
+            head_sha=record.head_sha[:10],
+            error=repr(exc)[:400],
+            reason_code=COMMENT_REPAIR_ITEM_PROVENANCE_RECORD_FAILED,
+        )
+        return
+    _log.info(
+        "monitor.comment_repair_item_commit_recorded",
+        workspace_id=workspace_id,
+        item_id=record.item_id,
+        item_start_head=record.item_start_head[:10],
+        head_sha=record.head_sha[:10],
+        operation_id=record.operation_id,
+        reason_code=COMMENT_REPAIR_ITEM_COMMIT_RECORDED,
+    )

--- a/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
@@ -116,8 +116,20 @@ def appended_item_commit_provenance_chain(
     A record whose ``item_start_head`` is not the current chain tip belongs to a
     different batch (or follows a reset / force-move), so the stale records are
     dropped rather than kept as a chain that no longer describes ``remote..HEAD``.
+
+    A change of ``operation_id`` restarts the chain too, even when the heads line
+    up: the previous batch pushed its commits, so the next batch's first item
+    starts at the *new* remote head. Appending there would leave the chain rooted
+    at a head that is now behind the PR, and recovery's
+    ``_item_provenance_chain_covers_range`` (which requires the first record to
+    start at the current remote head) would reject the whole chain and risk
+    parking resumable repair work.
     """
-    if existing and existing[-1].head_sha.lower() == record.item_start_head.lower():
+    if (
+        existing
+        and existing[-1].operation_id == record.operation_id
+        and existing[-1].head_sha.lower() == record.item_start_head.lower()
+    ):
         return (*existing, record)[-_MAX_CHAIN_RECORDS:]
     return (record,)
 

--- a/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
@@ -46,9 +46,10 @@ COMMENT_REPAIR_ITEM_PROVENANCE_RECORD_FAILED = "COMMENT_REPAIR_ITEM_PROVENANCE_R
 COMMENT_REPAIR_ITEM_PROVENANCE_CLEAR_FAILED = "COMMENT_REPAIR_ITEM_PROVENANCE_CLEAR_FAILED"
 ITEM_COMMIT_RECORDED_EVENT = "monitor.comment_repair_item_commit_recorded"
 
-# One batch's items. The chain-restart rule below already bounds growth to a single
-# batch; this is a belt-and-braces cap so a pathological settle loop cannot grow the
-# marker without limit.
+# One batch's items, generously. A successful push clears the chain and a moved head
+# restarts it, so growth is normally bounded by the unpushed batch; this cap keeps the
+# marker bounded even when neither happens (a chain that outlived a push, or a
+# pathological settle loop).
 _MAX_CHAIN_RECORDS = 200
 # Item id of the synthetic record that stands in for the oldest records the cap folds
 # away. It is not a real review item id, and nothing matches on it: only
@@ -202,25 +203,26 @@ def appended_item_commit_provenance_chain(
     different batch (or follows a reset / force-move), so the stale records are
     dropped rather than kept as a chain that no longer describes ``remote..HEAD``.
 
-    A change of ``operation_id`` restarts the chain too, even when the heads line
-    up: the previous batch pushed its commits, so the next batch's first item
-    starts at the *new* remote head. Appending there would leave the chain rooted
-    at a head that is now behind the PR. Recovery's
-    ``_item_provenance_chain_covers_range`` tolerates that (it matches the chain
-    suffix starting at the fetched remote head), and
-    ``_clear_published_item_commit_provenance_chain`` normally drops the chain on
-    push — but keeping one batch per chain means the marker stays small and each
-    record's meaning stays local to the batch that wrote it.
+    Head continuity is the ONLY restart rule: a change of ``operation_id`` must
+    not drop a chain whose tip is still local HEAD (PRRT_kwDOSJAM6s6fvrG1).
+    Recovery preserves an unpublished chain and then re-enters
+    ``AddressComments``; a changed unresolved-item set gives that poll a new
+    operation id over the *same* remote base, and restarting there would re-root
+    the chain at the already-local tip. A push failure plus a restart could then
+    no longer prove ``remote..HEAD`` and would park resumable repairs whose
+    subjects the legacy heuristic cannot attribute.
 
-    A batch that runs past ``_MAX_CHAIN_RECORDS`` items is compacted rather than
+    The published-batch carryover this rule used to guard against is handled
+    where it belongs: ``_clear_published_item_commit_provenance_chain`` drops the
+    chain on a successful push, and if that best-effort clear is lost, recovery's
+    ``_item_provenance_chain_covers_range`` matches the chain suffix starting at
+    the fetched remote head — so a published prefix is ignored rather than fatal.
+
+    A chain that runs past ``_MAX_CHAIN_RECORDS`` records is compacted rather than
     truncated, so the chain never loses the base it is rooted at (see
     :func:`_compacted_item_commit_provenance_chain`).
     """
-    if (
-        existing
-        and existing[-1].operation_id == record.operation_id
-        and existing[-1].head_sha.lower() == record.item_start_head.lower()
-    ):
+    if existing and existing[-1].head_sha.lower() == record.item_start_head.lower():
         return _compacted_item_commit_provenance_chain((*existing, record))
     return (record,)
 

--- a/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
@@ -43,6 +43,10 @@ ITEM_COMMIT_RECORDED_EVENT = "monitor.comment_repair_item_commit_recorded"
 # batch; this is a belt-and-braces cap so a pathological settle loop cannot grow the
 # marker without limit.
 _MAX_CHAIN_RECORDS = 200
+# Item id of the synthetic record that stands in for the oldest records the cap folds
+# away. It is not a real review item id, and nothing matches on it: only
+# ``_item_provenance_chain_covers_range`` reads the chain, and it matches on heads.
+_COMPACTED_RECORD_ITEM_ID = "awf:compacted-item-commit-span"
 
 
 @dataclass(frozen=True)
@@ -109,6 +113,33 @@ def encode_item_commit_provenance_chain(records: Sequence[ItemCommitProvenance])
     )
 
 
+def _compacted_item_commit_provenance_chain(
+    chain: tuple[ItemCommitProvenance, ...],
+) -> tuple[ItemCommitProvenance, ...]:
+    """Bound the chain by folding its oldest records into one span record.
+
+    Slicing the tail would be wrong: the dropped head is the record rooted at the
+    remote PR head, and recovery's ``_item_provenance_chain_covers_range`` locates
+    the covering suffix *by that base*. Without it, a valid durable chain is
+    rejected after a restart and the batch is parked whenever its commit subjects
+    do not match the legacy heuristic.
+
+    Folding keeps both ends of the linkage instead: the span starts where the
+    oldest folded record started and ends where the last folded record ended, so
+    the chain still runs root-to-tip and still links onto the record after it.
+    """
+    if len(chain) <= _MAX_CHAIN_RECORDS:
+        return chain
+    fold = chain[: len(chain) - _MAX_CHAIN_RECORDS + 1]
+    span = ItemCommitProvenance(
+        item_id=_COMPACTED_RECORD_ITEM_ID,
+        item_start_head=fold[0].item_start_head,
+        head_sha=fold[-1].head_sha,
+        operation_id=fold[-1].operation_id,
+    )
+    return (span, *chain[len(fold) :])
+
+
 def appended_item_commit_provenance_chain(
     existing: Sequence[ItemCommitProvenance],
     record: ItemCommitProvenance,
@@ -128,13 +159,17 @@ def appended_item_commit_provenance_chain(
     ``_clear_published_item_commit_provenance_chain`` normally drops the chain on
     push — but keeping one batch per chain means the marker stays small and each
     record's meaning stays local to the batch that wrote it.
+
+    A batch that runs past ``_MAX_CHAIN_RECORDS`` items is compacted rather than
+    truncated, so the chain never loses the base it is rooted at (see
+    :func:`_compacted_item_commit_provenance_chain`).
     """
     if (
         existing
         and existing[-1].operation_id == record.operation_id
         and existing[-1].head_sha.lower() == record.item_start_head.lower()
     ):
-        return (*existing, record)[-_MAX_CHAIN_RECORDS:]
+        return _compacted_item_commit_provenance_chain((*existing, record))
     return (record,)
 
 

--- a/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
@@ -21,6 +21,7 @@ only rolls back in memory.
 from __future__ import annotations
 
 import json
+import subprocess
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -188,7 +189,8 @@ async def _record_accepted_item_commit_provenance(
     ``fix_committed`` and every #925/#928/#931 correction outcome that preserves a
     commit, without re-deriving the verdict taxonomy here.
 
-    Best-effort by design: a DB/OS failure warns and lets the batch continue (the
+    Best-effort by design: a failing HEAD probe or DB/OS failure warns and lets the
+    batch continue (the
     commit still exists, and recovery's legacy subject fallback still preserves it).
     Programming errors propagate.
     """
@@ -205,7 +207,20 @@ async def _record_accepted_item_commit_provenance(
     worktree_path = worktrees_root / workspace_id
     if not worktree_path.exists():
         return
-    head_sha = await runner._rev_parse_head(worktree_path)
+    try:
+        head_sha = await runner._rev_parse_head(worktree_path)
+    except (TimeoutError, OSError, subprocess.SubprocessError) as exc:
+        # Same best-effort contract as the durable write below: a flaky HEAD probe
+        # must skip the audit write, not escape into the caller and fail the whole
+        # comment-repair batch. The item's commit itself is already on disk.
+        _log.warning(
+            "monitor.comment_repair_item_provenance_record_failed",
+            workspace_id=workspace_id,
+            item_id=str(item_id),
+            error=repr(exc)[:400],
+            reason_code=COMMENT_REPAIR_ITEM_PROVENANCE_RECORD_FAILED,
+        )
+        return
     if not head_sha or head_sha.strip().lower() == start_head.lower():
         return
     record = ItemCommitProvenance(

--- a/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
@@ -36,6 +36,7 @@ from awf.runtime.pr_monitor_runner.logging import _log
 
 COMMENT_REPAIR_ITEM_COMMIT_RECORDED = "COMMENT_REPAIR_ITEM_COMMIT_RECORDED"
 COMMENT_REPAIR_ITEM_PROVENANCE_RECORD_FAILED = "COMMENT_REPAIR_ITEM_PROVENANCE_RECORD_FAILED"
+COMMENT_REPAIR_ITEM_PROVENANCE_CLEAR_FAILED = "COMMENT_REPAIR_ITEM_PROVENANCE_CLEAR_FAILED"
 ITEM_COMMIT_RECORDED_EVENT = "monitor.comment_repair_item_commit_recorded"
 
 # One batch's items. The chain-restart rule below already bounds growth to a single
@@ -121,10 +122,12 @@ def appended_item_commit_provenance_chain(
     A change of ``operation_id`` restarts the chain too, even when the heads line
     up: the previous batch pushed its commits, so the next batch's first item
     starts at the *new* remote head. Appending there would leave the chain rooted
-    at a head that is now behind the PR, and recovery's
-    ``_item_provenance_chain_covers_range`` (which requires the first record to
-    start at the current remote head) would reject the whole chain and risk
-    parking resumable repair work.
+    at a head that is now behind the PR. Recovery's
+    ``_item_provenance_chain_covers_range`` tolerates that (it matches the chain
+    suffix starting at the fetched remote head), and
+    ``_clear_published_item_commit_provenance_chain`` normally drops the chain on
+    push — but keeping one batch per chain means the marker stays small and each
+    record's meaning stays local to the batch that wrote it.
     """
     if (
         existing
@@ -171,6 +174,65 @@ async def _persist_item_commit_provenance_durably(
             ],
         )
         await session.commit()
+
+
+async def _clear_item_commit_provenance_chain_durably(
+    runner: Any,
+    *,
+    workspace_id: str,
+) -> None:
+    """Remove ONLY the chain key from the persisted workspace row.
+
+    Mirrors :func:`_persist_item_commit_provenance_durably`: the record side
+    commits outside ``_persist_state``, so the clear must be durable too. It must
+    never flush the rest of the in-memory ``MonitorState`` — inside a fix cycle
+    that state can still carry unconfirmed addressed verdicts whose forge resolve
+    calls have not run yet (#305).
+    """
+    session_factory = getattr(getattr(runner, "_deps", None), "session_factory", None)
+    if not callable(session_factory):
+        return
+    async with session_factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        if ws is None:
+            return
+        threads_addressed = dict(ws.monitor_threads_addressed or {})
+        if threads_addressed.pop(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY, None) is None:
+            return
+        ws.monitor_threads_addressed = threads_addressed
+        await session.commit()
+
+
+async def _clear_published_item_commit_provenance_chain(
+    runner: Any,
+    *,
+    workspace_id: str,
+    state: MonitorState,
+) -> None:
+    """Drop the chain once the batch's commits reached the remote (#937).
+
+    The chain exists to prove that ``remote..HEAD`` is AWF's own unpublished
+    repair work. A successful push publishes exactly those commits, so the chain
+    has nothing left to describe. Leaving it behind lets the *next* batch link
+    onto it — its first item starts at the head this push just published, which
+    is the old chain's tip — producing a chain rooted at a base that is now
+    behind the PR. Recovery after a restart in that second batch would then have
+    to fall back to commit-subject matching, and park when the subjects are not
+    ones AWF emits.
+
+    Best-effort, like the record side: the push already succeeded, so a DB/OS
+    blip here must not fail the batch. Programming errors propagate.
+    """
+    state.threads_addressed_ids.pop(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY, None)
+    try:
+        await _clear_item_commit_provenance_chain_durably(runner, workspace_id=workspace_id)
+    except (SQLAlchemyError, OSError) as exc:
+        _log.warning(
+            "monitor.comment_repair_item_provenance_clear_failed",
+            workspace_id=workspace_id,
+            error=repr(exc)[:400],
+            reason_code=COMMENT_REPAIR_ITEM_PROVENANCE_CLEAR_FAILED,
+        )
 
 
 async def _record_accepted_item_commit_provenance(

--- a/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
@@ -448,10 +448,13 @@ async def _settle_pending_item_commit_provenance(
     accepted agent-authored commit whose subject the legacy heuristic cannot
     attribute is parked instead of resumed.
 
-    ``fix_cycle`` calls this before each next item, before the push, and before
-    re-raising a permanent settle-poll fault, so no exit leaves a record pending.
-    Nothing commits between an item's verdict and any of those points, so live
-    HEAD is still that item's end head. The guards stay in
+    ``fix_cycle`` calls this before the push, before re-raising a permanent
+    settle-poll fault, and on the per-item paths where the next item's start-head
+    read cannot supply the head itself — it raised, or there is no worktree to
+    probe — so no exit leaves a record pending. (When that read *does* succeed the
+    per-item path completes the record from it directly, without the re-probe
+    below.) Nothing commits between an item's verdict and any of those points, so
+    live HEAD is still that item's end head. The guards stay in
     ``_complete_pending_item_commit_provenance``: same operation, HEAD actually
     advanced. Best-effort like the rest of this module — an unreadable HEAD leaves
     the commit to the legacy subject heuristic, exactly as before. The marker is

--- a/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
@@ -20,8 +20,9 @@ only rolls back in memory.
 The end-HEAD probe is best-effort, but losing it must not lose the record: an
 unreadable HEAD is remembered as a *pending* record and completed by the next item
 of the same batch from that item's own start head — see
-:func:`_complete_pending_item_commit_provenance`. The batch's last item has no such
-successor, so the batch re-probes HEAD once before pushing — see
+:func:`_complete_pending_item_commit_provenance`. An item that has no successor to
+settle it — the batch's last, or any item followed by one that fails and exits the
+cycle early — is settled by a HEAD re-probe instead, see
 :func:`_settle_pending_item_commit_provenance`.
 """
 
@@ -437,7 +438,7 @@ async def _settle_pending_item_commit_provenance(
     state: MonitorState,
     operation_id: str | None,
 ) -> None:
-    """Complete the batch's *last* pending record before the push (#937).
+    """Re-probe HEAD to complete a still-pending record (#937).
 
     :func:`_complete_pending_item_commit_provenance` settles a failed end-HEAD
     probe from the next item's start head, so the final item of a batch has no
@@ -447,12 +448,14 @@ async def _settle_pending_item_commit_provenance(
     accepted agent-authored commit whose subject the legacy heuristic cannot
     attribute is parked instead of resumed.
 
-    Nothing commits between the last item's verdict and the push, so live HEAD
-    here is still that item's end head. Re-probe it once and write the record
-    while the marker is still in memory. The guards stay in
+    ``fix_cycle`` calls this before each next item, before the push, and before
+    re-raising a permanent settle-poll fault, so no exit leaves a record pending.
+    Nothing commits between an item's verdict and any of those points, so live
+    HEAD is still that item's end head. The guards stay in
     ``_complete_pending_item_commit_provenance``: same operation, HEAD actually
     advanced. Best-effort like the rest of this module — an unreadable HEAD leaves
-    the commit to the legacy subject heuristic, exactly as before.
+    the commit to the legacy subject heuristic, exactly as before. The marker is
+    one-shot, so the repeated calls are free once it is settled.
     """
     if state.pending_item_commit_provenance is None:
         return

--- a/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
@@ -20,7 +20,9 @@ only rolls back in memory.
 The end-HEAD probe is best-effort, but losing it must not lose the record: an
 unreadable HEAD is remembered as a *pending* record and completed by the next item
 of the same batch from that item's own start head — see
-:func:`_complete_pending_item_commit_provenance`.
+:func:`_complete_pending_item_commit_provenance`. The batch's last item has no such
+successor, so the batch re-probes HEAD once before pushing — see
+:func:`_settle_pending_item_commit_provenance`.
 """
 
 from __future__ import annotations
@@ -426,6 +428,61 @@ async def _complete_pending_item_commit_provenance(
     )
 
 
+async def _settle_pending_item_commit_provenance(
+    runner: Any,
+    *,
+    workspace_id: str,
+    state: MonitorState,
+    operation_id: str | None,
+) -> None:
+    """Complete the batch's *last* pending record before the push (#937).
+
+    :func:`_complete_pending_item_commit_provenance` settles a failed end-HEAD
+    probe from the next item's start head, so the final item of a batch has no
+    successor to settle it — and the pending marker is deliberately transient. A
+    push that then fails followed by a worker restart therefore used to lose that
+    record permanently, breaking the chain exactly where recovery reads it: an
+    accepted agent-authored commit whose subject the legacy heuristic cannot
+    attribute is parked instead of resumed.
+
+    Nothing commits between the last item's verdict and the push, so live HEAD
+    here is still that item's end head. Re-probe it once and write the record
+    while the marker is still in memory. The guards stay in
+    ``_complete_pending_item_commit_provenance``: same operation, HEAD actually
+    advanced. Best-effort like the rest of this module — an unreadable HEAD leaves
+    the commit to the legacy subject heuristic, exactly as before.
+    """
+    if state.pending_item_commit_provenance is None:
+        return
+    worktrees_root = getattr(runner, "_worktrees_root", None)
+    if not isinstance(worktrees_root, Path) or not (worktrees_root / workspace_id).exists():
+        # No local worktree to probe (hosted execution, unit seams): the marker
+        # is one-shot, and nothing later in this batch can complete it.
+        state.pending_item_commit_provenance = None
+        return
+    try:
+        head_sha = await runner._rev_parse_head(worktrees_root / workspace_id)
+    except (TimeoutError, OSError, subprocess.SubprocessError) as exc:
+        state.pending_item_commit_provenance = None
+        _log.warning(
+            "monitor.comment_repair_item_provenance_record_failed",
+            workspace_id=workspace_id,
+            error=repr(exc)[:400],
+            reason_code=COMMENT_REPAIR_ITEM_PROVENANCE_RECORD_FAILED,
+        )
+        return
+    if not head_sha or not head_sha.strip():
+        state.pending_item_commit_provenance = None
+        return
+    await _complete_pending_item_commit_provenance(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_start_head=head_sha.strip(),
+        operation_id=operation_id,
+    )
+
+
 async def _record_accepted_item_commit_provenance(
     runner: Any,
     *,
@@ -449,9 +506,10 @@ async def _record_accepted_item_commit_provenance(
 
     An unreadable HEAD no longer discards the record, though: it is held as a
     pending record and completed by the next item of the batch
-    (:func:`_complete_pending_item_commit_provenance`). Only an item whose probe
-    fails and which is never followed by another item in the same batch — the last
-    item before a push that then fails — still falls back to the legacy heuristic.
+    (:func:`_complete_pending_item_commit_provenance`), or — for the batch's last
+    item, which has no successor — by the pre-push re-probe in
+    :func:`_settle_pending_item_commit_provenance`. Only a probe that stays
+    unreadable at both points falls back to the legacy heuristic.
     """
     if state is None:
         return

--- a/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_repair_provenance.py
@@ -16,6 +16,11 @@ recovery can prove that ``remote..HEAD`` is exactly AWF's own repair work.
 The write deliberately does NOT flush the whole ``MonitorState``: that would
 durably publish half-batch ``fix_committed`` verdicts which a later push failure
 only rolls back in memory.
+
+The end-HEAD probe is best-effort, but losing it must not lose the record: an
+unreadable HEAD is remembered as a *pending* record and completed by the next item
+of the same batch from that item's own start head — see
+:func:`_complete_pending_item_commit_provenance`.
 """
 
 from __future__ import annotations
@@ -65,6 +70,51 @@ class ItemCommitProvenance:
             "head_sha": self.head_sha,
             "operation_id": self.operation_id,
         }
+
+
+@dataclass(frozen=True)
+class PendingItemCommitProvenance:
+    """An accepted item whose end HEAD the commit-time probe could not read."""
+
+    item_id: str
+    item_start_head: str
+    operation_id: str | None = None
+
+
+def _encode_pending_item_commit_provenance(pending: PendingItemCommitProvenance) -> str:
+    return json.dumps(
+        {
+            "item_id": pending.item_id,
+            "item_start_head": pending.item_start_head,
+            "operation_id": pending.operation_id,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _decode_pending_item_commit_provenance(raw: object) -> PendingItemCommitProvenance | None:
+    """Decode the pending marker, failing closed on anything malformed."""
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, Mapping):
+        return None
+    item_id = parsed.get("item_id")
+    item_start_head = parsed.get("item_start_head")
+    operation_id = parsed.get("operation_id")
+    if not isinstance(item_id, str) or not item_id.strip():
+        return None
+    if not isinstance(item_start_head, str) or not item_start_head.strip():
+        return None
+    return PendingItemCommitProvenance(
+        item_id=item_id,
+        item_start_head=item_start_head.strip(),
+        operation_id=operation_id if isinstance(operation_id, str) and operation_id else None,
+    )
 
 
 def _record_from_mapping(entry: object) -> ItemCommitProvenance | None:
@@ -270,62 +320,14 @@ async def _clear_published_item_commit_provenance_chain(
         )
 
 
-async def _record_accepted_item_commit_provenance(
+async def _write_item_commit_provenance_record(
     runner: Any,
     *,
     workspace_id: str,
-    state: MonitorState | None,
-    item_id: str,
-    item_start_head: str | None,
-    operation_id: str | None,
+    state: MonitorState,
+    record: ItemCommitProvenance,
 ) -> None:
-    """Record provenance when a review item's verdict kept a local commit.
-
-    "Accepted with a commit" is read mechanically: HEAD advanced past the item's
-    start head and survived the item's own verdict rollback. That covers
-    ``fix_committed`` and every #925/#928/#931 correction outcome that preserves a
-    commit, without re-deriving the verdict taxonomy here.
-
-    Best-effort by design: a failing HEAD probe or DB/OS failure warns and lets the
-    batch continue (the
-    commit still exists, and recovery's legacy subject fallback still preserves it).
-    Programming errors propagate.
-    """
-    if state is None:
-        return
-    start_head = (item_start_head or "").strip()
-    if not start_head:
-        return
-    worktrees_root = getattr(runner, "_worktrees_root", None)
-    if not isinstance(worktrees_root, Path):
-        # Hosted execution and unit seams legitimately run without a local worktree;
-        # there is no local HEAD to fingerprint.
-        return
-    worktree_path = worktrees_root / workspace_id
-    if not worktree_path.exists():
-        return
-    try:
-        head_sha = await runner._rev_parse_head(worktree_path)
-    except (TimeoutError, OSError, subprocess.SubprocessError) as exc:
-        # Same best-effort contract as the durable write below: a flaky HEAD probe
-        # must skip the audit write, not escape into the caller and fail the whole
-        # comment-repair batch. The item's commit itself is already on disk.
-        _log.warning(
-            "monitor.comment_repair_item_provenance_record_failed",
-            workspace_id=workspace_id,
-            item_id=str(item_id),
-            error=repr(exc)[:400],
-            reason_code=COMMENT_REPAIR_ITEM_PROVENANCE_RECORD_FAILED,
-        )
-        return
-    if not head_sha or head_sha.strip().lower() == start_head.lower():
-        return
-    record = ItemCommitProvenance(
-        item_id=str(item_id),
-        item_start_head=start_head,
-        head_sha=head_sha.strip(),
-        operation_id=operation_id,
-    )
+    """Link one record onto the chain, in memory and durably (best-effort)."""
     chain = appended_item_commit_provenance_chain(chain_from_state(state), record)
     encoded_chain = encode_item_commit_provenance_chain(chain)
     # Mark in memory first so the next item links onto this commit even when the
@@ -356,4 +358,163 @@ async def _record_accepted_item_commit_provenance(
         head_sha=record.head_sha[:10],
         operation_id=record.operation_id,
         reason_code=COMMENT_REPAIR_ITEM_COMMIT_RECORDED,
+    )
+
+
+def _remember_unrecorded_item_commit(
+    state: MonitorState,
+    *,
+    item_id: str,
+    item_start_head: str,
+    operation_id: str | None,
+) -> None:
+    """Hold an item whose end HEAD was unreadable until the next item supplies it."""
+    state.pending_item_commit_provenance = _encode_pending_item_commit_provenance(
+        PendingItemCommitProvenance(
+            item_id=item_id,
+            item_start_head=item_start_head,
+            operation_id=operation_id,
+        )
+    )
+
+
+async def _complete_pending_item_commit_provenance(
+    runner: Any,
+    *,
+    workspace_id: str,
+    state: MonitorState,
+    item_start_head: str,
+    operation_id: str | None,
+) -> None:
+    """Write the previous item's record from this item's start head (#937).
+
+    The end-HEAD probe below is the only reason an accepted item commit can go
+    unrecorded, and losing that record costs the whole chain: after a restart
+    ``_item_provenance_chain_covers_range`` finds a broken link, and an
+    agent-authored commit whose subject the legacy heuristic cannot attribute is
+    parked instead of resumed and pushed.
+
+    The head that probe failed to read is not lost, only late: ``fix_cycle``
+    re-reads live HEAD immediately before each item (``_current_item_operation_
+    start_head``, which fails the cycle rather than guess), and nothing commits
+    between one item's verdict and the next item's start. This item's start head
+    therefore *is* the previous item's end head, and the completed record spans
+    exactly the range the direct probe would have recorded.
+
+    Guarded so a stale marker cannot invent a record: the pending item must belong
+    to the same operation (a new batch starts after a push, at a new base), and
+    HEAD must actually have advanced past its start. The marker is one-shot — it is
+    dropped whether or not it produced a record.
+    """
+    pending = _decode_pending_item_commit_provenance(state.pending_item_commit_provenance)
+    state.pending_item_commit_provenance = None
+    if pending is None or pending.operation_id != operation_id:
+        return
+    if pending.item_start_head.lower() == item_start_head.lower():
+        # The item kept no commit after all; there is nothing to attribute.
+        return
+    await _write_item_commit_provenance_record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        record=ItemCommitProvenance(
+            item_id=pending.item_id,
+            item_start_head=pending.item_start_head,
+            head_sha=item_start_head,
+            operation_id=pending.operation_id,
+        ),
+    )
+
+
+async def _record_accepted_item_commit_provenance(
+    runner: Any,
+    *,
+    workspace_id: str,
+    state: MonitorState | None,
+    item_id: str,
+    item_start_head: str | None,
+    operation_id: str | None,
+) -> None:
+    """Record provenance when a review item's verdict kept a local commit.
+
+    "Accepted with a commit" is read mechanically: HEAD advanced past the item's
+    start head and survived the item's own verdict rollback. That covers
+    ``fix_committed`` and every #925/#928/#931 correction outcome that preserves a
+    commit, without re-deriving the verdict taxonomy here.
+
+    Best-effort by design: a failing HEAD probe or DB/OS failure warns and lets the
+    batch continue (the
+    commit still exists, and recovery's legacy subject fallback still preserves it).
+    Programming errors propagate.
+
+    An unreadable HEAD no longer discards the record, though: it is held as a
+    pending record and completed by the next item of the batch
+    (:func:`_complete_pending_item_commit_provenance`). Only an item whose probe
+    fails and which is never followed by another item in the same batch — the last
+    item before a push that then fails — still falls back to the legacy heuristic.
+    """
+    if state is None:
+        return
+    start_head = (item_start_head or "").strip()
+    if not start_head:
+        return
+    worktrees_root = getattr(runner, "_worktrees_root", None)
+    if not isinstance(worktrees_root, Path):
+        # Hosted execution and unit seams legitimately run without a local worktree;
+        # there is no local HEAD to fingerprint.
+        return
+    worktree_path = worktrees_root / workspace_id
+    if not worktree_path.exists():
+        return
+    # This item's start head is the previous item's end head; settle any record the
+    # previous item's probe could not write before recording this one.
+    await _complete_pending_item_commit_provenance(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_start_head=start_head,
+        operation_id=operation_id,
+    )
+    try:
+        head_sha = await runner._rev_parse_head(worktree_path)
+    except (TimeoutError, OSError, subprocess.SubprocessError) as exc:
+        # Same best-effort contract as the durable write below: a flaky HEAD probe
+        # must skip the audit write, not escape into the caller and fail the whole
+        # comment-repair batch. The item's commit itself is already on disk.
+        _remember_unrecorded_item_commit(
+            state,
+            item_id=str(item_id),
+            item_start_head=start_head,
+            operation_id=operation_id,
+        )
+        _log.warning(
+            "monitor.comment_repair_item_provenance_record_failed",
+            workspace_id=workspace_id,
+            item_id=str(item_id),
+            error=repr(exc)[:400],
+            reason_code=COMMENT_REPAIR_ITEM_PROVENANCE_RECORD_FAILED,
+        )
+        return
+    if not head_sha:
+        # Ordinary Git failure: ``_rev_parse_head`` returns None instead of raising,
+        # and the record is just as lost. Hold it for the next item as well.
+        _remember_unrecorded_item_commit(
+            state,
+            item_id=str(item_id),
+            item_start_head=start_head,
+            operation_id=operation_id,
+        )
+        return
+    if head_sha.strip().lower() == start_head.lower():
+        return
+    await _write_item_commit_provenance_record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        record=ItemCommitProvenance(
+            item_id=str(item_id),
+            item_start_head=start_head,
+            head_sha=head_sha.strip(),
+            operation_id=operation_id,
+        ),
     )

--- a/src/awf/runtime/pr_monitor_runner/comments.py
+++ b/src/awf/runtime/pr_monitor_runner/comments.py
@@ -20,6 +20,9 @@ from awf.runtime.ownership import (
     repair_agent_runtime_ownership,
 )
 from awf.runtime.pr_monitor_runner import comment_verdict as _comment_verdict
+from awf.runtime.pr_monitor_runner.comment_repair_provenance import (
+    _record_accepted_item_commit_provenance,
+)
 from awf.runtime.pr_monitor_runner.comment_verdict import (
     AgentVerdict,
     AgentVerdictExecutionError,
@@ -75,7 +78,7 @@ async def _address_thread(
     monitor_log: WorkspaceLogSink | None = None,
 ) -> Verdict:
     """Ask the monitor agent to resolve a review thread and return its verdict."""
-    del base_branch, remote_branch, operation_id, operation_type, monitor_log
+    del base_branch, remote_branch, operation_type, monitor_log
     from awf.runtime.pr_monitor import _review_thread_body_hash
     from awf.runtime.pr_monitor_runner.helpers import (
         _defer_reason_state_key,
@@ -122,7 +125,18 @@ async def _address_thread(
             evidence_anchor_head=cycle_start_head,
         )
     except AgentVerdictExecutionError:
-        return "agent_failed"
+        result = MonitorVerdictResult(verdict="agent_failed")
+    # #935: an accepted item commit must leave a durable audit trail immediately —
+    # the batch's ``comment_repair`` operation row is only finalised on push, so a
+    # restart between items would otherwise strand this commit with no provenance.
+    await _record_accepted_item_commit_provenance(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id=thread.thread_id,
+        item_start_head=operation_start_head,
+        operation_id=operation_id,
+    )
     if isinstance(result, MonitorVerdictResult):
         return result.verdict
     # Stash the agent's defer reason so the deferred-capture path can preserve it
@@ -200,7 +214,7 @@ async def _address_review_comment_result(
     monitor_log: WorkspaceLogSink | None = None,
 ) -> VerdictResult | MonitorVerdictResult:
     """Resolve a review comment while retaining its full monitor result."""
-    del base_branch, remote_branch, operation_id, operation_type, monitor_log
+    del base_branch, remote_branch, operation_type, monitor_log
     from awf.runtime.pr_monitor_runner.helpers import _review_comment_body_hash
 
     prompt_owned_paths = (
@@ -227,7 +241,7 @@ async def _address_review_comment_result(
         task_tag=resolved_task_tag,
     )
     try:
-        return await runner._invoke_cli_for_verdict_result(
+        result: VerdictResult | MonitorVerdictResult = await runner._invoke_cli_for_verdict_result(
             workspace_id=workspace_id,
             prompt=prompt,
             commit_message=f"fix: address PR review comment {comment.comment_id}",
@@ -240,7 +254,17 @@ async def _address_review_comment_result(
             evidence_body_hash=_review_comment_body_hash(comment),
         )
     except AgentVerdictExecutionError:
-        return MonitorVerdictResult(verdict="agent_failed")
+        result = MonitorVerdictResult(verdict="agent_failed")
+    # #935: record the accepted item commit before the batch ends (see _address_thread).
+    await _record_accepted_item_commit_provenance(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id=str(comment.comment_id),
+        item_start_head=operation_start_head,
+        operation_id=operation_id,
+    )
+    return result
 
 
 def _sync_comment_verdict_dependencies() -> None:

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -128,6 +128,7 @@ def _git_push_result_with_terminal_head_provenance_unavailable(
         failure_reason=push_result.failure_reason,
         details=details,
         paused_into_blocked=push_result.paused_into_blocked,
+        parked_needs_human=push_result.parked_needs_human,
     )
 
 
@@ -157,6 +158,7 @@ def _git_push_result_with_local_terminal_head(
         failure_reason=push_result.failure_reason,
         details=details,
         paused_into_blocked=push_result.paused_into_blocked,
+        parked_needs_human=push_result.parked_needs_human,
     )
 
 

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -40,6 +40,7 @@ from awf.runtime.pr_monitor import (
 )
 from awf.runtime.pr_monitor_runner.comment_repair_provenance import (
     _clear_published_item_commit_provenance_chain,
+    _complete_pending_item_commit_provenance,
     _settle_pending_item_commit_provenance,
 )
 from awf.runtime.pr_monitor_runner.comment_verdict import AgentVerdictProtocolError
@@ -291,6 +292,41 @@ async def _run_fix_cycle(
             operation_id=operation_id,
         )
 
+    async def _item_start_head_settling_previous() -> str:
+        """Read this item's start head and settle the previous item from it (#937).
+
+        Reading the start head is itself fallible, and its raise is caught by the
+        item loop's ``_MonitorHeadObjectMissingError`` arm — an early exit. Settling
+        only *after* that read would therefore drop a held record on exactly the
+        path the settle exists to cover, so settle before re-raising: the commit
+        object may be unverifiable while HEAD itself still reads, and then the
+        record is still recoverable (PRRT_kwDOSJAM6s6fv665).
+
+        On the readable path the head just probed *is* the pending item's end head
+        (nothing commits between one item's verdict and the next item's start), so
+        complete the record straight from it. Re-probing HEAD inside the settle
+        would only add a second chance to fail and clear a record already in hand.
+        """
+        try:
+            item_start_head = await _current_item_operation_start_head()
+        except BaseException:
+            await _settle_previous_item_provenance()
+            raise
+        if not worktree_path.exists():
+            # No worktree to probe: the head above is the cycle-start fallback, which
+            # predates the pending item's end head. Completing from it would write a
+            # backwards range, so keep the settle's clearing semantics instead.
+            await _settle_previous_item_provenance()
+            return item_start_head
+        await _complete_pending_item_commit_provenance(
+            self,
+            workspace_id=workspace_id,
+            state=state,
+            item_start_head=item_start_head,
+            operation_id=operation_id,
+        )
+        return item_start_head
+
     # Inline thread path/line coords are relative to the remote PR head from the
     # status that supplied the batch — not local worktree HEAD. Non-hosted agents
     # commit locally before push, so local HEAD can advance while settle re-polls
@@ -307,8 +343,7 @@ async def _run_fix_cycle(
         # 1) Address each item in the current batch.
         for t in threads:
             try:
-                item_operation_start_head = await _current_item_operation_start_head()
-                await _settle_previous_item_provenance()
+                item_operation_start_head = await _item_start_head_settling_previous()
                 verdict = await self._address_thread(
                     workspace_id=workspace_id,
                     repo=repo,
@@ -517,8 +552,7 @@ async def _run_fix_cycle(
                         workflow_scope_publish_dependent_ids.append(context.comment_id)
         for c in reviews:
             try:
-                item_operation_start_head = await _current_item_operation_start_head()
-                await _settle_previous_item_provenance()
+                item_operation_start_head = await _item_start_head_settling_previous()
                 verdict_result = await self._address_review_comment_result(
                     workspace_id=workspace_id,
                     repo=repo,

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -353,6 +353,29 @@ async def _run_fix_cycle(
             "per-item HEAD unavailable: commit object probe failed",
         )
 
+    async def _settle_previous_item_provenance() -> None:
+        """Complete a held item record BEFORE the next item can fail (#937).
+
+        The pre-push settle below is only reached on the normal fall-through
+        path. Every ``except`` arm of the item loops returns early, and a
+        permanent settle-poll fault re-raises — so a record still pending when a
+        *later* item raises never reaches it, and the marker is memory-only. A
+        restart then reads a chain with a hole exactly where recovery proves
+        ``remote..HEAD`` is AWF's own work, and parks (or discards) an accepted
+        commit whose subject the legacy heuristic cannot attribute.
+
+        Settling here costs nothing in the common case: the helper returns
+        immediately when no record is pending, and nothing commits between one
+        item's verdict and the next item's start, so the re-probed HEAD is still
+        the pending item's end head.
+        """
+        await _settle_pending_item_commit_provenance(
+            self,
+            workspace_id=workspace_id,
+            state=state,
+            operation_id=operation_id,
+        )
+
     # Inline thread path/line coords are relative to the remote PR head from the
     # status that supplied the batch — not local worktree HEAD. Non-hosted agents
     # commit locally before push, so local HEAD can advance while settle re-polls
@@ -370,6 +393,7 @@ async def _run_fix_cycle(
         for t in threads:
             try:
                 item_operation_start_head = await _current_item_operation_start_head()
+                await _settle_previous_item_provenance()
                 verdict = await self._address_thread(
                     workspace_id=workspace_id,
                     repo=repo,
@@ -579,6 +603,7 @@ async def _run_fix_cycle(
         for c in reviews:
             try:
                 item_operation_start_head = await _current_item_operation_start_head()
+                await _settle_previous_item_provenance()
                 verdict_result = await self._address_review_comment_result(
                     workspace_id=workspace_id,
                     repo=repo,
@@ -729,6 +754,9 @@ async def _run_fix_cycle(
                 # the stranded sweep below does not mistake it for the final one.
                 settle_status_is_fresh = False
                 break
+            # A permanent fault leaves this batch's commits local and unpushed,
+            # so the held record still has to survive the restart that follows.
+            await _settle_previous_item_provenance()
             raise
         settle_status_is_fresh = True
         # The settle re-poll succeeded: clear any stale retry count for this context
@@ -781,13 +809,9 @@ async def _run_fix_cycle(
     # end-HEAD probe could not write, and the pending marker only lives in memory.
     # Settle it here — nothing commits between the last verdict and this point, so
     # live HEAD is still that item's end head — or a failed push plus a restart
-    # would lose the record and park a resumable batch.
-    await _settle_pending_item_commit_provenance(
-        self,
-        workspace_id=workspace_id,
-        state=state,
-        operation_id=operation_id,
-    )
+    # would lose the record and park a resumable batch. Earlier items are settled
+    # before the next item runs, so a later failure cannot skip them.
+    await _settle_previous_item_provenance()
     protected_scope_block = await self._protected_scope_push_block(
         workspace_id=workspace_id,
         worktree_path=worktree_path,

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -675,6 +675,15 @@ async def _run_fix_cycle(
                 if verdict == "fix_committed":
                     workflow_scope_publish_dependent_ids.append(c.comment_id)
 
+        # The settle window below is cancellable: a worker stop/timeout raises
+        # ``CancelledError`` out of ``sleep()`` or the re-poll, and a
+        # ``BaseException`` bypasses the ``ForgeClientError`` arm and every settle
+        # after it. Complete the last item's held record here, before the window
+        # opens — nothing commits between that item's verdict and this point, so
+        # live HEAD is still its end head, and the memory-only marker would
+        # otherwise die with the worker and leave the chain holed (#937).
+        await _settle_previous_item_provenance()
+
         # 2) Settle window — small sleep, then re-poll for new activity.
         await self._deps.sleep(self._config.settle_interval_seconds)
         try:
@@ -756,10 +765,9 @@ async def _run_fix_cycle(
     # 3) Push everything we committed.
     # #937: the last item of the batch has no successor to complete a record its
     # end-HEAD probe could not write, and the pending marker only lives in memory.
-    # Settle it here — nothing commits between the last verdict and this point, so
-    # live HEAD is still that item's end head — or a failed push plus a restart
-    # would lose the record and park a resumable batch. Earlier items are settled
-    # before the next item runs, so a later failure cannot skip them.
+    # Each pass now settles before its (cancellable) settle window, so this call is
+    # the one-shot backstop for any exit that reaches the push — free once settled,
+    # and still correct because nothing commits between the last verdict and here.
     await _settle_previous_item_provenance()
     protected_scope_block = await self._protected_scope_push_block(
         workspace_id=workspace_id,

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -43,6 +43,7 @@ from awf.runtime.pr_monitor import (
 )
 from awf.runtime.pr_monitor_runner.comment_repair_provenance import (
     _clear_published_item_commit_provenance_chain,
+    _settle_pending_item_commit_provenance,
 )
 from awf.runtime.pr_monitor_runner.comment_verdict import AgentVerdictProtocolError
 from awf.runtime.pr_monitor_runner.comments import (
@@ -776,6 +777,17 @@ async def _run_fix_cycle(
     # iteration will re-poll and see what's left.)
 
     # 3) Push everything we committed.
+    # #937: the last item of the batch has no successor to complete a record its
+    # end-HEAD probe could not write, and the pending marker only lives in memory.
+    # Settle it here — nothing commits between the last verdict and this point, so
+    # live HEAD is still that item's end head — or a failed push plus a restart
+    # would lose the record and park a resumable batch.
+    await _settle_pending_item_commit_provenance(
+        self,
+        workspace_id=workspace_id,
+        state=state,
+        operation_id=operation_id,
+    )
     protected_scope_block = await self._protected_scope_push_block(
         workspace_id=workspace_id,
         worktree_path=worktree_path,

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -41,6 +41,9 @@ from awf.runtime.pr_monitor import (
     _review_thread_body_hash,
     _review_thread_needs_attention,
 )
+from awf.runtime.pr_monitor_runner.comment_repair_provenance import (
+    _clear_published_item_commit_provenance_chain,
+)
 from awf.runtime.pr_monitor_runner.comment_verdict import AgentVerdictProtocolError
 from awf.runtime.pr_monitor_runner.comments import (
     VerdictResult,
@@ -861,6 +864,16 @@ async def _run_fix_cycle(
     if push_result.pushed:
         pushed_head_sha = await self._rev_parse_head(worktree_path)
         state.last_push_sha = pushed_head_sha
+        # #937: the commit-time chain described this batch's UNPUBLISHED commits.
+        # They are published now, so the chain must not survive into the next
+        # batch — whose first item starts exactly at this pushed head, i.e. the
+        # old chain's tip, and would otherwise link onto a base that is now
+        # behind the PR.
+        await _clear_published_item_commit_provenance_chain(
+            self,
+            workspace_id=workspace_id,
+            state=state,
+        )
         await self._record_pr_monitor_audit_event(
             workspace_id=workspace_id,
             event_type=_AUDIT_GIT_PUSH_EVENT,

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -22,12 +22,10 @@ from awf.common.github_client import (
     GitHubClientError,
     RepoRef,
 )
-from awf.db.enums import FailureReason
 from awf.node.git_manager import git_env_without_object_lookup_overrides
 from awf.runtime.feedback_policy import (
     RESOLVABLE_THREAD_VERDICTS,
     canonical_unresolved_inline_threads,
-    review_thread_body_hashes,
 )
 from awf.runtime.logs import WorkspaceLogSink
 from awf.runtime.pr_monitor import (
@@ -38,7 +36,6 @@ from awf.runtime.pr_monitor import (
     _agent_can_triage_review_comment,
     _mark_review_thread_addressed,
     _needs_comment_attention,
-    _review_thread_body_hash,
     _review_thread_needs_attention,
 )
 from awf.runtime.pr_monitor_runner.comment_repair_provenance import (
@@ -60,18 +57,40 @@ from awf.runtime.pr_monitor_runner.constants import (
     _GITHUB_WORKFLOW_SCOPE_REQUIRED_REASON,
     _HEAD_OBJECT_MISSING_UNRECOVERABLE_REASON,
 )
+from awf.runtime.pr_monitor_runner.fix_cycle_deferred_capture import (
+    _capture_deferred_review_thread as _capture_deferred_review_thread,
+)
+from awf.runtime.pr_monitor_runner.fix_cycle_deferred_capture import (
+    _deferred_issue_already_filed as _deferred_issue_already_filed,
+)
+from awf.runtime.pr_monitor_runner.fix_cycle_deferred_capture import (
+    _deferred_issue_filed_marker as _deferred_issue_filed_marker,
+)
+from awf.runtime.pr_monitor_runner.fix_cycle_deferred_capture import (
+    _deferred_thread_conversation as _deferred_thread_conversation,
+)
 from awf.runtime.pr_monitor_runner.fix_cycle_resolution_invariant import (
     escalate_owner_missing_threads,
     stranded_resolvable_thread_ids,
 )
+from awf.runtime.pr_monitor_runner.fix_cycle_terminal_provenance import (
+    _agent_verdict_protocol_failure_result as _agent_verdict_protocol_failure_result,
+)
+from awf.runtime.pr_monitor_runner.fix_cycle_terminal_provenance import (
+    _enrich_failed_fix_cycle_result as _enrich_failed_fix_cycle_result,
+)
+from awf.runtime.pr_monitor_runner.fix_cycle_terminal_provenance import (
+    _git_push_result_with_local_terminal_head as _git_push_result_with_local_terminal_head,
+)
+from awf.runtime.pr_monitor_runner.fix_cycle_terminal_provenance import (
+    _git_push_result_with_terminal_head_provenance_unavailable as _git_push_result_with_terminal_head_provenance_unavailable,
+)
 from awf.runtime.pr_monitor_runner.git_utils import git_worktree_command
 from awf.runtime.pr_monitor_runner.helpers import (
     _clear_addressed_state_by_id,
-    _defer_reason_state_key,
     _is_transient_bitbucket_client_error,
     _is_transient_github_client_error,
     _mark_review_comment_addressed,
-    _redact_and_truncate_forge_error,
     _review_comment_needs_attention,
     _sync_needs_human_reason,
 )
@@ -93,110 +112,6 @@ from awf.runtime.pr_monitor_runner.types import (
 # queued it for resolution. Aliases the shared taxonomy so the in-cycle resolve
 # loop and the stranded-thread invariant (#925) cannot drift apart.
 _RESOLVABLE_THREAD_VERDICTS = RESOLVABLE_THREAD_VERDICTS
-
-
-def _agent_verdict_protocol_failure_result(
-    exc: AgentVerdictProtocolError,
-) -> _GitPushResult:
-    """Return a terminal agent failure without creating human-attention state."""
-    return _GitPushResult(
-        pushed=False,
-        failed=True,
-        returncode=1,
-        stderr=str(exc),
-        reason_code=exc.reason_code,
-        failure_reason=FailureReason.agent_failure,
-    )
-
-
-def _git_push_result_with_terminal_head_provenance_unavailable(
-    push_result: _GitPushResult,
-) -> _GitPushResult:
-    """Mark terminal failures whose unpushed HEAD could not be fingerprinted."""
-    if not push_result.failed:
-        return push_result
-    details = dict(push_result.details or {})
-    if details.get("local_terminal_head_provenance_unavailable"):
-        return push_result
-    if details.get("local_terminal_head_sha"):
-        return push_result
-    details["local_terminal_head_provenance_unavailable"] = True
-    return _GitPushResult(
-        pushed=push_result.pushed,
-        failed=push_result.failed,
-        returncode=push_result.returncode,
-        stdout=push_result.stdout,
-        stderr=push_result.stderr,
-        recovered_by_resync=push_result.recovered_by_resync,
-        reason_code=push_result.reason_code,
-        failure_reason=push_result.failure_reason,
-        details=details,
-        paused_into_blocked=push_result.paused_into_blocked,
-        parked_needs_human=push_result.parked_needs_human,
-    )
-
-
-def _git_push_result_with_local_terminal_head(
-    push_result: _GitPushResult,
-    *,
-    operation_start_head: str,
-    local_head: str | None,
-) -> _GitPushResult:
-    """Attach unpushed local HEAD provenance to a failed fix-cycle result."""
-    if not push_result.failed:
-        return push_result
-    if not local_head or local_head.lower() == operation_start_head.lower():
-        return push_result
-    details = dict(push_result.details or {})
-    if details.get("local_terminal_head_sha"):
-        return push_result
-    details["local_terminal_head_sha"] = local_head
-    return _GitPushResult(
-        pushed=push_result.pushed,
-        failed=push_result.failed,
-        returncode=push_result.returncode,
-        stdout=push_result.stdout,
-        stderr=push_result.stderr,
-        recovered_by_resync=push_result.recovered_by_resync,
-        reason_code=push_result.reason_code,
-        failure_reason=push_result.failure_reason,
-        details=details,
-        paused_into_blocked=push_result.paused_into_blocked,
-        parked_needs_human=push_result.parked_needs_human,
-    )
-
-
-async def _enrich_failed_fix_cycle_result(
-    self: Any,
-    push_result: _GitPushResult,
-    *,
-    worktree_path: Path,
-    operation_start_head: str,
-) -> _GitPushResult:
-    """Record unpushed local HEAD on terminal failed fix-cycle exits for provenance."""
-    if not push_result.failed or not push_result.terminal_monitor_failure:
-        return push_result
-    if push_result.reason_code == _HEAD_OBJECT_MISSING_UNRECOVERABLE_REASON:
-        return _git_push_result_with_terminal_head_provenance_unavailable(push_result)
-    try:
-        local_head = await self._rev_parse_head(worktree_path)
-    except (TimeoutError, OSError, subprocess.SubprocessError):
-        _log.warning(
-            "monitor.fix_cycle_terminal_head_provenance_unavailable",
-            reason_code=push_result.reason_code,
-        )
-        return _git_push_result_with_terminal_head_provenance_unavailable(push_result)
-    if not local_head:
-        _log.warning(
-            "monitor.fix_cycle_terminal_head_provenance_unavailable",
-            reason_code=push_result.reason_code,
-        )
-        return _git_push_result_with_terminal_head_provenance_unavailable(push_result)
-    return _git_push_result_with_local_terminal_head(
-        push_result,
-        operation_start_head=operation_start_head,
-        local_head=local_head,
-    )
 
 
 async def _run_fix_cycle(
@@ -1303,229 +1218,3 @@ def _requeue_workflow_scope_publish_dependent_items(
     del reason
     for item_id in dict.fromkeys([*resolution_dependent_ids, *item_ids]):
         _clear_addressed_state_by_id(state, item_id)
-
-
-def _deferred_issue_filed_marker(thread_id: str, body_hash: str) -> str:
-    """State key recording that a tracking issue was filed for a deferred thread.
-
-    Distinct from the verdict/body-hash keys that ``_clear_addressed_state_by_id``
-    pops, so the marker survives a resolve-retry's state clear and keeps the
-    capture idempotent across outer monitor iterations (no duplicate issues).
-
-    Keyed by the thread body hash as well as the id: a same-body resolve-retry
-    stays idempotent, but if the thread later gains new reviewer replies the
-    hash changes and the new feedback is captured into a fresh issue rather than
-    silently resolved under the stale one.
-    """
-    return f"__deferred_issue_filed__:{thread_id}:{body_hash}"
-
-
-def _deferred_issue_already_filed(state: MonitorState, thread: ReviewThread) -> bool:
-    """True when a tracking issue was filed for this conversation (any hash era).
-
-    Accepts markers keyed by the current content-only hash or either
-    pre-normalize legacy form (ID-bearing or fallback null-id) so an in-flight
-    resume does not file a duplicate — PRRT_kwDOSJAM6s6dfH8h /
-    PRRT_kwDOSJAM6s6dfSq-.
-    """
-    return any(
-        state.threads_addressed_ids.get(_deferred_issue_filed_marker(thread.thread_id, body_hash))
-        for body_hash in review_thread_body_hashes(thread)
-    )
-
-
-def _deferred_thread_conversation(thread: ReviewThread) -> str:
-    """Render the full review-bundle history for the tracking-issue body.
-
-    A body-aware recapture (see ``_deferred_issue_filed_marker``) fires precisely
-    because review evidence changed, so the filed issue must carry the associated
-    review body and whole inline conversation — not just the truncated
-    first-comment excerpt — or resolving the thread would lose deferred work.
-    """
-    blocks: list[str] = []
-    if thread.review_context is not None:
-        context = thread.review_context
-        quoted = "\n".join(
-            f"> {line}" for line in (context.body or context.body_excerpt).splitlines() or [""]
-        )
-        blocks.append(f"**Associated review body ({context.author or 'reviewer'})**:\n\n{quoted}")
-    for comment in thread.comments:
-        quoted = "\n".join(f"> {line}" for line in (comment.body or "").splitlines() or [""])
-        blocks.append(f"**{comment.author or 'reviewer'}**:\n\n{quoted}")
-    if not thread.comments:
-        blocks.append(f"> {thread.body_excerpt}")
-    return "\n\n".join(blocks)
-
-
-async def _capture_deferred_review_thread(
-    self: Any,
-    *,
-    workspace_id: str,
-    repo: RepoRef,
-    pr_number: int,
-    thread: ReviewThread,
-    state: MonitorState,
-    base_branch: str | None,
-    remote_branch: str,
-    operation_id: str | None,
-    operation_type: str | None,
-    monitor_log: WorkspaceLogSink | None,
-) -> bool | None:
-    """Durably capture a follow-up ``defer`` before its thread is resolved (#305).
-
-    Posts an explanatory PR comment and files a tracking issue. Idempotent per
-    thread *and body*: a marker records that the issue was already filed so a
-    later same-body resolve-retry (which clears the verdict and re-addresses the
-    thread) does not file a duplicate, while new reviewer replies (a changed
-    body) are captured into a fresh issue. Returns ``True`` when the deferred
-    work is durably captured (caller may resolve the thread); ``False`` on a
-    *permanent* capture failure (caller downgrades to ``needs_human`` so the
-    merge stays blocked and the operator is notified); or ``None`` on a
-    *transient* failure — the thread verdict is cleared so the next poll
-    re-addresses and re-attempts capture once GitHub recovers, instead of
-    permanently downgrading a valid defer.
-    """
-    marker = _deferred_issue_filed_marker(thread.thread_id, _review_thread_body_hash(thread))
-    if _deferred_issue_already_filed(state, thread):
-        return True
-    location = thread.path or "the PR diff"
-    thread_ref = thread.url or f"PR #{pr_number}"
-    issue_title = f"Deferred from PR #{pr_number}: {location}"
-    agent_reason = state.threads_addressed_ids.get(_defer_reason_state_key(thread.thread_id))
-    agent_reason_section = (
-        f"Agent's deferral reason:\n\n> {agent_reason}\n\n" if agent_reason else ""
-    )
-    issue_body = (
-        f"AWF deferred a review thread while monitoring PR #{pr_number}.\n\n"
-        f"- Path: {location}\n"
-        f"- Thread: {thread_ref}\n\n"
-        f"{agent_reason_section}"
-        f"Review thread (full history):\n\n{_deferred_thread_conversation(thread)}\n\n"
-        "This issue tracks the deferred follow-up so the PR thread could be "
-        "resolved without losing the work."
-    )
-    try:
-        issue_url = await self._deps.gh.create_issue(
-            repo=repo,
-            title=issue_title,
-            body=issue_body,
-        )
-    except ForgeClientError as exc:
-        # Both forges file the tracking issue through ``self._deps.gh``; either
-        # raises a ``ForgeClientError`` subclass (e.g. a 403 when the token lacks
-        # the issues-create scope, which Bitbucket cannot fall back to a comment).
-        # Catching the shared base keeps a Bitbucket fault from escaping to the
-        # runner's generic handler and terminating the monitor instead of
-        # downgrading to ``needs_human``. Transient blips clear the verdict to
-        # re-attempt next poll (``None``); permanent faults downgrade to
-        # ``needs_human`` (``False``) so the merge gate keeps blocking and the
-        # operator is notified. The transient-retry audit reason stays forge-specific.
-        transient_retry_reason = (
-            _BITBUCKET_TRANSIENT_RETRY_REASON
-            if isinstance(exc, BitbucketClientError)
-            else _GITHUB_TRANSIENT_RETRY_REASON
-        )
-        if await self._wait_after_transient_forge_error(
-            exc,
-            workspace_id=workspace_id,
-            pr_number=pr_number,
-            context="capture_deferred_thread",
-            state=state,
-            monitor_log=monitor_log,
-        ):
-            # Transient (502 / rate-limit / reset): a temporary issue-API outage
-            # must not permanently downgrade a valid defer to needs_human. Clear
-            # the verdict so the next poll re-addresses and re-attempts capture
-            # once the forge recovers. The thread stays unresolved meanwhile.
-            _clear_addressed_state_by_id(state, thread.thread_id)
-            await self._record_pr_monitor_audit_event(
-                workspace_id=workspace_id,
-                event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
-                action="capture_deferred_thread",
-                outcome="requeued",
-                reason_code=transient_retry_reason,
-                pr_number=pr_number,
-                status=None,
-                base_branch=base_branch or "",
-                remote_branch=remote_branch,
-                operation_id=operation_id,
-                operation_type=operation_type,
-                monitor_log=monitor_log,
-                evidence={"thread_ids": [thread.thread_id]},
-            )
-            return None
-        # Permanent failure (e.g. token missing the issues scope). ``str(exc)``
-        # already redacts; redact again defensively before logging/persisting.
-        # ``redacted_detail()`` normalizes the human detail (gh stderr / Bitbucket
-        # body) across forges.
-        redacted_error = _redact_and_truncate_forge_error(str(exc))
-        _log.warning(
-            "monitor.deferred_capture_failed",
-            thread_id=thread.thread_id,
-            stderr=_redact_and_truncate_forge_error(exc.redacted_detail()),
-        )
-        await self._record_pr_monitor_audit_event(
-            workspace_id=workspace_id,
-            event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
-            action="capture_deferred_thread",
-            outcome="failed",
-            reason_code="DEFERRED_CAPTURE_FAILED",
-            pr_number=pr_number,
-            status=None,
-            base_branch=base_branch or "",
-            remote_branch=remote_branch,
-            operation_id=operation_id,
-            operation_type=operation_type,
-            monitor_log=monitor_log,
-            evidence={"thread_ids": [thread.thread_id], "error_message": redacted_error},
-        )
-        return False
-    # The tracking issue was filed: clear any stale ``capture_deferred_thread``
-    # retry count so a recovered blip never accumulates toward the bounded budget.
-    await self._clear_forge_transient_retry_state_on_success(
-        workspace_id=workspace_id,
-        state=state,
-        context="capture_deferred_thread",
-    )
-    # Filing the tracking issue is the durable capture. Record it immediately so
-    # a later retry (e.g. after a failed push) never files a duplicate, even if
-    # the explanatory comment below fails. The comment is best-effort courtesy.
-    state.mark_addressed(marker, issue_url)
-    try:
-        await self._deps.gh.post_comment(
-            repo=repo,
-            pr_number=pr_number,
-            body=(
-                f"AWF deferred the review thread on `{location}` and filed "
-                f"{issue_url} to track the follow-up. Resolving this thread; the "
-                "deferred work lives in that issue."
-            ),
-        )
-    except ForgeClientError as exc:
-        # The tracking issue is already filed and recorded; this explanatory
-        # comment is best-effort courtesy, so a failure on either forge is
-        # swallowed. Catching the shared base keeps a Bitbucket fault from escaping
-        # and terminating the monitor after the durable capture is already done.
-        # ``redacted_detail()`` normalizes the human detail across forges.
-        _log.warning(
-            "monitor.deferred_capture_comment_failed",
-            thread_id=thread.thread_id,
-            issue_url=issue_url,
-            stderr=_redact_and_truncate_forge_error(exc.redacted_detail()),
-        )
-    await self._record_pr_monitor_audit_event(
-        workspace_id=workspace_id,
-        event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
-        action="capture_deferred_thread",
-        outcome="succeeded",
-        reason_code="DEFERRED_CAPTURE",
-        pr_number=pr_number,
-        status=None,
-        base_branch=base_branch or "",
-        remote_branch=remote_branch,
-        operation_id=operation_id,
-        operation_type=operation_type,
-        monitor_log=monitor_log,
-        evidence={"thread_ids": [thread.thread_id], "issue_url": issue_url},
-    )
-    return True

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle_deferred_capture.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle_deferred_capture.py
@@ -1,0 +1,263 @@
+"""Durable capture of deferred review threads for ``fix_cycle`` (#305).
+
+Kept separate so ``fix_cycle`` stays under the first-party line budget.
+
+When the agent answers ``defer`` on an inline thread, the fix cycle may only
+resolve that thread once the follow-up work exists somewhere durable. This
+module owns that hand-off: the idempotency marker keyed by thread id *and* body
+hash, the rendered conversation that becomes the tracking issue body, and the
+capture itself (file the issue, post the explanatory comment, audit the
+outcome).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from awf.common.bitbucket_client import BitbucketClientError
+from awf.common.forge_errors import ForgeClientError
+from awf.common.github_client import RepoRef
+from awf.runtime.feedback_policy import review_thread_body_hashes
+from awf.runtime.logs import WorkspaceLogSink
+from awf.runtime.pr_monitor import (
+    MonitorState,
+    ReviewThread,
+    _review_thread_body_hash,
+)
+from awf.runtime.pr_monitor_runner.constants import (
+    _AUDIT_COMMENT_RESOLUTION_EVENT,
+    _BITBUCKET_TRANSIENT_RETRY_REASON,
+    _GITHUB_TRANSIENT_RETRY_REASON,
+)
+from awf.runtime.pr_monitor_runner.helpers import (
+    _clear_addressed_state_by_id,
+    _defer_reason_state_key,
+    _redact_and_truncate_forge_error,
+)
+from awf.runtime.pr_monitor_runner.logging import _log
+
+
+def _deferred_issue_filed_marker(thread_id: str, body_hash: str) -> str:
+    """State key recording that a tracking issue was filed for a deferred thread.
+
+    Distinct from the verdict/body-hash keys that ``_clear_addressed_state_by_id``
+    pops, so the marker survives a resolve-retry's state clear and keeps the
+    capture idempotent across outer monitor iterations (no duplicate issues).
+
+    Keyed by the thread body hash as well as the id: a same-body resolve-retry
+    stays idempotent, but if the thread later gains new reviewer replies the
+    hash changes and the new feedback is captured into a fresh issue rather than
+    silently resolved under the stale one.
+    """
+    return f"__deferred_issue_filed__:{thread_id}:{body_hash}"
+
+
+def _deferred_issue_already_filed(state: MonitorState, thread: ReviewThread) -> bool:
+    """True when a tracking issue was filed for this conversation (any hash era).
+
+    Accepts markers keyed by the current content-only hash or either
+    pre-normalize legacy form (ID-bearing or fallback null-id) so an in-flight
+    resume does not file a duplicate — PRRT_kwDOSJAM6s6dfH8h /
+    PRRT_kwDOSJAM6s6dfSq-.
+    """
+    return any(
+        state.threads_addressed_ids.get(_deferred_issue_filed_marker(thread.thread_id, body_hash))
+        for body_hash in review_thread_body_hashes(thread)
+    )
+
+
+def _deferred_thread_conversation(thread: ReviewThread) -> str:
+    """Render the full review-bundle history for the tracking-issue body.
+
+    A body-aware recapture (see ``_deferred_issue_filed_marker``) fires precisely
+    because review evidence changed, so the filed issue must carry the associated
+    review body and whole inline conversation — not just the truncated
+    first-comment excerpt — or resolving the thread would lose deferred work.
+    """
+    blocks: list[str] = []
+    if thread.review_context is not None:
+        context = thread.review_context
+        quoted = "\n".join(
+            f"> {line}" for line in (context.body or context.body_excerpt).splitlines() or [""]
+        )
+        blocks.append(f"**Associated review body ({context.author or 'reviewer'})**:\n\n{quoted}")
+    for comment in thread.comments:
+        quoted = "\n".join(f"> {line}" for line in (comment.body or "").splitlines() or [""])
+        blocks.append(f"**{comment.author or 'reviewer'}**:\n\n{quoted}")
+    if not thread.comments:
+        blocks.append(f"> {thread.body_excerpt}")
+    return "\n\n".join(blocks)
+
+
+async def _capture_deferred_review_thread(
+    self: Any,
+    *,
+    workspace_id: str,
+    repo: RepoRef,
+    pr_number: int,
+    thread: ReviewThread,
+    state: MonitorState,
+    base_branch: str | None,
+    remote_branch: str,
+    operation_id: str | None,
+    operation_type: str | None,
+    monitor_log: WorkspaceLogSink | None,
+) -> bool | None:
+    """Durably capture a follow-up ``defer`` before its thread is resolved (#305).
+
+    Posts an explanatory PR comment and files a tracking issue. Idempotent per
+    thread *and body*: a marker records that the issue was already filed so a
+    later same-body resolve-retry (which clears the verdict and re-addresses the
+    thread) does not file a duplicate, while new reviewer replies (a changed
+    body) are captured into a fresh issue. Returns ``True`` when the deferred
+    work is durably captured (caller may resolve the thread); ``False`` on a
+    *permanent* capture failure (caller downgrades to ``needs_human`` so the
+    merge stays blocked and the operator is notified); or ``None`` on a
+    *transient* failure — the thread verdict is cleared so the next poll
+    re-addresses and re-attempts capture once GitHub recovers, instead of
+    permanently downgrading a valid defer.
+    """
+    marker = _deferred_issue_filed_marker(thread.thread_id, _review_thread_body_hash(thread))
+    if _deferred_issue_already_filed(state, thread):
+        return True
+    location = thread.path or "the PR diff"
+    thread_ref = thread.url or f"PR #{pr_number}"
+    issue_title = f"Deferred from PR #{pr_number}: {location}"
+    agent_reason = state.threads_addressed_ids.get(_defer_reason_state_key(thread.thread_id))
+    agent_reason_section = (
+        f"Agent's deferral reason:\n\n> {agent_reason}\n\n" if agent_reason else ""
+    )
+    issue_body = (
+        f"AWF deferred a review thread while monitoring PR #{pr_number}.\n\n"
+        f"- Path: {location}\n"
+        f"- Thread: {thread_ref}\n\n"
+        f"{agent_reason_section}"
+        f"Review thread (full history):\n\n{_deferred_thread_conversation(thread)}\n\n"
+        "This issue tracks the deferred follow-up so the PR thread could be "
+        "resolved without losing the work."
+    )
+    try:
+        issue_url = await self._deps.gh.create_issue(
+            repo=repo,
+            title=issue_title,
+            body=issue_body,
+        )
+    except ForgeClientError as exc:
+        # Both forges file the tracking issue through ``self._deps.gh``; either
+        # raises a ``ForgeClientError`` subclass (e.g. a 403 when the token lacks
+        # the issues-create scope, which Bitbucket cannot fall back to a comment).
+        # Catching the shared base keeps a Bitbucket fault from escaping to the
+        # runner's generic handler and terminating the monitor instead of
+        # downgrading to ``needs_human``. Transient blips clear the verdict to
+        # re-attempt next poll (``None``); permanent faults downgrade to
+        # ``needs_human`` (``False``) so the merge gate keeps blocking and the
+        # operator is notified. The transient-retry audit reason stays forge-specific.
+        transient_retry_reason = (
+            _BITBUCKET_TRANSIENT_RETRY_REASON
+            if isinstance(exc, BitbucketClientError)
+            else _GITHUB_TRANSIENT_RETRY_REASON
+        )
+        if await self._wait_after_transient_forge_error(
+            exc,
+            workspace_id=workspace_id,
+            pr_number=pr_number,
+            context="capture_deferred_thread",
+            state=state,
+            monitor_log=monitor_log,
+        ):
+            # Transient (502 / rate-limit / reset): a temporary issue-API outage
+            # must not permanently downgrade a valid defer to needs_human. Clear
+            # the verdict so the next poll re-addresses and re-attempts capture
+            # once the forge recovers. The thread stays unresolved meanwhile.
+            _clear_addressed_state_by_id(state, thread.thread_id)
+            await self._record_pr_monitor_audit_event(
+                workspace_id=workspace_id,
+                event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
+                action="capture_deferred_thread",
+                outcome="requeued",
+                reason_code=transient_retry_reason,
+                pr_number=pr_number,
+                status=None,
+                base_branch=base_branch or "",
+                remote_branch=remote_branch,
+                operation_id=operation_id,
+                operation_type=operation_type,
+                monitor_log=monitor_log,
+                evidence={"thread_ids": [thread.thread_id]},
+            )
+            return None
+        # Permanent failure (e.g. token missing the issues scope). ``str(exc)``
+        # already redacts; redact again defensively before logging/persisting.
+        # ``redacted_detail()`` normalizes the human detail (gh stderr / Bitbucket
+        # body) across forges.
+        redacted_error = _redact_and_truncate_forge_error(str(exc))
+        _log.warning(
+            "monitor.deferred_capture_failed",
+            thread_id=thread.thread_id,
+            stderr=_redact_and_truncate_forge_error(exc.redacted_detail()),
+        )
+        await self._record_pr_monitor_audit_event(
+            workspace_id=workspace_id,
+            event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
+            action="capture_deferred_thread",
+            outcome="failed",
+            reason_code="DEFERRED_CAPTURE_FAILED",
+            pr_number=pr_number,
+            status=None,
+            base_branch=base_branch or "",
+            remote_branch=remote_branch,
+            operation_id=operation_id,
+            operation_type=operation_type,
+            monitor_log=monitor_log,
+            evidence={"thread_ids": [thread.thread_id], "error_message": redacted_error},
+        )
+        return False
+    # The tracking issue was filed: clear any stale ``capture_deferred_thread``
+    # retry count so a recovered blip never accumulates toward the bounded budget.
+    await self._clear_forge_transient_retry_state_on_success(
+        workspace_id=workspace_id,
+        state=state,
+        context="capture_deferred_thread",
+    )
+    # Filing the tracking issue is the durable capture. Record it immediately so
+    # a later retry (e.g. after a failed push) never files a duplicate, even if
+    # the explanatory comment below fails. The comment is best-effort courtesy.
+    state.mark_addressed(marker, issue_url)
+    try:
+        await self._deps.gh.post_comment(
+            repo=repo,
+            pr_number=pr_number,
+            body=(
+                f"AWF deferred the review thread on `{location}` and filed "
+                f"{issue_url} to track the follow-up. Resolving this thread; the "
+                "deferred work lives in that issue."
+            ),
+        )
+    except ForgeClientError as exc:
+        # The tracking issue is already filed and recorded; this explanatory
+        # comment is best-effort courtesy, so a failure on either forge is
+        # swallowed. Catching the shared base keeps a Bitbucket fault from escaping
+        # and terminating the monitor after the durable capture is already done.
+        # ``redacted_detail()`` normalizes the human detail across forges.
+        _log.warning(
+            "monitor.deferred_capture_comment_failed",
+            thread_id=thread.thread_id,
+            issue_url=issue_url,
+            stderr=_redact_and_truncate_forge_error(exc.redacted_detail()),
+        )
+    await self._record_pr_monitor_audit_event(
+        workspace_id=workspace_id,
+        event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
+        action="capture_deferred_thread",
+        outcome="succeeded",
+        reason_code="DEFERRED_CAPTURE",
+        pr_number=pr_number,
+        status=None,
+        base_branch=base_branch or "",
+        remote_branch=remote_branch,
+        operation_id=operation_id,
+        operation_type=operation_type,
+        monitor_log=monitor_log,
+        evidence={"thread_ids": [thread.thread_id], "issue_url": issue_url},
+    )
+    return True

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle_terminal_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle_terminal_provenance.py
@@ -1,0 +1,131 @@
+"""Terminal fix-cycle result shaping for ``fix_cycle``.
+
+Kept separate so ``fix_cycle`` stays under the first-party line budget.
+
+Every terminal (non-retryable) fix-cycle exit has to answer one question for the
+operator: where did the work that never reached the remote end up? These helpers
+own that answer — they stamp the unpushed local HEAD onto a failed
+``_GitPushResult``, or record that the HEAD could not be fingerprinted at all —
+and they build the terminal result for an agent verdict-protocol breach, which
+is an agent failure rather than something a human is asked to look at.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from awf.db.enums import FailureReason
+from awf.runtime.pr_monitor_runner.comment_verdict import AgentVerdictProtocolError
+from awf.runtime.pr_monitor_runner.constants import (
+    _HEAD_OBJECT_MISSING_UNRECOVERABLE_REASON,
+)
+from awf.runtime.pr_monitor_runner.logging import _log
+from awf.runtime.pr_monitor_runner.remote_ops import (
+    _GitPushResult,
+)
+
+
+def _agent_verdict_protocol_failure_result(
+    exc: AgentVerdictProtocolError,
+) -> _GitPushResult:
+    """Return a terminal agent failure without creating human-attention state."""
+    return _GitPushResult(
+        pushed=False,
+        failed=True,
+        returncode=1,
+        stderr=str(exc),
+        reason_code=exc.reason_code,
+        failure_reason=FailureReason.agent_failure,
+    )
+
+
+def _git_push_result_with_terminal_head_provenance_unavailable(
+    push_result: _GitPushResult,
+) -> _GitPushResult:
+    """Mark terminal failures whose unpushed HEAD could not be fingerprinted."""
+    if not push_result.failed:
+        return push_result
+    details = dict(push_result.details or {})
+    if details.get("local_terminal_head_provenance_unavailable"):
+        return push_result
+    if details.get("local_terminal_head_sha"):
+        return push_result
+    details["local_terminal_head_provenance_unavailable"] = True
+    return _GitPushResult(
+        pushed=push_result.pushed,
+        failed=push_result.failed,
+        returncode=push_result.returncode,
+        stdout=push_result.stdout,
+        stderr=push_result.stderr,
+        recovered_by_resync=push_result.recovered_by_resync,
+        reason_code=push_result.reason_code,
+        failure_reason=push_result.failure_reason,
+        details=details,
+        paused_into_blocked=push_result.paused_into_blocked,
+        parked_needs_human=push_result.parked_needs_human,
+    )
+
+
+def _git_push_result_with_local_terminal_head(
+    push_result: _GitPushResult,
+    *,
+    operation_start_head: str,
+    local_head: str | None,
+) -> _GitPushResult:
+    """Attach unpushed local HEAD provenance to a failed fix-cycle result."""
+    if not push_result.failed:
+        return push_result
+    if not local_head or local_head.lower() == operation_start_head.lower():
+        return push_result
+    details = dict(push_result.details or {})
+    if details.get("local_terminal_head_sha"):
+        return push_result
+    details["local_terminal_head_sha"] = local_head
+    return _GitPushResult(
+        pushed=push_result.pushed,
+        failed=push_result.failed,
+        returncode=push_result.returncode,
+        stdout=push_result.stdout,
+        stderr=push_result.stderr,
+        recovered_by_resync=push_result.recovered_by_resync,
+        reason_code=push_result.reason_code,
+        failure_reason=push_result.failure_reason,
+        details=details,
+        paused_into_blocked=push_result.paused_into_blocked,
+        parked_needs_human=push_result.parked_needs_human,
+    )
+
+
+async def _enrich_failed_fix_cycle_result(
+    self: Any,
+    push_result: _GitPushResult,
+    *,
+    worktree_path: Path,
+    operation_start_head: str,
+) -> _GitPushResult:
+    """Record unpushed local HEAD on terminal failed fix-cycle exits for provenance."""
+    if not push_result.failed or not push_result.terminal_monitor_failure:
+        return push_result
+    if push_result.reason_code == _HEAD_OBJECT_MISSING_UNRECOVERABLE_REASON:
+        return _git_push_result_with_terminal_head_provenance_unavailable(push_result)
+    try:
+        local_head = await self._rev_parse_head(worktree_path)
+    except (TimeoutError, OSError, subprocess.SubprocessError):
+        _log.warning(
+            "monitor.fix_cycle_terminal_head_provenance_unavailable",
+            reason_code=push_result.reason_code,
+        )
+        return _git_push_result_with_terminal_head_provenance_unavailable(push_result)
+    if not local_head:
+        _log.warning(
+            "monitor.fix_cycle_terminal_head_provenance_unavailable",
+            reason_code=push_result.reason_code,
+        )
+        return _git_push_result_with_terminal_head_provenance_unavailable(push_result)
+    return _git_push_result_with_local_terminal_head(
+        push_result,
+        operation_start_head=operation_start_head,
+        local_head=local_head,
+    )

--- a/src/awf/runtime/pr_monitor_runner/loop.py
+++ b/src/awf/runtime/pr_monitor_runner/loop.py
@@ -66,6 +66,7 @@ from awf.runtime.pr_monitor_runner.loop_helpers import (
 from awf.runtime.pr_monitor_runner.loop_recovery_ops import (
     _finish_agent_service_recovery_failed_operation,
     _finish_agent_service_recovery_superseded_operation,
+    _finish_parked_comment_repair_cycle,
     _provider_recovery_operation_result_updates,
 )
 from awf.runtime.pr_monitor_runner.remote_ops import (
@@ -1180,6 +1181,18 @@ async def _execute(
                 },
             )
             return True
+        if push_result.parked_needs_human:
+            # #935: unattributable unpushed commits were preserved for a human. End
+            # the cycle without terminally failing — the work must survive on disk.
+            return await _finish_parked_comment_repair_cycle(
+                self,
+                workspace_id=workspace_id,
+                state=state,
+                operation=operation,
+                push_result=push_result,
+                thread_count=len(action.threads),
+                review_comment_count=len(action.review_comments),
+            )
         if push_result.failed:
             reason_code = push_result.reason_code
             outcome = _git_push_failure_outcome(push_result)

--- a/src/awf/runtime/pr_monitor_runner/loop.py
+++ b/src/awf/runtime/pr_monitor_runner/loop.py
@@ -47,6 +47,9 @@ from awf.runtime.pr_monitor_runner import (
 from awf.runtime.pr_monitor_runner import (
     notify_human_loop as _notify_human_loop,
 )
+from awf.runtime.pr_monitor_runner import (
+    operator_hint_loop as _operator_hint_loop,
+)
 from awf.runtime.pr_monitor_runner.constants import (
     _AUDIT_GIT_PUSH_EVENT,
     _CI_TRANSIENT_RERUN_FAILED_REASON,
@@ -1290,182 +1293,21 @@ async def _execute(
         return False
 
     if isinstance(action, AddressOperatorHint):
-        operation = await self._begin_monitor_operation(
+        return await _operator_hint_loop.handle_operator_hint_action(
+            self,
+            action=action,
             workspace_id=workspace_id,
-            operation_type=OperationType.comment_repair,
-            action="operator_hint_repair",
-            requested_action="address_operator_hint",
-            reason="Operator remonitor hint required repair before merge.",
-            reason_code=action.hint.reason_code,
+            repo=repo,
             pr_number=pr_number,
             status=status,
+            state=state,
             base_branch=base_branch,
             remote_branch=remote_branch,
+            compose_project=compose_project,
+            compose_file=compose_file,
             monitor_log=monitor_log,
-            extra_payload={
-                "operator_hint_operation_id": action.hint.operation_id,
-                "operator_hint_status": action.hint.status,
-            },
-            extra_identity=(action.hint.operation_id, action.hint.reason),
+            remote_push_url=remote_push_url,
         )
-        try:
-            push_result = await self._run_operator_hint_cycle(
-                workspace_id=workspace_id,
-                repo=repo,
-                pr_number=pr_number,
-                pr_head_sha=status.head_sha,
-                hint=action.hint,
-                state=state,
-                base_branch=base_branch,
-                remote_branch=remote_branch,
-                remote_push_url=remote_push_url,
-                compose_project=compose_project,
-                compose_file=compose_file,
-                _monitor_log=monitor_log,
-                _operation_id=operation.operation_id if operation is not None else None,
-                _operation_type=OperationType.comment_repair.value,
-            )
-        except _MonitorAgentServiceRecoverySupersededError as exc:
-            await _finish_agent_service_recovery_superseded_operation(
-                self,
-                operation,
-                exc=exc,
-                error_message=str(exc),
-            )
-            raise
-        except _MonitorAgentServiceRecoveryFailedError as exc:
-            await _finish_agent_service_recovery_failed_operation(
-                self,
-                operation,
-                exc=exc,
-                error_message=str(exc),
-            )
-            raise
-        except ProviderRecoveryRetryError:
-            await self._finish_monitor_operation(
-                operation,
-                status=OperationStatus.failed,
-                result={
-                    "status": "failed",
-                    "outcome": "provider_retry",
-                    "reason_code": "PROVIDER_OUTAGE",
-                    "pushed": False,
-                },
-                error_code="PROVIDER_OUTAGE",
-                error_message="Provider recovery requested retry",
-            )
-            raise
-        except ProviderRecoveryFallbackError:
-            await self._finish_monitor_operation(
-                operation,
-                status=OperationStatus.failed,
-                result={
-                    "status": "failed",
-                    "outcome": "provider_fallback",
-                    "reason_code": "PROVIDER_FALLBACK",
-                    "pushed": False,
-                },
-                error_code="PROVIDER_FALLBACK",
-                error_message="Provider recovery triggered fallback",
-            )
-            raise
-        except ProviderRecoveryAuthError:
-            await self._finish_provider_auth_failed_operation(operation)
-            raise
-        except ComposeExecCleanupError as exc:
-            await self._finish_monitor_operation(
-                operation,
-                status=OperationStatus.failed,
-                result={
-                    "status": "failed",
-                    "reason_code": EXEC_PROCESS_CLEANUP_FAILED,
-                },
-                error_code=EXEC_PROCESS_CLEANUP_FAILED,
-                error_message=cleanup_failure_message(exc),
-            )
-            await self._terminate_failed(
-                workspace_id,
-                message=cleanup_failure_message(exc),
-                reason_code=EXEC_PROCESS_CLEANUP_FAILED,
-            )
-            return True
-        if push_result.paused_into_blocked:
-            # A directive-revert / grant resume that still trips the protected
-            # gate re-paused the workspace into ``blocked`` (WS-2 §2 re-block).
-            # End the cycle cleanly without terminally failing.
-            await self._persist_state(workspace_id, state)
-            await self._finish_monitor_operation(
-                operation,
-                status=OperationStatus.succeeded,
-                result={
-                    "status": "succeeded",
-                    "outcome": "protected_scope_paused",
-                    "reason_code": push_result.reason_code,
-                    "pushed": False,
-                },
-            )
-            return True
-        if push_result.failed:
-            reason_code = push_result.reason_code
-            outcome = _git_push_failure_outcome(push_result)
-            await self._finish_monitor_operation(
-                operation,
-                status=OperationStatus.failed,
-                result={
-                    "status": "failed",
-                    "outcome": outcome,
-                    "reason_code": reason_code,
-                    "pushed": False,
-                    "failure_evidence": push_result.failure_evidence(),
-                },
-                error_code=reason_code,
-                error_message=push_result.error_message,
-            )
-            if push_result.terminal_monitor_failure:
-                await self._persist_state(workspace_id, state)
-                await self._terminate_failed(
-                    workspace_id,
-                    message=push_result.error_message or push_result.reason_code,
-                    reason_code=push_result.reason_code,
-                    details=push_result.failure_evidence(),
-                    failure_reason=push_result.failure_reason,
-                )
-                return True
-            state.iter_count += 1
-            return False
-        if push_result.pushed or (
-            not push_result.pushed
-            and (
-                state.pending_operator_hint is None
-                or state.pending_operator_hint.status in {"needs_human", "agent_failed"}
-            )
-        ):
-            # Persist terminal, processed no-op, or pushed hint status before
-            # returning to the outer loop so a restart cannot re-run the same
-            # hint as pending.
-            await self._persist_state(workspace_id, state)
-        if push_result.pushed:
-            outcome = "operator_hint_pushed"
-        elif state.pending_operator_hint is None:
-            outcome = "operator_hint_processed"
-        elif (
-            state.pending_operator_hint is not None
-            and state.pending_operator_hint.status == "agent_failed"
-        ):
-            outcome = "operator_hint_agent_failed"
-        else:
-            outcome = "operator_hint_needs_human"
-        await self._finish_monitor_operation(
-            operation,
-            status=OperationStatus.succeeded,
-            result={
-                "status": "succeeded",
-                "outcome": outcome,
-                "pushed": push_result.pushed,
-            },
-        )
-        state.iter_count += 1
-        return False
 
     merge_result = await _merge_loop.handle_merge_action(
         self,

--- a/src/awf/runtime/pr_monitor_runner/loop.py
+++ b/src/awf/runtime/pr_monitor_runner/loop.py
@@ -167,9 +167,20 @@ async def _execute(
     # ``_run_fix_cycle`` so unpublished repairs are not abandoned. The marker is
     # cleared after the fix cycle (or immediately when ``decide()`` leaves
     # ``AddressComments``).
+    #
+    # A parked unattributable-commits episode (#935) waits the same way: the
+    # monitor keeps polling ``AddressComments`` while the commits sit on disk, so
+    # the marker keeps ``awaiting_human_since`` from being nulled and re-stamped
+    # every poll (which would reset the operator-visible wait duration).
     awaiting_workflow_scope = state.awaiting_workflow_scope
     if not isinstance(action, AddressComments) and awaiting_workflow_scope:
         state.clear_awaiting_workflow_scope()
+    parked_unpublished_repair = bool(state.parked_unpublished_repair)
+    if not isinstance(action, AddressComments) and parked_unpublished_repair:
+        # ``decide()`` left the repair arm, so the park episode is over: drop the
+        # marker AND let the resume clear below retire the attention flag.
+        state.clear_parked_unpublished_repair()
+        parked_unpublished_repair = False
     # The merge-block attention marker only makes sense while ``decide()`` stays on
     # the ``Merge`` arm (the branch-protection fallback that sets it keeps
     # ``decide()`` returning ``Merge``). The moment ``decide()`` returns any other
@@ -180,7 +191,11 @@ async def _execute(
     # branch-protection block persists.
     if not isinstance(action, Merge):
         state.clear_merge_block_attention()
-    if not isinstance(action, (NotifyHuman, Merge)) and not awaiting_workflow_scope:
+    if (
+        not isinstance(action, (NotifyHuman, Merge))
+        and not awaiting_workflow_scope
+        and not parked_unpublished_repair
+    ):
         await self._clear_workspace_attention(workspace_id)
 
     if isinstance(action, ShortCircuitCompleted):
@@ -1183,7 +1198,9 @@ async def _execute(
             return True
         if push_result.parked_needs_human:
             # #935: unattributable unpushed commits were preserved for a human. End
-            # the cycle without terminally failing — the work must survive on disk.
+            # the cycle without terminally failing — the work must survive on disk —
+            # and hold the wait in this monitor's polling loop (non-terminal) so the
+            # worker does not reclaim the still-``monitoring_pr`` row every cycle.
             return await _finish_parked_comment_repair_cycle(
                 self,
                 workspace_id=workspace_id,

--- a/src/awf/runtime/pr_monitor_runner/loop.py
+++ b/src/awf/runtime/pr_monitor_runner/loop.py
@@ -1267,6 +1267,14 @@ async def _execute(
             state.iter_count += 1
             return False
         state.clear_awaiting_workflow_scope()
+        # The cycle got all the way through push without parking, so any earlier
+        # park episode is over (PRRT_kwDOSJAM6s6fu_-o) — the parked arm returns via
+        # ``_finish_parked_comment_repair_cycle`` above and never reaches here.
+        # Leaving a stale marker set would keep gating this arm's attention clear
+        # for as long as unresolved feedback holds ``decide()`` on
+        # ``AddressComments``, stranding the operator-visible ``awaiting_human_since``
+        # and park reason.
+        state.clear_parked_unpublished_repair()
         await self._finish_monitor_operation(
             operation,
             status=OperationStatus.succeeded,

--- a/src/awf/runtime/pr_monitor_runner/loop_recovery_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/loop_recovery_ops.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from awf.db.enums import OperationStatus
+from awf.runtime.pr_monitor_runner.remote_ops import _git_push_failure_outcome
 from awf.runtime.pr_monitor_runner.types import (
     _MonitorAgentServiceRecoveryFailedError,
     _MonitorAgentServiceRecoverySupersededError,
@@ -72,6 +73,50 @@ def _provider_recovery_operation_result_updates(exc: BaseException) -> dict[str,
     if isinstance(rollback_error, dict):
         updates["rollback_error"] = rollback_error
     return updates
+
+
+async def _finish_parked_comment_repair_cycle(
+    self: Any,
+    *,
+    workspace_id: str,
+    state: Any,
+    operation: Any,
+    push_result: Any,
+    thread_count: int,
+    review_comment_count: int,
+) -> bool:
+    """End an ``AddressComments`` cycle that parked preserved commits for a human (#935).
+
+    The workspace stays in ``monitoring_pr`` with the worktree untouched: nothing was
+    reset and nothing was pushed. Persist the monitor state (the item-provenance chain
+    rides ``monitor_threads_addressed``), finish the operation ``failed`` carrying the
+    preserved reason code, and raise the awaiting-human attention flag naming the
+    commits. Re-entering on a later poll re-parks idempotently — the abandon check runs
+    before any item work, so no agent is launched.
+    """
+    state.clear_awaiting_workflow_scope()
+    await self._persist_state(workspace_id, state)
+    reason_code = push_result.reason_code
+    await self._finish_monitor_operation(
+        operation,
+        status=OperationStatus.failed,
+        result={
+            "status": "failed",
+            "outcome": _git_push_failure_outcome(push_result),
+            "reason_code": reason_code,
+            "thread_count": thread_count,
+            "review_comment_count": review_comment_count,
+            "pushed": False,
+            "failure_evidence": push_result.failure_evidence(),
+        },
+        error_code=reason_code,
+        error_message=push_result.error_message,
+    )
+    await self._set_workspace_attention(
+        workspace_id,
+        reason=push_result.error_message or reason_code,
+    )
+    return True
 
 
 async def _finish_agent_service_recovery_failed_operation(

--- a/src/awf/runtime/pr_monitor_runner/loop_recovery_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/loop_recovery_ops.py
@@ -89,12 +89,22 @@ async def _finish_parked_comment_repair_cycle(
 
     The workspace stays in ``monitoring_pr`` with the worktree untouched: nothing was
     reset and nothing was pushed. Persist the monitor state (the item-provenance chain
-    rides ``monitor_threads_addressed``), finish the operation ``failed`` carrying the
-    preserved reason code, and raise the awaiting-human attention flag naming the
-    commits. Re-entering on a later poll re-parks idempotently — the abandon check runs
-    before any item work, so no agent is launched.
+    and the park marker ride ``monitor_threads_addressed``), finish the operation
+    ``failed`` carrying the preserved reason code, and raise the awaiting-human
+    attention flag naming the commits.
+
+    Returns ``False`` — NOT terminal. The wait is a human wait, so it is held exactly
+    like the ``NotifyHuman`` arm: sleep one poll interval and keep this monitor in its
+    normal polling loop. Returning terminal would exit the runner while leaving the row
+    in ``monitoring_pr``, and the worker (whose monitor claim does not exclude
+    ``awaiting_human_since``) would immediately reclaim it and start a whole new
+    monitor, over and over. Re-entering on a later poll re-parks idempotently — the
+    abandon check runs before any item work, so no agent is launched, the operation
+    replays on its idempotency key, and the park marker keeps the event and the
+    attention episode from being re-emitted.
     """
     state.clear_awaiting_workflow_scope()
+    state.iter_count += 1
     await self._persist_state(workspace_id, state)
     reason_code = push_result.reason_code
     await self._finish_monitor_operation(
@@ -116,7 +126,8 @@ async def _finish_parked_comment_repair_cycle(
         workspace_id,
         reason=push_result.error_message or reason_code,
     )
-    return True
+    await self._deps.sleep(self._config.poll_interval_seconds)
+    return False
 
 
 async def _finish_agent_service_recovery_failed_operation(

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_loop.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_loop.py
@@ -1,0 +1,237 @@
+"""AddressOperatorHint action branch for the PR monitor decision loop.
+
+Mechanically extracted from :mod:`awf.runtime.pr_monitor_runner.loop` so that
+module stays within the first-party file-line guardrail
+(``tests/unit/test_core_decomposition_maintainability.py``). Behavior is
+unchanged; this mirrors the ``notify_human_loop.handle_notify_human_action``
+delegation pattern — the caller dispatches on
+``isinstance(action, AddressOperatorHint)`` before invoking this helper.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from awf.common.compose_exec import (
+    EXEC_PROCESS_CLEANUP_FAILED,
+    ComposeExecCleanupError,
+    cleanup_failure_message,
+)
+from awf.common.github_client import RepoRef
+from awf.db.enums import OperationStatus, OperationType
+from awf.runtime.logs import WorkspaceLogSink
+from awf.runtime.pr_monitor import (
+    AddressOperatorHint,
+    MonitorState,
+    PRStatus,
+)
+from awf.runtime.pr_monitor_runner.loop_recovery_ops import (
+    _finish_agent_service_recovery_failed_operation,
+    _finish_agent_service_recovery_superseded_operation,
+)
+from awf.runtime.pr_monitor_runner.remote_ops import (
+    _git_push_failure_outcome,
+)
+from awf.runtime.pr_monitor_runner.types import (
+    ProviderRecoveryAuthError,
+    ProviderRecoveryFallbackError,
+    ProviderRecoveryRetryError,
+    _MonitorAgentServiceRecoveryFailedError,
+    _MonitorAgentServiceRecoverySupersededError,
+)
+
+
+async def handle_operator_hint_action(
+    self: Any,
+    *,
+    action: AddressOperatorHint,
+    workspace_id: str,
+    repo: RepoRef,
+    pr_number: int,
+    status: PRStatus,
+    state: MonitorState,
+    base_branch: str,
+    remote_branch: str,
+    compose_project: str,
+    compose_file: Path,
+    monitor_log: WorkspaceLogSink | None,
+    remote_push_url: str | None,
+) -> bool:
+    """Run one operator-hint repair cycle; return True iff the monitor is terminal."""
+    operation = await self._begin_monitor_operation(
+        workspace_id=workspace_id,
+        operation_type=OperationType.comment_repair,
+        action="operator_hint_repair",
+        requested_action="address_operator_hint",
+        reason="Operator remonitor hint required repair before merge.",
+        reason_code=action.hint.reason_code,
+        pr_number=pr_number,
+        status=status,
+        base_branch=base_branch,
+        remote_branch=remote_branch,
+        monitor_log=monitor_log,
+        extra_payload={
+            "operator_hint_operation_id": action.hint.operation_id,
+            "operator_hint_status": action.hint.status,
+        },
+        extra_identity=(action.hint.operation_id, action.hint.reason),
+    )
+    try:
+        push_result = await self._run_operator_hint_cycle(
+            workspace_id=workspace_id,
+            repo=repo,
+            pr_number=pr_number,
+            pr_head_sha=status.head_sha,
+            hint=action.hint,
+            state=state,
+            base_branch=base_branch,
+            remote_branch=remote_branch,
+            remote_push_url=remote_push_url,
+            compose_project=compose_project,
+            compose_file=compose_file,
+            _monitor_log=monitor_log,
+            _operation_id=operation.operation_id if operation is not None else None,
+            _operation_type=OperationType.comment_repair.value,
+        )
+    except _MonitorAgentServiceRecoverySupersededError as exc:
+        await _finish_agent_service_recovery_superseded_operation(
+            self,
+            operation,
+            exc=exc,
+            error_message=str(exc),
+        )
+        raise
+    except _MonitorAgentServiceRecoveryFailedError as exc:
+        await _finish_agent_service_recovery_failed_operation(
+            self,
+            operation,
+            exc=exc,
+            error_message=str(exc),
+        )
+        raise
+    except ProviderRecoveryRetryError:
+        await self._finish_monitor_operation(
+            operation,
+            status=OperationStatus.failed,
+            result={
+                "status": "failed",
+                "outcome": "provider_retry",
+                "reason_code": "PROVIDER_OUTAGE",
+                "pushed": False,
+            },
+            error_code="PROVIDER_OUTAGE",
+            error_message="Provider recovery requested retry",
+        )
+        raise
+    except ProviderRecoveryFallbackError:
+        await self._finish_monitor_operation(
+            operation,
+            status=OperationStatus.failed,
+            result={
+                "status": "failed",
+                "outcome": "provider_fallback",
+                "reason_code": "PROVIDER_FALLBACK",
+                "pushed": False,
+            },
+            error_code="PROVIDER_FALLBACK",
+            error_message="Provider recovery triggered fallback",
+        )
+        raise
+    except ProviderRecoveryAuthError:
+        await self._finish_provider_auth_failed_operation(operation)
+        raise
+    except ComposeExecCleanupError as exc:
+        await self._finish_monitor_operation(
+            operation,
+            status=OperationStatus.failed,
+            result={
+                "status": "failed",
+                "reason_code": EXEC_PROCESS_CLEANUP_FAILED,
+            },
+            error_code=EXEC_PROCESS_CLEANUP_FAILED,
+            error_message=cleanup_failure_message(exc),
+        )
+        await self._terminate_failed(
+            workspace_id,
+            message=cleanup_failure_message(exc),
+            reason_code=EXEC_PROCESS_CLEANUP_FAILED,
+        )
+        return True
+    if push_result.paused_into_blocked:
+        # A directive-revert / grant resume that still trips the protected
+        # gate re-paused the workspace into ``blocked`` (WS-2 §2 re-block).
+        # End the cycle cleanly without terminally failing.
+        await self._persist_state(workspace_id, state)
+        await self._finish_monitor_operation(
+            operation,
+            status=OperationStatus.succeeded,
+            result={
+                "status": "succeeded",
+                "outcome": "protected_scope_paused",
+                "reason_code": push_result.reason_code,
+                "pushed": False,
+            },
+        )
+        return True
+    if push_result.failed:
+        reason_code = push_result.reason_code
+        outcome = _git_push_failure_outcome(push_result)
+        await self._finish_monitor_operation(
+            operation,
+            status=OperationStatus.failed,
+            result={
+                "status": "failed",
+                "outcome": outcome,
+                "reason_code": reason_code,
+                "pushed": False,
+                "failure_evidence": push_result.failure_evidence(),
+            },
+            error_code=reason_code,
+            error_message=push_result.error_message,
+        )
+        if push_result.terminal_monitor_failure:
+            await self._persist_state(workspace_id, state)
+            await self._terminate_failed(
+                workspace_id,
+                message=push_result.error_message or push_result.reason_code,
+                reason_code=push_result.reason_code,
+                details=push_result.failure_evidence(),
+                failure_reason=push_result.failure_reason,
+            )
+            return True
+        state.iter_count += 1
+        return False
+    if push_result.pushed or (
+        not push_result.pushed
+        and (
+            state.pending_operator_hint is None
+            or state.pending_operator_hint.status in {"needs_human", "agent_failed"}
+        )
+    ):
+        # Persist terminal, processed no-op, or pushed hint status before
+        # returning to the outer loop so a restart cannot re-run the same
+        # hint as pending.
+        await self._persist_state(workspace_id, state)
+    if push_result.pushed:
+        outcome = "operator_hint_pushed"
+    elif state.pending_operator_hint is None:
+        outcome = "operator_hint_processed"
+    elif (
+        state.pending_operator_hint is not None
+        and state.pending_operator_hint.status == "agent_failed"
+    ):
+        outcome = "operator_hint_agent_failed"
+    else:
+        outcome = "operator_hint_needs_human"
+    await self._finish_monitor_operation(
+        operation,
+        status=OperationStatus.succeeded,
+        result={
+            "status": "succeeded",
+            "outcome": outcome,
+            "pushed": push_result.pushed,
+        },
+    )
+    state.iter_count += 1
+    return False

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -165,6 +165,12 @@ class _GitPushResult:
     decision (a protected-scope violation in an unpushed commit, WS-2). The row
     already left ``monitoring_pr``; the monitor loop ends this cycle WITHOUT
     terminally failing the workspace and the offending commit is preserved."""
+    parked_needs_human: bool = False
+    """Unpublished repair commits AWF could not attribute were parked for a human
+    (#935). The worktree is untouched, nothing was reset, and the row stays in
+    ``monitoring_pr`` with the awaiting-human attention flag set. Like
+    ``paused_into_blocked`` this ends the monitor cycle WITHOUT terminally failing
+    the workspace — the preserved commits must survive for the operator."""
 
     @property
     def error_message(self: Any) -> str | None:
@@ -197,8 +203,9 @@ class _GitPushResult:
         """Return whether the push failure should end monitor recovery."""
         # A pause into ``blocked`` is NOT a terminal failure: the workspace is
         # preserved for an operator decision, not failed. The loop ends the
-        # cycle via the dedicated paused-into-blocked handling instead.
-        if self.paused_into_blocked:
+        # cycle via the dedicated paused-into-blocked handling instead. The same
+        # carve-out applies to an unpublished-repair park (#935).
+        if self.paused_into_blocked or self.parked_needs_human:
             return False
         return self.failed and (
             self.protected_scope_blocked
@@ -225,7 +232,10 @@ class _GitPushResult:
                 AGENT_NON_FIXED_WITH_MUTATION,
                 _COMMENT_REPAIR_REMOTE_HEAD_VERIFICATION_FAILED,
                 _COMMENT_REPAIR_ROLLBACK_FAILED,
-                _COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
+                # #935: ``_COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING`` is
+                # deliberately absent — unattributable unpushed commits park the
+                # workspace for a human with the worktree intact instead of failing
+                # it and stranding accepted repair work.
                 VALIDATION_WORKTREE_CLEANUP_FAILED,
                 VALIDATION_WORKTREE_PRE_EXISTING_DIRTY,
                 VALIDATION_WORKTREE_STATUS_FAILED,
@@ -299,6 +309,8 @@ def _git_push_failure_outcome(push_result: _GitPushResult) -> str:
         _REPAIR_WORKTREE_STATUS_FAILED_REASON,
     }:
         return "repair_start_blocked"
+    if push_result.reason_code == _COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING:
+        return "comment_repair_unpublished_parked"
     return "git_push_failed"
 
 

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished.py
@@ -27,7 +27,6 @@ from awf.runtime.pr_monitor import MonitorState
 from awf.runtime.pr_monitor_runner.constants import (
     _COMMENT_REPAIR_REMOTE_HEAD_VERIFICATION_FAILED,
     _COMMENT_REPAIR_ROLLBACK_FAILED,
-    _COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
 )
 from awf.runtime.pr_monitor_runner.git_utils import (
     git_pinned_worktree_command,
@@ -41,6 +40,18 @@ from awf.runtime.pr_monitor_runner.pre_push_validation_fix_pass_ancestry import 
 from awf.runtime.pr_monitor_runner.remote_ops import (
     AGENT_RUNTIME_OWNERSHIP_REPAIR_FAILED_REASON_CODE,
     _GitPushResult,
+)
+from awf.runtime.pr_monitor_runner.remote_repair_unpublished_provenance import (
+    COMMENT_REPAIR_UNPUBLISHED_PRESERVED as COMMENT_REPAIR_UNPUBLISHED_PRESERVED,
+)
+from awf.runtime.pr_monitor_runner.remote_repair_unpublished_provenance import (
+    _is_review_item_commit_subject as _is_review_item_commit_subject,
+)
+from awf.runtime.pr_monitor_runner.remote_repair_unpublished_provenance import (
+    _item_provenance_chain_covers_range as _item_provenance_chain_covers_range,
+)
+from awf.runtime.pr_monitor_runner.remote_repair_unpublished_provenance import (
+    _resolve_unpublished_comment_repair_disposition,
 )
 from awf.runtime.pr_monitor_runner.types import ProtectedScopeDiffError
 from awf.runtime.worktree_writer_lock import hold_exclusive_worktree_writer_lock
@@ -1118,25 +1129,25 @@ async def _abandon_unpublished_comment_repairs(
             discarded_local_head=current_head,
         )
     )
-    if not has_comment_repair_provenance or has_conflicting_repair_provenance:
-        _log.info(
-            "monitor.comment_repair_unpublished_reset_skipped_missing_provenance",
-            workspace_id=workspace_id,
-            local_head=current_head,
-            fetched_remote_head=fetched_head,
-            has_comment_repair_provenance=has_comment_repair_provenance,
-            has_conflicting_repair_provenance=has_conflicting_repair_provenance,
-            current_operation_id=current_operation_id,
-        )
-        return failure(
-            _COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
-            "Local HEAD is ahead of the remote PR head without comment-repair provenance; refusing to reset or push.",
-            local_head=current_head,
-            fetched_remote_head=fetched_head,
-            has_comment_repair_provenance=has_comment_repair_provenance,
-            has_conflicting_repair_provenance=has_conflicting_repair_provenance,
-            current_operation_id=current_operation_id,
-        )
+    # #935: preserved repair work is never reset and never terminally fails the
+    # workspace. The ordered disposition resumes provably-AWF commits, keeps the
+    # operation-owned reset unchanged, and parks anything else for a human.
+    disposition = await _resolve_unpublished_comment_repair_disposition(
+        self,
+        workspace_id=workspace_id,
+        worktree_path=worktree_path,
+        state=state,
+        current_head=current_head,
+        fetched_head=fetched_head,
+        provenance_remote_head=provenance_remote_head,
+        diff_range=diff_range,
+        use_stale_snapshot_diff=use_stale_snapshot_diff,
+        has_comment_repair_provenance=has_comment_repair_provenance,
+        has_conflicting_repair_provenance=has_conflicting_repair_provenance,
+        current_operation_id=current_operation_id,
+    )
+    if disposition is not None:
+        return disposition
 
     recovery_reset = await _run_recovery_hard_reset_under_writer_lock(
         self._deps.runner,

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished.py
@@ -780,6 +780,16 @@ async def _abandon_unpublished_comment_repairs(
             git_env=_git_env_for_merge_safety_object_lookup(),
         )
         if equality.reconciled:
+            # Live HEAD equals the accepted remote tip, so no unpublished commits
+            # remain: any earlier park episode is over (PRRT_kwDOSJAM6s6fu_-o). An
+            # operator following the documented recovery — resetting the parked
+            # range or pushing it — lands exactly here, and this path returns
+            # before ``_resolve_unpublished_comment_repair_disposition`` ever runs,
+            # so neither ``_park`` nor ``_preserve`` can retire the marker. Leaving
+            # it set keeps the ``AddressComments`` arm's attention clear gated
+            # while unresolved feedback holds ``decide()`` on that arm, stranding
+            # the operator-visible ``awaiting_human_since`` and park reason.
+            state.clear_parked_unpublished_repair()
             restored_head = equality.live_head or current_head
             if not await _flush_pending_unpublished_abandon_event(
                 self,

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
@@ -1,0 +1,306 @@
+"""Disposition for unpublished comment-repair commits found after a restart (#935).
+
+``_abandon_unpublished_comment_repairs`` reaches this module only once local HEAD is
+a proven descendant of the PR head. The question left is what to do with the commits
+in ``remote..HEAD``:
+
+* AWF's own, still-resumable repair work → **preserve** it and let the batch push it
+  on the next settle;
+* an operation-owned interrupted repair → **reset** it, exactly as before;
+* anything else → **park** the workspace for a human with the worktree untouched.
+
+Parking is deliberately NOT a terminal workspace failure (#935, #932: never delete
+agent work): the commits stay on disk, the reason names them, and the operator
+decides. The refusal to reset unknown commits is unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from awf.db.repositories import WorkspaceEventCreate
+from awf.runtime.pr_monitor import MonitorState
+from awf.runtime.pr_monitor_runner.comment_repair_provenance import chain_from_state
+from awf.runtime.pr_monitor_runner.constants import (
+    _COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
+)
+from awf.runtime.pr_monitor_runner.git_utils import git_worktree_command
+from awf.runtime.pr_monitor_runner.logging import _log
+from awf.runtime.pr_monitor_runner.pre_push_validation_fix_pass_ancestry import (
+    _git_env_for_merge_safety_object_lookup,
+)
+from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
+
+COMMENT_REPAIR_UNPUBLISHED_PRESERVED = "COMMENT_REPAIR_UNPUBLISHED_PRESERVED"
+_PRESERVED_EVENT = "monitor.comment_repair_unpublished_preserved"
+_PARKED_EVENT = "monitor.comment_repair_unpublished_parked"
+
+_COMMIT_LOG_TIMEOUT_SECONDS = 30.0
+# Keep the operator-facing reason bounded; the audit event carries the full list.
+_MAX_REASON_COMMITS = 10
+
+# Review-item identifiers AWF puts in its own fix-commit subjects: GraphQL node ids
+# (``PRRT_…``/``PRRC_…``/``IC_…``), the ``issue:<databaseId>`` shape used for review
+# comments, and bare databaseIds. Three digits minimum so a stray ``#12`` cannot match.
+_REVIEW_ITEM_ID = r"(?:[A-Z]{2,4}_[A-Za-z0-9_-]{6,}|issue:\d+|\d{3,})"
+# The four subjects AWF emits for review items: ``comments.py`` uses
+# ``fix: address PR review thread|comment <id>``; ``monitor_prompts.py`` asks the
+# agent for ``fix: address <id> — …`` / ``fix: address review comment <id> — …``.
+_REVIEW_ITEM_COMMIT_SUBJECT_RE = re.compile(
+    r"^fix: address (?:(?:PR )?review (?:thread|comment) )?(?:" + _REVIEW_ITEM_ID + r")(?:\b|$)"
+)
+
+
+def _item_provenance_chain_covers_range(
+    state: MonitorState,
+    *,
+    base_head: str,
+    head_sha: str,
+) -> bool:
+    """Whether the commit-time chain covers ``base_head..head_sha`` exactly.
+
+    Fails closed: a malformed marker, a broken link, a different base or a tip that
+    is not the current HEAD all mean the chain does not describe these commits.
+    """
+    chain = chain_from_state(state)
+    if not chain:
+        return False
+    base = base_head.strip().lower()
+    tip = head_sha.strip().lower()
+    if not base or not tip:
+        return False
+    if chain[0].item_start_head.lower() != base:
+        return False
+    for previous, record in zip(chain, chain[1:], strict=False):
+        if record.item_start_head.lower() != previous.head_sha.lower():
+            return False
+    return chain[-1].head_sha.lower() == tip
+
+
+def _is_review_item_commit_subject(subject: str) -> bool:
+    """Whether a commit subject names an AWF review item (legacy-state fallback)."""
+    return _REVIEW_ITEM_COMMIT_SUBJECT_RE.match(subject.strip()) is not None
+
+
+def _parse_commit_log_entries(stdout: str) -> tuple[tuple[str, str], ...]:
+    """Parse ``git log --format=%h %s`` output into ``(short_sha, subject)`` pairs."""
+    entries: list[tuple[str, str]] = []
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        short_sha, _, subject = stripped.partition(" ")
+        entries.append((short_sha, subject.strip()))
+    return tuple(entries)
+
+
+async def _unpublished_commit_log_entries(
+    runner: Any,
+    *,
+    worktree_path: Path,
+    diff_range: str,
+) -> tuple[tuple[str, str], ...] | None:
+    """Read the unpushed commits' short SHAs and subjects, or ``None`` on failure."""
+    result = await runner._deps.runner.run(
+        git_worktree_command(worktree_path, "log", "--format=%h %s", diff_range),
+        env=_git_env_for_merge_safety_object_lookup(),
+        timeout_seconds=_COMMIT_LOG_TIMEOUT_SECONDS,
+    )
+    if not result.ok:
+        return None
+    return _parse_commit_log_entries(result.stdout)
+
+
+def _unpublished_repair_park_reason(entries: tuple[tuple[str, str], ...]) -> str:
+    """Operator-facing reason naming the preserved commits."""
+    if not entries:
+        return (
+            "Local HEAD is ahead of the remote PR head with unpushed commits AWF could "
+            "not attribute to this comment-repair batch; the worktree is preserved "
+            "untouched for a human."
+        )
+    listed = "; ".join(f"{sha} {subject}".strip() for sha, subject in entries[:_MAX_REASON_COMMITS])
+    hidden = len(entries) - _MAX_REASON_COMMITS
+    suffix = f" (+{hidden} more)" if hidden > 0 else ""
+    return (
+        f"Preserved {len(entries)} unpushed local commit(s) AWF could not attribute to "
+        f"this comment-repair batch: {listed}{suffix}. The worktree is untouched; "
+        "a human must decide whether to keep or drop them."
+    )
+
+
+async def _append_disposition_event(
+    runner: Any,
+    *,
+    workspace_id: str,
+    event_type: str,
+    reason_code: str,
+    payload: dict[str, object],
+) -> None:
+    """Append the operator-facing disposition event through the runner's event sink."""
+    append_events = getattr(runner, "_append_workspace_events", None)
+    if not callable(append_events):
+        return
+    await append_events(
+        workspace_id=workspace_id,
+        events=[
+            WorkspaceEventCreate(
+                event_type=event_type,
+                reason_code=reason_code,
+                payload=payload,
+            )
+        ],
+    )
+
+
+def _park_push_result(
+    *,
+    reason: str,
+    local_head: str,
+    fetched_head: str,
+    entries: tuple[tuple[str, str], ...],
+    disposition: str,
+) -> _GitPushResult:
+    return _GitPushResult(
+        pushed=False,
+        failed=True,
+        returncode=1,
+        stderr=reason,
+        reason_code=_COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
+        parked_needs_human=True,
+        details={
+            "phase": "comment_repair_recovery",
+            "pushed": False,
+            "local_head": local_head,
+            "fetched_remote_head": fetched_head,
+            "disposition": disposition,
+            "preserved_commits": [f"{sha} {subject}".strip() for sha, subject in entries],
+        },
+    )
+
+
+async def _resolve_unpublished_comment_repair_disposition(
+    runner: Any,
+    *,
+    workspace_id: str,
+    worktree_path: Path,
+    state: MonitorState,
+    current_head: str,
+    fetched_head: str,
+    provenance_remote_head: str,
+    diff_range: str,
+    use_stale_snapshot_diff: bool,
+    has_comment_repair_provenance: bool,
+    has_conflicting_repair_provenance: bool,
+    current_operation_id: str | None,
+) -> tuple[str, _GitPushResult | None] | None:
+    """Decide what to do with ``remote..HEAD``; ``None`` means "reset as before".
+
+    Ordered so today's abandon behaviour is untouched for operation-owned repairs:
+
+    1. another repair path (CI repair / sync base / operator hint) owns the commits
+       → park (never reset someone else's work);
+    2. the commit-time item chain covers the range exactly → preserve and resume;
+    3. an operation record owns the range → reset (unchanged);
+    4. legacy state whose commit subjects name review items → preserve and resume;
+    5. otherwise → park.
+
+    Preserving is only offered when the fetched head still equals the batch base. On
+    a stale-snapshot advance the remote moved past that base, so the preserved
+    commits could not fast-forward and resuming would only fail the push.
+    """
+    preserve_allowed = not use_stale_snapshot_diff
+    commit_log: tuple[tuple[str, str], ...] | None = None
+    commit_log_read = False
+
+    async def _commit_log_entries() -> tuple[tuple[str, str], ...] | None:
+        # One ``git log`` per disposition at most: the legacy-subject scan and the
+        # park reason both need the same range.
+        nonlocal commit_log, commit_log_read
+        if not commit_log_read:
+            commit_log = await _unpublished_commit_log_entries(
+                runner,
+                worktree_path=worktree_path,
+                diff_range=diff_range,
+            )
+            commit_log_read = True
+        return commit_log
+
+    async def _park(disposition: str) -> tuple[str, _GitPushResult]:
+        entries = await _commit_log_entries()
+        listed = entries or ()
+        reason = _unpublished_repair_park_reason(listed)
+        _log.warning(
+            "monitor.comment_repair_unpublished_parked",
+            workspace_id=workspace_id,
+            local_head=current_head,
+            fetched_remote_head=fetched_head,
+            disposition=disposition,
+            commit_log_unavailable=entries is None,
+            current_operation_id=current_operation_id,
+            reason_code=_COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
+        )
+        await _append_disposition_event(
+            runner,
+            workspace_id=workspace_id,
+            event_type=_PARKED_EVENT,
+            reason_code=_COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
+            payload={
+                "local_head": current_head,
+                "fetched_remote_head": fetched_head,
+                "disposition": disposition,
+                "commit_log_unavailable": entries is None,
+                "preserved_commits": [f"{sha} {subject}".strip() for sha, subject in listed],
+                "pushed": False,
+            },
+        )
+        return current_head, _park_push_result(
+            reason=reason,
+            local_head=current_head,
+            fetched_head=fetched_head,
+            entries=listed,
+            disposition=disposition,
+        )
+
+    async def _preserve(disposition: str) -> tuple[str, None]:
+        _log.info(
+            "monitor.comment_repair_unpublished_preserved",
+            workspace_id=workspace_id,
+            local_head=current_head,
+            fetched_remote_head=fetched_head,
+            disposition=disposition,
+            current_operation_id=current_operation_id,
+            reason_code=COMMENT_REPAIR_UNPUBLISHED_PRESERVED,
+        )
+        await _append_disposition_event(
+            runner,
+            workspace_id=workspace_id,
+            event_type=_PRESERVED_EVENT,
+            reason_code=COMMENT_REPAIR_UNPUBLISHED_PRESERVED,
+            payload={
+                "local_head": current_head,
+                "fetched_remote_head": fetched_head,
+                "disposition": disposition,
+                "pushed": False,
+            },
+        )
+        return current_head, None
+
+    if has_conflicting_repair_provenance:
+        return await _park("conflicting_repair_provenance")
+    if preserve_allowed and _item_provenance_chain_covers_range(
+        state,
+        base_head=provenance_remote_head,
+        head_sha=current_head,
+    ):
+        return await _preserve("item_commit_provenance_chain")
+    if has_comment_repair_provenance:
+        return None
+    if not preserve_allowed:
+        return await _park("stale_snapshot_advance")
+    entries = await _commit_log_entries()
+    if entries and any(_is_review_item_commit_subject(subject) for _sha, subject in entries):
+        return await _preserve("legacy_review_item_commit_subjects")
+    return await _park("no_comment_repair_provenance")

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
@@ -41,10 +41,17 @@ _COMMIT_LOG_TIMEOUT_SECONDS = 30.0
 # Keep the operator-facing reason bounded; the audit event carries the full list.
 _MAX_REASON_COMMITS = 10
 
-# Review-item identifiers AWF puts in its own fix-commit subjects: GraphQL node ids
-# (``PRRT_…``/``PRRC_…``/``IC_…``), the ``issue:<databaseId>`` shape used for review
-# comments, and bare databaseIds. Three digits minimum so a stray ``#12`` cannot match.
-_REVIEW_ITEM_ID = r"(?:[A-Z]{2,4}_[A-Za-z0-9_-]{6,}|issue:\d+|\d{3,})"
+# Review-item identifiers AWF puts in its own fix-commit subjects. GitHub: GraphQL
+# node ids (``PRRT_…``/``PRRC_…``/``IC_…``), the ``issue:<databaseId>`` shape used for
+# review comments, and bare databaseIds (three digits minimum so a stray ``#12`` cannot
+# match). Bitbucket (``bitbucket_client_parsing.py``): ``bb:<owner>/<repo>#<pr>:<id>``,
+# ``bbtask:…``, ``bbcomment:<id>`` and ``bbreview:<key>`` — the ``bb…:`` prefix is the
+# discriminator, so the trailing token is left unconstrained (a ``bbreview`` key can be
+# a display name). Without these a legitimate Bitbucket repair commit would fail the
+# legacy subject check and park the workspace instead of resuming the fix push.
+_REVIEW_ITEM_ID = (
+    r"(?:[A-Z]{2,4}_[A-Za-z0-9_-]{6,}|issue:\d+|bb(?:task|comment|review)?:\S+|\d{3,})"
+)
 # The four subjects AWF emits for review items: ``comments.py`` uses
 # ``fix: address PR review thread|comment <id>``; ``monitor_prompts.py`` asks the
 # agent for ``fix: address <id> — …`` / ``fix: address review comment <id> — …``.

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
@@ -120,6 +120,11 @@ async def _unpublished_commit_log_entries(
     return _parse_commit_log_entries(result.stdout)
 
 
+def _park_signature(*, disposition: str, local_head: str, fetched_head: str) -> str:
+    """Identify one parked situation: same disposition over the same commit range."""
+    return f"{disposition}:{local_head.strip().lower()}:{fetched_head.strip().lower()}"
+
+
 def _unpublished_repair_park_reason(entries: tuple[tuple[str, str], ...]) -> str:
     """Operator-facing reason naming the preserved commits."""
     if not entries:
@@ -239,30 +244,42 @@ async def _resolve_unpublished_comment_repair_disposition(
         entries = await _commit_log_entries()
         listed = entries or ()
         reason = _unpublished_repair_park_reason(listed)
-        _log.warning(
-            "monitor.comment_repair_unpublished_parked",
-            workspace_id=workspace_id,
-            local_head=current_head,
-            fetched_remote_head=fetched_head,
+        # The monitor stays in its polling wait while parked, so this path is
+        # re-entered every poll until a human acts. Log and audit the episode
+        # ONCE: the marker carries the situation's signature, and an unchanged
+        # signature means the same commits are still sitting there.
+        signature = _park_signature(
             disposition=disposition,
-            commit_log_unavailable=entries is None,
-            current_operation_id=current_operation_id,
-            reason_code=_COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
+            local_head=current_head,
+            fetched_head=fetched_head,
         )
-        await _append_disposition_event(
-            runner,
-            workspace_id=workspace_id,
-            event_type=_PARKED_EVENT,
-            reason_code=_COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
-            payload={
-                "local_head": current_head,
-                "fetched_remote_head": fetched_head,
-                "disposition": disposition,
-                "commit_log_unavailable": entries is None,
-                "preserved_commits": [f"{sha} {subject}".strip() for sha, subject in listed],
-                "pushed": False,
-            },
-        )
+        already_parked = state.parked_unpublished_repair == signature
+        state.mark_parked_unpublished_repair(signature)
+        if not already_parked:
+            _log.warning(
+                "monitor.comment_repair_unpublished_parked",
+                workspace_id=workspace_id,
+                local_head=current_head,
+                fetched_remote_head=fetched_head,
+                disposition=disposition,
+                commit_log_unavailable=entries is None,
+                current_operation_id=current_operation_id,
+                reason_code=_COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
+            )
+            await _append_disposition_event(
+                runner,
+                workspace_id=workspace_id,
+                event_type=_PARKED_EVENT,
+                reason_code=_COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
+                payload={
+                    "local_head": current_head,
+                    "fetched_remote_head": fetched_head,
+                    "disposition": disposition,
+                    "commit_log_unavailable": entries is None,
+                    "preserved_commits": [f"{sha} {subject}".strip() for sha, subject in listed],
+                    "pushed": False,
+                },
+            )
         return current_head, _park_push_result(
             reason=reason,
             local_head=current_head,
@@ -272,6 +289,8 @@ async def _resolve_unpublished_comment_repair_disposition(
         )
 
     async def _preserve(disposition: str) -> tuple[str, None]:
+        # The commits are resumable after all — any earlier park episode is over.
+        state.clear_parked_unpublished_repair()
         _log.info(
             "monitor.comment_repair_unpublished_preserved",
             workspace_id=workspace_id,
@@ -304,6 +323,8 @@ async def _resolve_unpublished_comment_repair_disposition(
     ):
         return await _preserve("item_commit_provenance_chain")
     if has_comment_repair_provenance:
+        # The verified reset path takes the commits back; no park episode survives it.
+        state.clear_parked_unpublished_repair()
         return None
     if not preserve_allowed:
         return await _park("stale_snapshot_advance")

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from sqlalchemy.exc import SQLAlchemyError
 
+from awf.common.audit import redact_audit_text
 from awf.db.repositories import WorkspaceEventCreate
 from awf.runtime.pr_monitor import MonitorState
 from awf.runtime.pr_monitor_runner.comment_repair_provenance import chain_from_state
@@ -151,6 +152,20 @@ def _park_signature(*, disposition: str, local_head: str, fetched_head: str) -> 
     return f"{disposition}:{local_head.strip().lower()}:{fetched_head.strip().lower()}"
 
 
+def _redacted_commit_entries(entries: tuple[tuple[str, str], ...]) -> list[str]:
+    """Render ``<short sha> <subject>`` lines that are safe to persist.
+
+    Commit subjects are worktree-local, agent-authored text. Both representations
+    built from them leave the worktree for good — the park reason becomes the
+    workspace's ``awaiting_human_reason`` and the operation error message, and the
+    disposition event's ``preserved_commits`` payload reaches every event consumer —
+    so a secret that leaked into a subject must not ride along. Attribution still
+    matches on the raw subject (``_is_review_item_commit_subject``); only what is
+    persisted is redacted.
+    """
+    return [redact_audit_text(f"{sha} {subject}".strip()) for sha, subject in entries]
+
+
 def _unpublished_repair_park_reason(entries: tuple[tuple[str, str], ...]) -> str:
     """Operator-facing reason naming the preserved commits."""
     if not entries:
@@ -159,7 +174,7 @@ def _unpublished_repair_park_reason(entries: tuple[tuple[str, str], ...]) -> str
             "not attribute to this comment-repair batch; the worktree is preserved "
             "untouched for a human."
         )
-    listed = "; ".join(f"{sha} {subject}".strip() for sha, subject in entries[:_MAX_REASON_COMMITS])
+    listed = "; ".join(_redacted_commit_entries(entries[:_MAX_REASON_COMMITS]))
     hidden = len(entries) - _MAX_REASON_COMMITS
     suffix = f" (+{hidden} more)" if hidden > 0 else ""
     return (
@@ -238,7 +253,7 @@ def _park_push_result(
             "local_head": local_head,
             "fetched_remote_head": fetched_head,
             "disposition": disposition,
-            "preserved_commits": [f"{sha} {subject}".strip() for sha, subject in entries],
+            "preserved_commits": _redacted_commit_entries(entries),
         },
     )
 
@@ -325,7 +340,7 @@ async def _resolve_unpublished_comment_repair_disposition(
                     "fetched_remote_head": fetched_head,
                     "disposition": disposition,
                     "commit_log_unavailable": entries is None,
-                    "preserved_commits": [f"{sha} {subject}".strip() for sha, subject in listed],
+                    "preserved_commits": _redacted_commit_entries(listed),
                     "pushed": False,
                 },
             )

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
@@ -61,11 +61,25 @@ _REVIEW_ITEM_ID = r"(?:[A-Z]{2,4}_[A-Za-z0-9_-]{6,}|issue:\d+|bb(?:task|comment|
 # id, never a bare number; accepting digits there would match ordinary subjects such as
 # ``fix: address 404 errors`` and preserve — then push — commits AWF cannot attribute.
 _BARE_REVIEW_ITEM_ID = r"\d{3,}"
+# A task-tagged workspace legitimately carries the workspace task tag ahead of those
+# subjects: ``commit_message_with_task_tag`` prepends it to every AWF-authored commit
+# (``_commit_dirty_worktree``) and ``_commit_footer`` instructs the agent to prefix its
+# own commits identically — bare for Jira issue keys (``PROJ-123 fix: address …``),
+# bracketed for Aira entity keys (``[PROJ-T123] fix: address …``). Anchoring at
+# ``^fix`` would reject both and park accepted repair commits, so allow one leading
+# validated tag. The shape mirrors ``common/task_tag`` (``TASK_TAG_PATTERN`` /
+# ``ENTITY_KEY_PATTERN``) with the brackets optional so a tag written in the other
+# emitted form still matches; attribution still rests on the review-item id that
+# follows, so this cannot widen which subjects qualify.
+_TASK_TAG = r"[A-Z][A-Z0-9]+-T?\d+"
+_TASK_TAG_PREFIX = rf"(?:(?:\[{_TASK_TAG}\]|{_TASK_TAG}) +)?"
 # The four subjects AWF emits for review items: ``comments.py`` uses
 # ``fix: address PR review thread|comment <id>``; ``monitor_prompts.py`` asks the
 # agent for ``fix: address <id> — …`` / ``fix: address review comment <id> — …``.
 _REVIEW_ITEM_COMMIT_SUBJECT_RE = re.compile(
-    r"^fix: address (?:(?:PR )?review (?:thread|comment) (?:"
+    r"^"
+    + _TASK_TAG_PREFIX
+    + r"fix: address (?:(?:PR )?review (?:thread|comment) (?:"
     + _REVIEW_ITEM_ID
     + r"|"
     + _BARE_REVIEW_ITEM_ID

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
@@ -43,22 +43,34 @@ _COMMIT_LOG_TIMEOUT_SECONDS = 30.0
 # Keep the operator-facing reason bounded; the audit event carries the full list.
 _MAX_REASON_COMMITS = 10
 
-# Review-item identifiers AWF puts in its own fix-commit subjects. GitHub: GraphQL
-# node ids (``PRRT_…``/``PRRC_…``/``IC_…``), the ``issue:<databaseId>`` shape used for
-# review comments, and bare databaseIds (three digits minimum so a stray ``#12`` cannot
-# match). Bitbucket (``bitbucket_client_parsing.py``): ``bb:<owner>/<repo>#<pr>:<id>``,
-# ``bbtask:…``, ``bbcomment:<id>`` and ``bbreview:<key>`` — the ``bb…:`` prefix is the
-# discriminator, so the trailing token is left unconstrained (a ``bbreview`` key can be
-# a display name). Without these a legitimate Bitbucket repair commit would fail the
-# legacy subject check and park the workspace instead of resuming the fix push.
-_REVIEW_ITEM_ID = (
-    r"(?:[A-Z]{2,4}_[A-Za-z0-9_-]{6,}|issue:\d+|bb(?:task|comment|review)?:\S+|\d{3,})"
-)
+# Self-discriminating review-item identifiers AWF puts in its own fix-commit subjects.
+# GitHub: GraphQL node ids (``PRRT_…``/``PRRC_…``/``IC_…``) and the ``issue:<databaseId>``
+# shape used for review comments. Bitbucket (``bitbucket_client_parsing.py``):
+# ``bb:<owner>/<repo>#<pr>:<id>``, ``bbtask:…``, ``bbcomment:<id>`` and ``bbreview:<key>``
+# — the ``bb…:`` prefix is the discriminator, so the trailing token is left unconstrained
+# (a ``bbreview`` key can be a display name). Without these a legitimate Bitbucket repair
+# commit would fail the legacy subject check and park the workspace instead of resuming
+# the fix push.
+_REVIEW_ITEM_ID = r"(?:[A-Z]{2,4}_[A-Za-z0-9_-]{6,}|issue:\d+|bb(?:task|comment|review)?:\S+)"
+# A bare databaseId carries no discriminator of its own (three digits minimum so a stray
+# ``#12`` cannot match), so it only counts behind the ``review thread|comment`` words —
+# the only shapes AWF emits it in (``comments.py``: ``fix: address PR review comment
+# <databaseId>``; ``monitor_prompts.py``: ``fix: address review comment <id> — …``). The
+# unprefixed slot always holds a ``thread_id``, which is a node id / ``issue:`` / ``bb…:``
+# id, never a bare number; accepting digits there would match ordinary subjects such as
+# ``fix: address 404 errors`` and preserve — then push — commits AWF cannot attribute.
+_BARE_REVIEW_ITEM_ID = r"\d{3,}"
 # The four subjects AWF emits for review items: ``comments.py`` uses
 # ``fix: address PR review thread|comment <id>``; ``monitor_prompts.py`` asks the
 # agent for ``fix: address <id> — …`` / ``fix: address review comment <id> — …``.
 _REVIEW_ITEM_COMMIT_SUBJECT_RE = re.compile(
-    r"^fix: address (?:(?:PR )?review (?:thread|comment) )?(?:" + _REVIEW_ITEM_ID + r")(?:\b|$)"
+    r"^fix: address (?:(?:PR )?review (?:thread|comment) (?:"
+    + _REVIEW_ITEM_ID
+    + r"|"
+    + _BARE_REVIEW_ITEM_ID
+    + r")|"
+    + _REVIEW_ITEM_ID
+    + r")(?:\b|$)"
 )
 
 

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
@@ -82,8 +82,15 @@ def _item_provenance_chain_covers_range(
 ) -> bool:
     """Whether the commit-time chain covers ``base_head..head_sha`` exactly.
 
-    Fails closed: a malformed marker, a broken link, a different base or a tip that
-    is not the current HEAD all mean the chain does not describe these commits.
+    The covering records are the chain SUFFIX that starts at ``base_head``: a chain
+    that outlived an earlier successful push is rooted at the head that push
+    published, which is now behind the PR (#937). Its earlier records describe
+    commits the remote already carries, so only the records from ``base_head``
+    onwards can — and must — describe ``base_head..head_sha``.
+
+    Fails closed: a malformed marker, a broken link inside that suffix, a base no
+    record starts at, or a tip that is not the current HEAD all mean the chain does
+    not describe these commits.
     """
     chain = chain_from_state(state)
     if not chain:
@@ -92,12 +99,17 @@ def _item_provenance_chain_covers_range(
     tip = head_sha.strip().lower()
     if not base or not tip:
         return False
-    if chain[0].item_start_head.lower() != base:
+    suffix_start = next(
+        (index for index, record in enumerate(chain) if record.item_start_head.lower() == base),
+        None,
+    )
+    if suffix_start is None:
         return False
-    for previous, record in zip(chain, chain[1:], strict=False):
+    suffix = chain[suffix_start:]
+    for previous, record in zip(suffix, suffix[1:], strict=False):
         if record.item_start_head.lower() != previous.head_sha.lower():
             return False
-    return chain[-1].head_sha.lower() == tip
+    return suffix[-1].head_sha.lower() == tip
 
 
 def _is_review_item_commit_subject(subject: str) -> bool:

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
@@ -20,6 +20,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from awf.db.repositories import WorkspaceEventCreate
 from awf.runtime.pr_monitor import MonitorState
 from awf.runtime.pr_monitor_runner.comment_repair_provenance import chain_from_state
@@ -151,20 +153,37 @@ async def _append_disposition_event(
     reason_code: str,
     payload: dict[str, object],
 ) -> None:
-    """Append the operator-facing disposition event through the runner's event sink."""
+    """Append the operator-facing disposition event through the runner's event sink.
+
+    Best-effort by design (#935): this audit write must never turn a disposition
+    into an unexpected exception. A DB/OS blip here would otherwise swallow the
+    parked ``needs_human`` result — leaving unattributable commits looking like a
+    monitor crash instead of preserved work — or the preserve resume. Warn and let
+    the caller return its decision; the commits themselves are already on disk.
+    Programming errors propagate.
+    """
     append_events = getattr(runner, "_append_workspace_events", None)
     if not callable(append_events):
         return
-    await append_events(
-        workspace_id=workspace_id,
-        events=[
-            WorkspaceEventCreate(
-                event_type=event_type,
-                reason_code=reason_code,
-                payload=payload,
-            )
-        ],
-    )
+    try:
+        await append_events(
+            workspace_id=workspace_id,
+            events=[
+                WorkspaceEventCreate(
+                    event_type=event_type,
+                    reason_code=reason_code,
+                    payload=payload,
+                )
+            ],
+        )
+    except (SQLAlchemyError, OSError) as exc:
+        _log.warning(
+            "monitor.comment_repair_unpublished_disposition_event_failed",
+            workspace_id=workspace_id,
+            event_type=event_type,
+            error=repr(exc)[:400],
+            reason_code=reason_code,
+        )
 
 
 def _park_push_result(

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_unpublished_provenance.py
@@ -176,8 +176,8 @@ async def _append_disposition_event(
     event_type: str,
     reason_code: str,
     payload: dict[str, object],
-) -> None:
-    """Append the operator-facing disposition event through the runner's event sink.
+) -> bool:
+    """Append the operator-facing disposition event; ``True`` once it is durable.
 
     Best-effort by design (#935): this audit write must never turn a disposition
     into an unexpected exception. A DB/OS blip here would otherwise swallow the
@@ -185,10 +185,15 @@ async def _append_disposition_event(
     monitor crash instead of preserved work — or the preserve resume. Warn and let
     the caller return its decision; the commits themselves are already on disk.
     Programming errors propagate.
+
+    Returning the outcome is what keeps "best-effort" from meaning "silently
+    dropped": a caller that dedupes on a marker must only set that marker once
+    this returns ``True``. A runner with no event sink returns ``True`` — there is
+    no audit write to lose.
     """
     append_events = getattr(runner, "_append_workspace_events", None)
     if not callable(append_events):
-        return
+        return True
     try:
         await append_events(
             workspace_id=workspace_id,
@@ -208,6 +213,8 @@ async def _append_disposition_event(
             error=repr(exc)[:400],
             reason_code=reason_code,
         )
+        return False
+    return True
 
 
 def _park_push_result(
@@ -297,7 +304,6 @@ async def _resolve_unpublished_comment_repair_disposition(
             fetched_head=fetched_head,
         )
         already_parked = state.parked_unpublished_repair == signature
-        state.mark_parked_unpublished_repair(signature)
         if not already_parked:
             _log.warning(
                 "monitor.comment_repair_unpublished_parked",
@@ -309,7 +315,7 @@ async def _resolve_unpublished_comment_repair_disposition(
                 current_operation_id=current_operation_id,
                 reason_code=_COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING,
             )
-            await _append_disposition_event(
+            audited = await _append_disposition_event(
                 runner,
                 workspace_id=workspace_id,
                 event_type=_PARKED_EVENT,
@@ -323,6 +329,17 @@ async def _resolve_unpublished_comment_repair_disposition(
                     "pushed": False,
                 },
             )
+            # Mark the episode ONLY once its event is durable. The marker rides
+            # ``monitor_threads_addressed`` and is persisted by
+            # ``_finish_parked_comment_repair_cycle`` regardless, so setting it
+            # after a transient sink failure would make every later poll
+            # short-circuit on ``already_parked`` and lose the operator-facing
+            # park event for good (PRRT_kwDOSJAM6s6fu_-m). Leaving it unset costs
+            # one repeated warning and re-emits the event on the next poll, which
+            # is the recoverable side of the trade. Parking itself is unaffected:
+            # the decision below is returned either way.
+            if audited:
+                state.mark_parked_unpublished_repair(signature)
         return current_head, _park_push_result(
             reason=reason,
             local_head=current_head,

--- a/src/awf/service/doctor/reasons.py
+++ b/src/awf/service/doctor/reasons.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from awf.runtime.ownership import AGENT_RUNTIME_OWNERSHIP_REPAIR_FAILED_REASON_CODE
 from awf.service.doctor.models import DiagnosticStatus
+from awf.service.doctor.reasons_comment_repair import get_comment_repair_reasons
 from awf.service.doctor.reasons_helpers import (
     get_claude_overlay_reasons,
     get_salvage_and_monitor_reasons,
@@ -92,58 +93,6 @@ _REASON_TEXT: dict[str, _ReasonText] = {
         ),
         "awf workspace logs <workspace_id>",
         _reason_catalog_link("AGENT_VERDICT_PROTOCOL_VIOLATION"),
-    ),
-    "COMMENT_REPAIR_REMOTE_HEAD_VERIFICATION_FAILED": _ReasonText(
-        "AWF could not verify the remote PR head before abandoning unpublished comment repairs.",
-        (
-            "Restore forge connectivity and credentials, verify the PR head, then remonitor the "
-            "workspace."
-        ),
-        (
-            "A comment-repair cycle stopped before publication, and the forge head could not be "
-            "read or did not match the expected repository identity."
-        ),
-        "awf workspace logs <workspace_id>",
-        _reason_catalog_link("COMMENT_REPAIR_REMOTE_HEAD_VERIFICATION_FAILED"),
-    ),
-    "COMMENT_REPAIR_ROLLBACK_FAILED": _ReasonText(
-        "AWF could not reset unpublished comment repairs to the verified remote PR head.",
-        (
-            "Preserve the workspace for diagnosis, inspect Git and ownership errors in worker logs, "
-            "then repair the worktree before remonitoring."
-        ),
-        (
-            "AWF verified the remote head but the local hard reset or post-reset verification failed."
-        ),
-        "awf service logs --service worker",
-        _reason_catalog_link("COMMENT_REPAIR_ROLLBACK_FAILED"),
-    ),
-    "COMMENT_REPAIR_UNPUBLISHED_ABANDONED": _ReasonText(
-        "AWF discarded an interrupted set of unpublished PR-comment repair commits.",
-        (
-            "No action is normally required. If monitoring does not resume, inspect workspace logs "
-            "and remonitor the workspace."
-        ),
-        (
-            "The repair cycle ended before push, so AWF reset the local worktree to the verified "
-            "remote PR head to prevent stale unpublished commits from contaminating a later cycle."
-        ),
-        "awf workspace show <workspace_id>",
-        _reason_catalog_link("COMMENT_REPAIR_UNPUBLISHED_ABANDONED"),
-    ),
-    "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING": _ReasonText(
-        "AWF blocked comment repair because unpushed local commits lack comment-repair provenance.",
-        (
-            "Inspect the worktree for unrelated local commits, preserve or reset them manually if "
-            "needed, then remonitor the workspace."
-        ),
-        (
-            "Local HEAD advanced past the remote PR head without a matching comment-repair "
-            "operation fingerprint, or with conflicting non-comment repair provenance. AWF refused "
-            "to reset or push those commits."
-        ),
-        "awf workspace logs <workspace_id>",
-        _reason_catalog_link("COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"),
     ),
     "WORKSPACE_REMONITOR_METADATA_MISSING": _ReasonText(
         (
@@ -1476,6 +1425,7 @@ _REASON_TEXT: dict[str, _ReasonText] = {
         "docs/REASON_CATALOG.md#post_agent_commit_precommit_failed",
     ),
 }
+_REASON_TEXT.update(get_comment_repair_reasons(_ReasonText))
 _REASON_TEXT.update(get_salvage_and_monitor_reasons(_ReasonText))
 _REASON_TEXT.update(get_claude_overlay_reasons(_ReasonText))
 

--- a/src/awf/service/doctor/reasons_comment_repair.py
+++ b/src/awf/service/doctor/reasons_comment_repair.py
@@ -1,0 +1,93 @@
+"""Operator-facing doctor reason text for the PR-comment repair paths.
+
+Extracted from ``reasons`` so that module stays within the first-party file-line
+guardrail (``tests/unit/test_core_decomposition_maintainability.py``). Behavior is
+unchanged: the entries are merged back into ``_REASON_TEXT`` at import time.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from awf.service.doctor.reasons_helpers import reason_catalog_link
+
+if TYPE_CHECKING:
+    from awf.service.doctor.reasons import _ReasonText
+
+
+def get_comment_repair_reasons(
+    reason_text_cls: type[_ReasonText],
+) -> dict[str, _ReasonText]:
+    """Return the comment-repair catalog reason text entries."""
+    return {
+        "COMMENT_REPAIR_REMOTE_HEAD_VERIFICATION_FAILED": reason_text_cls(
+            "AWF could not verify the remote PR head before abandoning unpublished comment repairs.",
+            (
+                "Restore forge connectivity and credentials, verify the PR head, then remonitor the "
+                "workspace."
+            ),
+            (
+                "A comment-repair cycle stopped before publication, and the forge head could not be "
+                "read or did not match the expected repository identity."
+            ),
+            "awf workspace logs <workspace_id>",
+            reason_catalog_link("COMMENT_REPAIR_REMOTE_HEAD_VERIFICATION_FAILED"),
+        ),
+        "COMMENT_REPAIR_ROLLBACK_FAILED": reason_text_cls(
+            "AWF could not reset unpublished comment repairs to the verified remote PR head.",
+            (
+                "Preserve the workspace for diagnosis, inspect Git and ownership errors in worker logs, "
+                "then repair the worktree before remonitoring."
+            ),
+            (
+                "AWF verified the remote head but the local hard reset or post-reset verification failed."
+            ),
+            "awf service logs --service worker",
+            reason_catalog_link("COMMENT_REPAIR_ROLLBACK_FAILED"),
+        ),
+        "COMMENT_REPAIR_UNPUBLISHED_ABANDONED": reason_text_cls(
+            "AWF discarded an interrupted set of unpublished PR-comment repair commits.",
+            (
+                "No action is normally required. If monitoring does not resume, inspect workspace logs "
+                "and remonitor the workspace."
+            ),
+            (
+                "The repair cycle ended before push, so AWF reset the local worktree to the verified "
+                "remote PR head to prevent stale unpublished commits from contaminating a later cycle."
+            ),
+            "awf workspace show <workspace_id>",
+            reason_catalog_link("COMMENT_REPAIR_UNPUBLISHED_ABANDONED"),
+        ),
+        "COMMENT_REPAIR_UNPUBLISHED_PRESERVED": reason_text_cls(
+            "AWF resumed an interrupted PR-comment repair from its unpushed local commits.",
+            (
+                "No action is required. The commits are pushed with the next monitor cycle; watch "
+                "the PR for the repair push."
+            ),
+            (
+                "A restart interrupted the repair batch mid-way. The local commits ahead of the PR "
+                "head carry comment-repair provenance, so AWF kept them and continued the batch "
+                "instead of discarding accepted review fixes."
+            ),
+            "awf workspace show <workspace_id>",
+            reason_catalog_link("COMMENT_REPAIR_UNPUBLISHED_PRESERVED"),
+        ),
+        "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING": reason_text_cls(
+            (
+                "AWF parked comment repair for a human: unpushed local commits could not be "
+                "attributed to this repair batch. The commits are preserved."
+            ),
+            (
+                "Inspect the named commits in the workspace worktree, then either keep them (push or "
+                "let AWF resume) or drop them manually, and remonitor the workspace."
+            ),
+            (
+                "Local HEAD advanced past the remote PR head without matching comment-repair "
+                "provenance, or with conflicting non-comment repair provenance. AWF refused to reset "
+                "or push those commits and left the worktree untouched instead of failing the "
+                "workspace."
+            ),
+            "awf workspace logs <workspace_id>",
+            reason_catalog_link("COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"),
+        ),
+    }

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_001.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_001.py
@@ -1,0 +1,466 @@
+"""Commit-time provenance for accepted comment-repair item commits (#935, part 001).
+
+A worker restart between two items of an ``AddressComments`` batch used to strand
+every already-accepted item commit with no durable audit trail, because the
+``comment_repair`` operation row is only finalised at batch end. These tests pin
+the commit-time marker: each accepted item commit is durably recorded (item id,
+item start head, resulting HEAD, operation id) plus an audit event, before the
+batch ends.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.db.models import WorkspaceEvent
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
+from awf.runtime.pr_monitor import MonitorState, ReviewComment, ReviewThread
+from awf.runtime.pr_monitor_runner import comment_repair_provenance, comments
+from awf.runtime.pr_monitor_runner.comment_verdict import VerdictResult
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import seed_monitoring_workspace
+
+_FAKE_REPO = SimpleNamespace(slug=lambda: "owner/repo")
+_BASE = "a" * 40
+_FIRST = "b" * 40
+_SECOND = "c" * 40
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+class _HeadTrackingRunner(SimpleNamespace):
+    """Minimal comment-path runner whose HEAD advances per accepted item."""
+
+
+def _runner(
+    *,
+    factory: async_sessionmaker[AsyncSession],
+    worktrees_root: Path,
+    heads: list[str],
+) -> _HeadTrackingRunner:
+    async def _resolve_task_tag(_workspace_id: str) -> str | None:
+        return None
+
+    async def _invoke(**_kwargs: object) -> VerdictResult:
+        return VerdictResult(verdict="fix_committed")
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return heads.pop(0) if heads else None
+
+    return _HeadTrackingRunner(
+        _workspace_runtime_context="",
+        _worktrees_root=worktrees_root,
+        _deps=SimpleNamespace(session_factory=factory),
+        _resolve_task_tag=_resolve_task_tag,
+        _invoke_cli_for_verdict_result=_invoke,
+        _rev_parse_head=_rev_parse_head,
+    )
+
+
+def _thread(thread_id: str) -> ReviewThread:
+    return ReviewThread(
+        thread_id=thread_id,
+        path="src/app.py",
+        line=12,
+        body_excerpt="please fix",
+        author="reviewer",
+    )
+
+
+def _make_worktree(root: Path, workspace_id: str) -> Path:
+    worktree = root / workspace_id
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text("gitdir: test\n", encoding="utf-8")
+    return worktree
+
+
+async def _persisted_chain(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+) -> list[dict[str, object]]:
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+    assert ws is not None
+    raw = (ws.monitor_threads_addressed or {}).get(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY)
+    if raw is None:
+        return []
+    decoded = json.loads(raw)
+    assert isinstance(decoded, list)
+    return decoded
+
+
+async def _provenance_events(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+) -> list[WorkspaceEvent]:
+    async with factory() as session:
+        rows = await session.execute(
+            select(WorkspaceEvent)
+            .where(
+                WorkspaceEvent.workspace_id == workspace_id,
+                WorkspaceEvent.event_type == "monitor.comment_repair_item_commit_recorded",
+            )
+            .order_by(WorkspaceEvent.event_order)
+        )
+        return list(rows.scalars().all())
+
+
+@pytest.mark.unit
+async def test_accepted_item_commit_records_provenance_before_batch_ends(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(factory=factory, worktrees_root=tmp_path, heads=[_FIRST])
+
+    verdict = await comments._address_thread(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        thread=_thread("PRRT_one"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_BASE,
+        operation_id="op_comment_repair",
+    )
+
+    assert verdict == "fix_committed"
+    chain = await _persisted_chain(factory, workspace_id)
+    assert chain == [
+        {
+            "item_id": "PRRT_one",
+            "item_start_head": _BASE,
+            "head_sha": _FIRST,
+            "operation_id": "op_comment_repair",
+        }
+    ]
+    events = await _provenance_events(factory, workspace_id)
+    assert len(events) == 1
+    assert events[0].reason_code == "COMMENT_REPAIR_ITEM_COMMIT_RECORDED"
+    assert events[0].payload == chain[0]
+
+
+@pytest.mark.unit
+async def test_unchanged_head_after_item_records_nothing(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(factory=factory, worktrees_root=tmp_path, heads=[_BASE])
+
+    await comments._address_thread(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        thread=_thread("PRRT_none"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_BASE,
+        operation_id="op_comment_repair",
+    )
+
+    assert await _persisted_chain(factory, workspace_id) == []
+    assert await _provenance_events(factory, workspace_id) == []
+    assert _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+async def test_second_accepted_item_appends_and_links_the_chain(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(factory=factory, worktrees_root=tmp_path, heads=[_FIRST, _SECOND])
+
+    await comments._address_thread(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        thread=_thread("PRRT_one"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_BASE,
+        operation_id="op_comment_repair",
+    )
+    await comments._address_review_comment_result(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        comment=ReviewComment(comment_id="issue:99", body_excerpt="x", body="x"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_FIRST,
+        operation_id="op_comment_repair",
+    )
+
+    chain = await _persisted_chain(factory, workspace_id)
+    assert [record["item_id"] for record in chain] == ["PRRT_one", "issue:99"]
+    assert chain[1]["item_start_head"] == chain[0]["head_sha"] == _FIRST
+    assert chain[1]["head_sha"] == _SECOND
+    assert len(await _provenance_events(factory, workspace_id)) == 2
+
+
+@pytest.mark.unit
+async def test_non_matching_start_head_restarts_the_chain(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(factory=factory, worktrees_root=tmp_path, heads=[_FIRST, _SECOND])
+
+    await comments._address_thread(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        thread=_thread("PRRT_stale"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_BASE,
+        operation_id="op_comment_repair",
+    )
+    await comments._address_thread(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        thread=_thread("PRRT_fresh"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head="e" * 40,
+        operation_id="op_comment_repair",
+    )
+
+    chain = await _persisted_chain(factory, workspace_id)
+    assert [record["item_id"] for record in chain] == ["PRRT_fresh"]
+    assert chain[0]["item_start_head"] == "e" * 40
+
+
+@pytest.mark.unit
+async def test_database_error_warns_and_lets_the_batch_continue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    workspace_id = "ws_provenance_db_error"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+
+    async def _failing_write(*_args: object, **_kwargs: object) -> None:
+        raise SQLAlchemyError("connection reset")
+
+    monkeypatch.setattr(
+        comment_repair_provenance,
+        "_persist_item_commit_provenance_durably",
+        _failing_write,
+    )
+    runner = _runner(
+        factory=SimpleNamespace(),  # type: ignore[arg-type]
+        worktrees_root=tmp_path,
+        heads=[_FIRST],
+    )
+
+    verdict = await comments._address_thread(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        thread=_thread("PRRT_one"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_BASE,
+        operation_id="op_comment_repair",
+    )
+
+    assert verdict == "fix_committed"
+    # In-memory chain still advances so the next item links onto this commit and
+    # the outer ``_persist_state`` can still flush it.
+    assert _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+async def test_missing_worktree_skips_recording(
+    tmp_path: Path,
+) -> None:
+    state = MonitorState()
+    runner = _runner(
+        factory=SimpleNamespace(),  # type: ignore[arg-type]
+        worktrees_root=tmp_path,
+        heads=[_FIRST],
+    )
+
+    await comment_repair_provenance._record_accepted_item_commit_provenance(
+        runner,
+        workspace_id="ws_missing_worktree",
+        state=state,
+        item_id="PRRT_one",
+        item_start_head=_BASE,
+        operation_id="op_comment_repair",
+    )
+
+    assert state.threads_addressed_ids == {}
+
+
+@pytest.mark.unit
+async def test_absent_worktrees_root_skips_recording() -> None:
+    state = MonitorState()
+    runner = SimpleNamespace()
+
+    await comment_repair_provenance._record_accepted_item_commit_provenance(
+        runner,
+        workspace_id="ws_hosted",
+        state=state,
+        item_id="PRRT_one",
+        item_start_head=_BASE,
+        operation_id=None,
+    )
+
+    assert state.threads_addressed_ids == {}
+
+
+@pytest.mark.unit
+async def test_missing_item_start_head_skips_recording(tmp_path: Path) -> None:
+    state = MonitorState()
+    runner = _runner(
+        factory=SimpleNamespace(),  # type: ignore[arg-type]
+        worktrees_root=tmp_path,
+        heads=[_FIRST],
+    )
+
+    await comment_repair_provenance._record_accepted_item_commit_provenance(
+        runner,
+        workspace_id="ws_no_start_head",
+        state=state,
+        item_id="PRRT_one",
+        item_start_head=None,
+        operation_id=None,
+    )
+
+    assert state.threads_addressed_ids == {}
+
+
+@pytest.mark.unit
+async def test_unreadable_head_skips_recording(tmp_path: Path) -> None:
+    workspace_id = "ws_unreadable_head"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(
+        factory=SimpleNamespace(),  # type: ignore[arg-type]
+        worktrees_root=tmp_path,
+        heads=[],
+    )
+
+    await comment_repair_provenance._record_accepted_item_commit_provenance(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_one",
+        item_start_head=_BASE,
+        operation_id=None,
+    )
+
+    assert state.threads_addressed_ids == {}
+
+
+@pytest.mark.unit
+async def test_durable_write_without_session_factory_is_a_no_op(tmp_path: Path) -> None:
+    state = MonitorState()
+
+    await comment_repair_provenance._persist_item_commit_provenance_durably(
+        SimpleNamespace(_deps=SimpleNamespace()),
+        workspace_id="ws_no_factory",
+        encoded_chain="[]",
+        record=comment_repair_provenance.ItemCommitProvenance(
+            item_id="PRRT_one",
+            item_start_head=_BASE,
+            head_sha=_FIRST,
+            operation_id=None,
+        ),
+    )
+
+    assert state.threads_addressed_ids == {}
+
+
+@pytest.mark.unit
+async def test_durable_write_skips_a_missing_workspace_row(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    await comment_repair_provenance._persist_item_commit_provenance_durably(
+        SimpleNamespace(_deps=SimpleNamespace(session_factory=factory)),
+        workspace_id="ws_absent",
+        encoded_chain="[]",
+        record=comment_repair_provenance.ItemCommitProvenance(
+            item_id="PRRT_one",
+            item_start_head=_BASE,
+            head_sha=_FIRST,
+            operation_id=None,
+        ),
+    )
+
+
+@pytest.mark.unit
+async def test_stateless_call_sites_skip_recording(tmp_path: Path) -> None:
+    """A ``state``-less comment path (legacy seams) has nowhere to chain onto."""
+    workspace_id = "ws_no_state"
+    _make_worktree(tmp_path, workspace_id)
+    runner = _runner(
+        factory=SimpleNamespace(),  # type: ignore[arg-type]
+        worktrees_root=tmp_path,
+        heads=[_FIRST],
+    )
+
+    await comment_repair_provenance._record_accepted_item_commit_provenance(
+        runner,
+        workspace_id=workspace_id,
+        state=None,
+        item_id="PRRT_one",
+        item_start_head=_BASE,
+        operation_id=None,
+    )

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_001.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_001.py
@@ -26,6 +26,9 @@ from awf.db.session import make_session_factory
 from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
 from awf.runtime.pr_monitor import MonitorState, ReviewComment, ReviewThread
 from awf.runtime.pr_monitor_runner import comment_repair_provenance, comments
+from awf.runtime.pr_monitor_runner import (
+    remote_repair_unpublished_provenance as _provenance,
+)
 from awf.runtime.pr_monitor_runner.comment_verdict import VerdictResult
 from tests.postgres import postgres_test_engine
 from tests.unit.runtime._monitor_runner_fixtures import seed_monitoring_workspace
@@ -278,6 +281,62 @@ async def test_non_matching_start_head_restarts_the_chain(
     chain = await _persisted_chain(factory, workspace_id)
     assert [record["item_id"] for record in chain] == ["PRRT_fresh"]
     assert chain[0]["item_start_head"] == "e" * 40
+
+
+@pytest.mark.unit
+async def test_new_operation_restarts_the_chain_after_a_push(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A later batch starts a fresh chain even though it begins at the old tip.
+
+    The first batch pushed ``_FIRST``, so the next batch's first item starts
+    exactly there. Appending would leave the chain rooted at ``_BASE`` — behind
+    the new remote head — and recovery would reject it.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(factory=factory, worktrees_root=tmp_path, heads=[_FIRST, _SECOND])
+
+    await comments._address_thread(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        thread=_thread("PRRT_pushed"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_BASE,
+        operation_id="op_first_batch",
+    )
+    await comments._address_thread(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        thread=_thread("PRRT_next_batch"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_FIRST,
+        operation_id="op_second_batch",
+    )
+
+    chain = await _persisted_chain(factory, workspace_id)
+    assert [record["item_id"] for record in chain] == ["PRRT_next_batch"]
+    assert chain[0]["item_start_head"] == _FIRST
+    assert chain[0]["operation_id"] == "op_second_batch"
+    # The restarted chain now describes exactly ``_FIRST..HEAD``, so recovery
+    # after a mid-batch restart preserves the work instead of parking it.
+    assert _provenance._item_provenance_chain_covers_range(
+        state, base_head=_FIRST, head_sha=_SECOND
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_001.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_001.py
@@ -517,6 +517,42 @@ async def test_failing_head_probe_warns_and_lets_the_batch_continue(
 
 
 @pytest.mark.unit
+async def test_failing_head_probe_keeps_the_review_comment_result(tmp_path: Path) -> None:
+    """The review-comment call site must also survive a flaky HEAD probe."""
+    workspace_id = "ws_head_probe_failure_comment"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(
+        factory=SimpleNamespace(),  # type: ignore[arg-type]
+        worktrees_root=tmp_path,
+        heads=[_FIRST],
+    )
+
+    async def _exploding_rev_parse_head(_worktree_path: Path) -> str | None:
+        raise subprocess.SubprocessError("git died")
+
+    runner._rev_parse_head = _exploding_rev_parse_head
+
+    result = await comments._address_review_comment_result(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        comment=ReviewComment(comment_id="issue:99", body_excerpt="x", body="x"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_BASE,
+        operation_id="op_comment_repair",
+    )
+
+    assert result.verdict == "fix_committed"
+    assert state.threads_addressed_ids == {}
+
+
+@pytest.mark.unit
 async def test_durable_write_without_session_factory_is_a_no_op(tmp_path: Path) -> None:
     state = MonitorState()
 

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_001.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_001.py
@@ -11,6 +11,7 @@ batch ends.
 from __future__ import annotations
 
 import json
+import subprocess
 from collections.abc import AsyncIterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -465,6 +466,53 @@ async def test_unreadable_head_skips_recording(tmp_path: Path) -> None:
         operation_id=None,
     )
 
+    assert state.threads_addressed_ids == {}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "error",
+    [
+        TimeoutError("git rev-parse timed out"),
+        OSError("cannot fork"),
+        subprocess.SubprocessError("git died"),
+    ],
+)
+async def test_failing_head_probe_warns_and_lets_the_batch_continue(
+    tmp_path: Path,
+    error: Exception,
+) -> None:
+    """A flaky HEAD probe must not abort the item — provenance is best-effort."""
+    workspace_id = "ws_head_probe_failure"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(
+        factory=SimpleNamespace(),  # type: ignore[arg-type]
+        worktrees_root=tmp_path,
+        heads=[_FIRST],
+    )
+
+    async def _exploding_rev_parse_head(_worktree_path: Path) -> str | None:
+        raise error
+
+    runner._rev_parse_head = _exploding_rev_parse_head
+
+    verdict = await comments._address_thread(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        thread=_thread("PRRT_one"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_BASE,
+        operation_id="op_comment_repair",
+    )
+
+    assert verdict == "fix_committed"
     assert state.threads_addressed_ids == {}
 
 

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_001.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_001.py
@@ -285,15 +285,17 @@ async def test_non_matching_start_head_restarts_the_chain(
 
 
 @pytest.mark.unit
-async def test_new_operation_restarts_the_chain_after_a_push(
+async def test_a_chain_that_outlived_a_push_still_covers_the_next_batch(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
-    """A later batch starts a fresh chain even though it begins at the old tip.
+    """A new operation links onto the old tip and recovery still resumes.
 
-    The first batch pushed ``_FIRST``, so the next batch's first item starts
-    exactly there. Appending would leave the chain rooted at ``_BASE`` — behind
-    the new remote head — and recovery would reject it.
+    The first batch pushed ``_FIRST`` but its chain outlived the push (the
+    best-effort clear did not land), so the next batch's first item starts
+    exactly at the old tip. The chain then carries a published prefix — which
+    recovery ignores, because it matches the suffix starting at the fetched
+    remote head ``_FIRST``.
     """
     workspace_id = await seed_monitoring_workspace(factory)
     _make_worktree(tmp_path, workspace_id)
@@ -330,14 +332,68 @@ async def test_new_operation_restarts_the_chain_after_a_push(
     )
 
     chain = await _persisted_chain(factory, workspace_id)
-    assert [record["item_id"] for record in chain] == ["PRRT_next_batch"]
-    assert chain[0]["item_start_head"] == _FIRST
-    assert chain[0]["operation_id"] == "op_second_batch"
-    # The restarted chain now describes exactly ``_FIRST..HEAD``, so recovery
-    # after a mid-batch restart preserves the work instead of parking it.
+    assert [record["item_id"] for record in chain] == ["PRRT_pushed", "PRRT_next_batch"]
+    assert chain[1]["item_start_head"] == _FIRST
+    assert chain[1]["operation_id"] == "op_second_batch"
+    # The suffix from the fetched remote head describes exactly ``_FIRST..HEAD``,
+    # so recovery after a mid-batch restart preserves the work instead of parking
+    # it — the published prefix rooted at ``_BASE`` does not get in the way.
     assert _provenance._item_provenance_chain_covers_range(
         state, base_head=_FIRST, head_sha=_SECOND
     )
+
+
+@pytest.mark.unit
+async def test_new_operation_keeps_an_unpublished_recovered_chain(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A head-contiguous chain survives an operation change before publication.
+
+    Recovery preserved the first batch's unpushed commits (``_BASE.._FIRST``),
+    and the poll that resumes them re-enters ``AddressComments`` with a changed
+    unresolved-item set — a different operation id over the *same* remote base.
+    Dropping the chain there would leave it rooted at ``_FIRST``, so a failed
+    push plus a restart could no longer prove ``_BASE..HEAD`` and would park
+    resumable repairs whose subjects the legacy heuristic cannot attribute.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    state.mark_addressed(
+        _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY,
+        comment_repair_provenance.encode_item_commit_provenance_chain(
+            [
+                comment_repair_provenance.ItemCommitProvenance(
+                    item_id="PRRT_recovered",
+                    item_start_head=_BASE,
+                    head_sha=_FIRST,
+                    operation_id="op_first_batch",
+                )
+            ]
+        ),
+    )
+    runner = _runner(factory=factory, worktrees_root=tmp_path, heads=[_SECOND])
+
+    await comments._address_thread(
+        runner,
+        workspace_id=workspace_id,
+        repo=_FAKE_REPO,
+        pr_number=42,
+        thread=_thread("PRRT_resumed"),
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+        operation_start_head=_FIRST,
+        operation_id="op_second_batch",
+    )
+
+    chain = await _persisted_chain(factory, workspace_id)
+    assert [record["item_id"] for record in chain] == ["PRRT_recovered", "PRRT_resumed"]
+    assert chain[0]["item_start_head"] == _BASE
+    assert _provenance._item_provenance_chain_covers_range(state, base_head=_BASE, head_sha=_SECOND)
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_002.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_002.py
@@ -1,0 +1,307 @@
+"""Clearing the commit-time provenance chain on a successful push (#937, part 002).
+
+The chain proves that ``remote..HEAD`` is AWF's own *unpublished* repair work. Once
+the batch pushes, those commits are on the remote and the chain describes nothing —
+but it used to survive, so the next batch (whose first item starts at exactly the
+head this push published) linked onto it and left the chain rooted behind the PR.
+These tests pin the clear: in memory and on the workspace row, best-effort.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import RepoRef
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    PRStatus,
+    ReviewThread,
+)
+from awf.runtime.pr_monitor_runner import comment_repair_provenance
+from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+_BASE = "a" * 40
+_PUSHED = "b" * 40
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+def _encoded_chain() -> str:
+    return json.dumps(
+        [
+            {
+                "item_id": "PRRT_one",
+                "item_start_head": _BASE,
+                "head_sha": _PUSHED,
+                "operation_id": "op_comment_repair",
+            }
+        ],
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+async def _seed_workspace_with_chain(
+    factory: async_sessionmaker[AsyncSession],
+) -> str:
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        ws = await repo.get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {
+            **(ws.monitor_threads_addressed or {}),
+            _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY: _encoded_chain(),
+        }
+        await session.commit()
+    return workspace_id
+
+
+async def _persisted_chain_raw(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+) -> str | None:
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+    assert ws is not None
+    return (ws.monitor_threads_addressed or {}).get(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY)
+
+
+@pytest.mark.unit
+async def test_clear_removes_the_chain_from_state_and_the_workspace_row(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    workspace_id = await _seed_workspace_with_chain(factory)
+    state = MonitorState()
+    state.mark_addressed(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY, _encoded_chain())
+
+    await comment_repair_provenance._clear_published_item_commit_provenance_chain(
+        SimpleNamespace(_deps=SimpleNamespace(session_factory=factory)),
+        workspace_id=workspace_id,
+        state=state,
+    )
+
+    assert _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY not in state.threads_addressed_ids
+    assert await _persisted_chain_raw(factory, workspace_id) is None
+
+
+@pytest.mark.unit
+async def test_clear_leaves_other_addressed_state_untouched(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Only the chain key goes; unrelated addressed markers must survive."""
+    workspace_id = await _seed_workspace_with_chain(factory)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        ws = await repo.get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {
+            **(ws.monitor_threads_addressed or {}),
+            "PRRT_other": "fix_committed",
+        }
+        await session.commit()
+    state = MonitorState()
+
+    await comment_repair_provenance._clear_published_item_commit_provenance_chain(
+        SimpleNamespace(_deps=SimpleNamespace(session_factory=factory)),
+        workspace_id=workspace_id,
+        state=state,
+    )
+
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+    assert ws is not None
+    assert ws.monitor_threads_addressed["PRRT_other"] == "fix_committed"
+    assert _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY not in ws.monitor_threads_addressed
+
+
+@pytest.mark.unit
+async def test_clear_without_a_persisted_chain_is_a_no_op(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+
+    await comment_repair_provenance._clear_published_item_commit_provenance_chain(
+        SimpleNamespace(_deps=SimpleNamespace(session_factory=factory)),
+        workspace_id=workspace_id,
+        state=MonitorState(),
+    )
+
+    assert await _persisted_chain_raw(factory, workspace_id) is None
+
+
+@pytest.mark.unit
+async def test_clear_skips_a_missing_workspace_row(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    state = MonitorState()
+    state.mark_addressed(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY, _encoded_chain())
+
+    await comment_repair_provenance._clear_published_item_commit_provenance_chain(
+        SimpleNamespace(_deps=SimpleNamespace(session_factory=factory)),
+        workspace_id="ws_absent",
+        state=state,
+    )
+
+    assert _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+async def test_clear_without_a_session_factory_still_clears_memory() -> None:
+    """Hosted execution and unit seams have no local session factory."""
+    state = MonitorState()
+    state.mark_addressed(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY, _encoded_chain())
+
+    await comment_repair_provenance._clear_published_item_commit_provenance_chain(
+        SimpleNamespace(_deps=SimpleNamespace()),
+        workspace_id="ws_hosted",
+        state=state,
+    )
+
+    assert _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "error",
+    [SQLAlchemyError("connection reset"), OSError("socket closed")],
+)
+async def test_clear_survives_a_durable_write_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> None:
+    """The push already succeeded — a DB blip here must not fail the batch."""
+
+    async def _failing_clear(*_args: object, **_kwargs: object) -> None:
+        raise error
+
+    monkeypatch.setattr(
+        comment_repair_provenance,
+        "_clear_item_commit_provenance_chain_durably",
+        _failing_clear,
+    )
+    state = MonitorState()
+    state.mark_addressed(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY, _encoded_chain())
+
+    await comment_repair_provenance._clear_published_item_commit_provenance_chain(
+        SimpleNamespace(_deps=SimpleNamespace()),
+        workspace_id="ws_clear_failure",
+        state=state,
+    )
+
+    # The in-memory clear still stands, so the outer ``_persist_state`` flushes it.
+    assert _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+async def test_fix_cycle_clears_the_chain_after_a_successful_push(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End of the batch: the pushed commits need no unpublished-work marker."""
+    workspace_id = await _seed_workspace_with_chain(factory)
+    worktrees_root = tmp_path / "worktrees"
+    (worktrees_root / workspace_id).mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=worktrees_root,
+    )
+    state = MonitorState()
+    state.mark_addressed(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY, _encoded_chain())
+
+    async def _no_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _start_head(**_kwargs: object) -> tuple[str, None]:
+        return (_BASE, None)
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return _PUSHED
+
+    async def _address(**_kwargs: object) -> str:
+        return "false_positive"
+
+    async def _settle(**_kwargs: object) -> PRStatus:
+        return PRStatus(
+            number=42,
+            head_sha=_BASE,
+            mergeable=MergeableState.MERGEABLE,
+            check_state=CheckState.SUCCESS,
+            unresolved_inline_threads=(),
+            unresolved_review_comments=(),
+            base_behind_count=0,
+            merge_state_status=MergeStateStatus.CLEAN,
+        )
+
+    async def _no_block(**_kwargs: object) -> None:
+        return None
+
+    async def _pushed(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=True, failed=False, returncode=0)
+
+    async def _resolve_thread(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner._deps.gh, "resolve_thread", _resolve_thread)
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head)
+    monkeypatch.setattr(runner, "_rev_parse_head", _rev_parse_head)
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _settle)
+    monkeypatch.setattr(runner, "_protected_scope_push_block", _no_block)
+    monkeypatch.setattr(runner, "_validated_git_push_result", _pushed)
+
+    result = await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=_BASE,
+        initial_threads=(
+            ReviewThread(
+                thread_id="PRRT_one",
+                path="src/foo.py",
+                line=3,
+                body_excerpt="please fix",
+                author="reviewer",
+            ),
+        ),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert result.pushed is True
+    assert _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY not in state.threads_addressed_ids
+    assert await _persisted_chain_raw(factory, workspace_id) is None

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_003.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_003.py
@@ -1,0 +1,103 @@
+"""Bounding the commit-time provenance chain without losing its root (#937, part 003).
+
+The chain is capped so a pathological settle loop cannot grow the marker without
+limit. Capping by tail slice used to drop the record rooted at the remote PR head,
+and recovery's ``_item_provenance_chain_covers_range`` locates the covering suffix
+*by that base* — so a batch past the cap was rejected after a restart and parked
+whenever its commit subjects did not match the legacy heuristic. These tests pin the
+compaction: bounded length, preserved root, unbroken root-to-tip linkage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
+from awf.runtime.pr_monitor import MonitorState
+from awf.runtime.pr_monitor_runner import comment_repair_provenance
+from awf.runtime.pr_monitor_runner import (
+    remote_repair_unpublished_provenance as _provenance,
+)
+
+_MAX = comment_repair_provenance._MAX_CHAIN_RECORDS
+_OPERATION_ID = "op_comment_repair"
+
+
+def _sha(index: int) -> str:
+    return f"{index:040x}"
+
+
+def _chain(item_count: int) -> tuple[comment_repair_provenance.ItemCommitProvenance, ...]:
+    """Build a linked chain of ``item_count`` accepted item commits, one batch."""
+    chain: tuple[comment_repair_provenance.ItemCommitProvenance, ...] = ()
+    for index in range(item_count):
+        chain = comment_repair_provenance.appended_item_commit_provenance_chain(
+            chain,
+            comment_repair_provenance.ItemCommitProvenance(
+                item_id=f"PRRT_{index}",
+                item_start_head=_sha(index),
+                head_sha=_sha(index + 1),
+                operation_id=_OPERATION_ID,
+            ),
+        )
+    return chain
+
+
+def _state_with(chain: tuple[comment_repair_provenance.ItemCommitProvenance, ...]) -> MonitorState:
+    state = MonitorState()
+    state.mark_addressed(
+        _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY,
+        comment_repair_provenance.encode_item_commit_provenance_chain(chain),
+    )
+    return state
+
+
+@pytest.mark.unit
+def test_chain_below_the_cap_keeps_every_record() -> None:
+    chain = _chain(_MAX)
+
+    assert len(chain) == _MAX
+    assert [record.item_id for record in chain] == [f"PRRT_{index}" for index in range(_MAX)]
+
+
+@pytest.mark.unit
+def test_chain_past_the_cap_folds_the_oldest_records_but_keeps_the_root() -> None:
+    chain = _chain(_MAX + 5)
+
+    assert len(chain) == _MAX
+    # The fold spans the six oldest items root-to-tip instead of discarding them.
+    assert chain[0].item_id == comment_repair_provenance._COMPACTED_RECORD_ITEM_ID
+    assert chain[0].item_start_head == _sha(0)
+    assert chain[0].head_sha == _sha(6)
+    assert chain[0].operation_id == _OPERATION_ID
+    # Every remaining record is a real item, still linked head to start head.
+    assert [record.item_id for record in chain[1:]] == [
+        f"PRRT_{index}" for index in range(6, _MAX + 5)
+    ]
+    for previous, record in zip(chain, chain[1:], strict=False):
+        assert record.item_start_head == previous.head_sha
+    assert chain[-1].head_sha == _sha(_MAX + 5)
+
+
+@pytest.mark.unit
+def test_compacted_chain_still_covers_the_remote_to_head_range() -> None:
+    """Recovery accepts the durable chain of an over-long batch after a restart."""
+    state = _state_with(_chain(_MAX + 5))
+
+    assert _provenance._item_provenance_chain_covers_range(
+        state,
+        base_head=_sha(0),
+        head_sha=_sha(_MAX + 5),
+    )
+
+
+@pytest.mark.unit
+def test_compacted_chain_still_rejects_a_base_it_is_not_rooted_at() -> None:
+    """Compaction bounds the marker; it must not widen what the chain vouches for."""
+    state = _state_with(_chain(_MAX + 5))
+
+    assert not _provenance._item_provenance_chain_covers_range(
+        state,
+        base_head=_sha(3),
+        head_sha=_sha(_MAX + 5),
+    )

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_004.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_004.py
@@ -1,0 +1,371 @@
+"""Completing an item record whose end-HEAD probe failed (#937, part 004).
+
+The commit-time probe is best-effort, but dropping its record costs the whole
+chain: recovery's ``_item_provenance_chain_covers_range`` then finds a broken link
+and parks an otherwise resumable batch whose commit subjects the legacy heuristic
+cannot attribute. The next item of the same batch starts at exactly the head the
+failed probe should have read, so these tests pin the completion — and the guards
+that keep a stale marker from inventing a record.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.db.models import WorkspaceEvent
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
+from awf.runtime.pr_monitor import MonitorState
+from awf.runtime.pr_monitor_runner import comment_repair_provenance
+from awf.runtime.pr_monitor_runner import (
+    remote_repair_unpublished_provenance as _provenance,
+)
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import seed_monitoring_workspace
+
+_BASE = "a" * 40
+_FIRST = "b" * 40
+_SECOND = "c" * 40
+_OPERATION_ID = "op_comment_repair"
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+def _runner(
+    *,
+    factory: object,
+    worktrees_root: Path,
+    heads: list[str | Exception | None],
+) -> SimpleNamespace:
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        head = heads.pop(0) if heads else None
+        if isinstance(head, Exception):
+            raise head
+        return head
+
+    return SimpleNamespace(
+        _worktrees_root=worktrees_root,
+        _deps=SimpleNamespace(session_factory=factory),
+        _rev_parse_head=_rev_parse_head,
+    )
+
+
+def _make_worktree(root: Path, workspace_id: str) -> Path:
+    worktree = root / workspace_id
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text("gitdir: test\n", encoding="utf-8")
+    return worktree
+
+
+def _chain(state: MonitorState) -> list[dict[str, object]]:
+    raw = state.threads_addressed_ids.get(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY)
+    if raw is None:
+        return []
+    decoded = json.loads(raw)
+    assert isinstance(decoded, list)
+    return decoded
+
+
+async def _record(
+    runner: SimpleNamespace,
+    *,
+    workspace_id: str,
+    state: MonitorState,
+    item_id: str,
+    item_start_head: str,
+    operation_id: str | None = _OPERATION_ID,
+) -> None:
+    await comment_repair_provenance._record_accepted_item_commit_provenance(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id=item_id,
+        item_start_head=item_start_head,
+        operation_id=operation_id,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "probe_outcome",
+    [
+        TimeoutError("git rev-parse timed out"),
+        OSError("cannot fork"),
+        subprocess.SubprocessError("git died"),
+        None,  # ordinary Git failure: ``_rev_parse_head`` returns None
+    ],
+)
+async def test_next_item_completes_the_record_the_probe_could_not_write(
+    tmp_path: Path,
+    probe_outcome: Exception | None,
+) -> None:
+    """The next item's start head IS the failed item's end head — use it."""
+    workspace_id = "ws_probe_failure_completed"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(
+        factory=SimpleNamespace(),
+        worktrees_root=tmp_path,
+        heads=[probe_outcome, _SECOND],
+    )
+
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_one",
+        item_start_head=_BASE,
+    )
+    assert _chain(state) == []
+
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_two",
+        item_start_head=_FIRST,
+    )
+
+    assert _chain(state) == [
+        {
+            "item_id": "PRRT_one",
+            "item_start_head": _BASE,
+            "head_sha": _FIRST,
+            "operation_id": _OPERATION_ID,
+        },
+        {
+            "item_id": "PRRT_two",
+            "item_start_head": _FIRST,
+            "head_sha": _SECOND,
+            "operation_id": _OPERATION_ID,
+        },
+    ]
+    # The completed chain is what recovery needs after a restart: without it the
+    # batch falls back to commit-subject matching and parks.
+    assert _provenance._item_provenance_chain_covers_range(
+        state,
+        base_head=_BASE,
+        head_sha=_SECOND,
+    )
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_completed_record_is_durable_before_the_batch_ends(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A restart after the *next* item must find the failed item's record on the row."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(
+        factory=factory,
+        worktrees_root=tmp_path,
+        heads=[OSError("cannot fork"), _SECOND],
+    )
+
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_one",
+        item_start_head=_BASE,
+    )
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_two",
+        item_start_head=_FIRST,
+    )
+
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+        assert ws is not None
+        persisted = (ws.monitor_threads_addressed or {}).get(
+            _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
+        )
+        events = list(
+            (
+                await session.execute(
+                    select(WorkspaceEvent)
+                    .where(
+                        WorkspaceEvent.workspace_id == workspace_id,
+                        WorkspaceEvent.event_type
+                        == comment_repair_provenance.ITEM_COMMIT_RECORDED_EVENT,
+                    )
+                    .order_by(WorkspaceEvent.event_order)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert persisted is not None
+    assert [record["item_id"] for record in json.loads(persisted)] == ["PRRT_one", "PRRT_two"]
+    # Each record lands with its own audit event, including the completed one.
+    assert [event.payload["item_id"] for event in events] == ["PRRT_one", "PRRT_two"]
+    assert events[0].payload["head_sha"] == _FIRST
+
+
+@pytest.mark.unit
+async def test_pending_record_is_dropped_when_head_never_advanced(tmp_path: Path) -> None:
+    """An item that kept no commit has nothing to attribute, probe failure or not."""
+    workspace_id = "ws_probe_failure_no_commit"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(
+        factory=SimpleNamespace(),
+        worktrees_root=tmp_path,
+        heads=[OSError("cannot fork"), _SECOND],
+    )
+
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_one",
+        item_start_head=_BASE,
+    )
+    # The next item starts at the same head: item one committed nothing.
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_two",
+        item_start_head=_BASE,
+    )
+
+    assert [record["item_id"] for record in _chain(state)] == ["PRRT_two"]
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_pending_record_is_dropped_in_a_later_batch(tmp_path: Path) -> None:
+    """A new operation starts at a new base; its start head is not the old end head."""
+    workspace_id = "ws_probe_failure_new_batch"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    runner = _runner(
+        factory=SimpleNamespace(),
+        worktrees_root=tmp_path,
+        heads=[OSError("cannot fork"), _SECOND],
+    )
+
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_one",
+        item_start_head=_BASE,
+    )
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_two",
+        item_start_head=_FIRST,
+        operation_id="op_later_batch",
+    )
+
+    assert [record["item_id"] for record in _chain(state)] == ["PRRT_two"]
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_pending_marker_survives_a_second_failed_probe(tmp_path: Path) -> None:
+    """Two consecutive probe failures still record both items, one item late each."""
+    workspace_id = "ws_probe_failure_twice"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    third = "d" * 40
+    runner = _runner(
+        factory=SimpleNamespace(),
+        worktrees_root=tmp_path,
+        heads=[OSError("cannot fork"), OSError("cannot fork"), third],
+    )
+
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_one",
+        item_start_head=_BASE,
+    )
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_two",
+        item_start_head=_FIRST,
+    )
+    await _record(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        item_id="PRRT_three",
+        item_start_head=_SECOND,
+    )
+
+    assert [record["item_id"] for record in _chain(state)] == [
+        "PRRT_one",
+        "PRRT_two",
+        "PRRT_three",
+    ]
+    assert _provenance._item_provenance_chain_covers_range(
+        state,
+        base_head=_BASE,
+        head_sha=third,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "",
+        "   ",
+        "{not json",
+        "[]",
+        json.dumps({"item_start_head": _BASE}),
+        json.dumps({"item_id": " ", "item_start_head": _BASE}),
+        json.dumps({"item_id": "PRRT_one"}),
+        json.dumps({"item_id": "PRRT_one", "item_start_head": "  "}),
+    ],
+)
+def test_malformed_pending_markers_decode_to_nothing(raw: object) -> None:
+    assert comment_repair_provenance._decode_pending_item_commit_provenance(raw) is None
+
+
+@pytest.mark.unit
+def test_pending_marker_round_trips_without_an_operation_id() -> None:
+    encoded = comment_repair_provenance._encode_pending_item_commit_provenance(
+        comment_repair_provenance.PendingItemCommitProvenance(
+            item_id="PRRT_one",
+            item_start_head=_BASE,
+            operation_id=None,
+        )
+    )
+
+    assert comment_repair_provenance._decode_pending_item_commit_provenance(encoded) == (
+        comment_repair_provenance.PendingItemCommitProvenance(
+            item_id="PRRT_one",
+            item_start_head=_BASE,
+            operation_id=None,
+        )
+    )

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_005.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_005.py
@@ -1,0 +1,388 @@
+"""Settling the batch's last pending item record before the push (#937, part 005).
+
+``_complete_pending_item_commit_provenance`` completes a failed end-HEAD probe from
+the *next* item's start head — but the last item of a batch has no successor, and
+the pending marker only lives in memory. A push that then fails, followed by a
+worker restart, used to lose that record for good: the chain has a hole exactly
+where recovery reads it, and an accepted agent-authored commit whose subject the
+legacy heuristic cannot attribute is parked instead of resumed. These tests pin the
+pre-push re-probe that closes it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import RepoRef
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    PRStatus,
+    ReviewThread,
+)
+from awf.runtime.pr_monitor_runner import comment_repair_provenance
+from awf.runtime.pr_monitor_runner import (
+    remote_repair_unpublished_provenance as _provenance,
+)
+from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+_BASE = "a" * 40
+_FIRST = "b" * 40
+_OPERATION_ID = "op_comment_repair"
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+def _runner(
+    *,
+    factory: object,
+    worktrees_root: Path,
+    heads: list[str | Exception | None],
+) -> SimpleNamespace:
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        head = heads.pop(0) if heads else None
+        if isinstance(head, Exception):
+            raise head
+        return head
+
+    return SimpleNamespace(
+        _worktrees_root=worktrees_root,
+        _deps=SimpleNamespace(session_factory=factory),
+        _rev_parse_head=_rev_parse_head,
+    )
+
+
+def _make_worktree(root: Path, workspace_id: str) -> Path:
+    worktree = root / workspace_id
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text("gitdir: test\n", encoding="utf-8")
+    return worktree
+
+
+def _chain(state: MonitorState) -> list[dict[str, object]]:
+    raw = state.threads_addressed_ids.get(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY)
+    if raw is None:
+        return []
+    decoded = json.loads(raw)
+    assert isinstance(decoded, list)
+    return decoded
+
+
+def _pending(state: MonitorState, *, item_start_head: str = _BASE) -> None:
+    comment_repair_provenance._remember_unrecorded_item_commit(
+        state,
+        item_id="PRRT_last",
+        item_start_head=item_start_head,
+        operation_id=_OPERATION_ID,
+    )
+
+
+async def _settle(
+    runner: SimpleNamespace,
+    *,
+    workspace_id: str,
+    state: MonitorState,
+    operation_id: str | None = _OPERATION_ID,
+) -> None:
+    await comment_repair_provenance._settle_pending_item_commit_provenance(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        operation_id=operation_id,
+    )
+
+
+@pytest.mark.unit
+async def test_last_item_record_is_written_from_a_pre_push_head_probe(
+    tmp_path: Path,
+) -> None:
+    """Nothing commits after the last verdict, so live HEAD is its end head."""
+    workspace_id = "ws_settle_last_item"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    _pending(state)
+    runner = _runner(factory=SimpleNamespace(), worktrees_root=tmp_path, heads=[_FIRST])
+
+    await _settle(runner, workspace_id=workspace_id, state=state)
+
+    assert _chain(state) == [
+        {
+            "item_id": "PRRT_last",
+            "item_start_head": _BASE,
+            "head_sha": _FIRST,
+            "operation_id": _OPERATION_ID,
+        }
+    ]
+    # This is what a restart after a failed push needs: without the record the
+    # range is uncovered and the batch parks on the legacy subject heuristic.
+    assert _provenance._item_provenance_chain_covers_range(
+        state,
+        base_head=_BASE,
+        head_sha=_FIRST,
+    )
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_settled_record_is_durable_before_the_push_is_attempted(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A restart right after a failed push must find the record on the row."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    _pending(state)
+    runner = _runner(factory=factory, worktrees_root=tmp_path, heads=[_FIRST])
+
+    await _settle(runner, workspace_id=workspace_id, state=state)
+
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+    assert ws is not None
+    persisted = (ws.monitor_threads_addressed or {}).get(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY)
+    assert persisted is not None
+    assert [record["item_id"] for record in json.loads(persisted)] == ["PRRT_last"]
+
+
+@pytest.mark.unit
+async def test_settle_without_a_pending_marker_never_probes_head(tmp_path: Path) -> None:
+    """The common case: no marker, no extra git call before the push."""
+    workspace_id = "ws_settle_nothing_pending"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    probes: list[Path] = []
+
+    async def _rev_parse_head(worktree_path: Path) -> str | None:
+        probes.append(worktree_path)
+        return _FIRST
+
+    runner = SimpleNamespace(
+        _worktrees_root=tmp_path,
+        _deps=SimpleNamespace(session_factory=SimpleNamespace()),
+        _rev_parse_head=_rev_parse_head,
+    )
+
+    await _settle(runner, workspace_id=workspace_id, state=state)
+
+    assert probes == []
+    assert _chain(state) == []
+
+
+@pytest.mark.unit
+async def test_settle_drops_the_marker_when_head_never_advanced(tmp_path: Path) -> None:
+    """The last item kept no commit after all; there is nothing to attribute."""
+    workspace_id = "ws_settle_no_commit"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    _pending(state)
+    runner = _runner(factory=SimpleNamespace(), worktrees_root=tmp_path, heads=[_BASE])
+
+    await _settle(runner, workspace_id=workspace_id, state=state)
+
+    assert _chain(state) == []
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_settle_ignores_a_marker_from_another_operation(tmp_path: Path) -> None:
+    """A stale marker must not invent a record against this batch's head."""
+    workspace_id = "ws_settle_other_operation"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    _pending(state)
+    runner = _runner(factory=SimpleNamespace(), worktrees_root=tmp_path, heads=[_FIRST])
+
+    await _settle(
+        runner,
+        workspace_id=workspace_id,
+        state=state,
+        operation_id="op_other_batch",
+    )
+
+    assert _chain(state) == []
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "probe_outcome",
+    [
+        TimeoutError("git rev-parse timed out"),
+        OSError("cannot fork"),
+        subprocess.SubprocessError("git died"),
+        None,  # ordinary Git failure: ``_rev_parse_head`` returns None
+        "",
+    ],
+)
+async def test_settle_falls_back_to_the_legacy_heuristic_on_a_second_probe_failure(
+    tmp_path: Path,
+    probe_outcome: Exception | str | None,
+) -> None:
+    """Best-effort: a still-unreadable HEAD must not fail the batch's push."""
+    workspace_id = "ws_settle_probe_failure"
+    _make_worktree(tmp_path, workspace_id)
+    state = MonitorState()
+    _pending(state)
+    runner = _runner(
+        factory=SimpleNamespace(),
+        worktrees_root=tmp_path,
+        heads=[probe_outcome],
+    )
+
+    await _settle(runner, workspace_id=workspace_id, state=state)
+
+    assert _chain(state) == []
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("with_worktree", [False, True])
+async def test_settle_without_a_local_worktree_drops_the_marker(
+    tmp_path: Path,
+    with_worktree: bool,
+) -> None:
+    """Hosted execution and unit seams have no local HEAD to fingerprint."""
+    workspace_id = "ws_settle_no_worktree"
+    worktrees_root: object = tmp_path if with_worktree else None
+    state = MonitorState()
+    _pending(state)
+    runner = SimpleNamespace(
+        _worktrees_root=worktrees_root,
+        _deps=SimpleNamespace(session_factory=SimpleNamespace()),
+    )
+
+    await _settle(runner, workspace_id=workspace_id, state=state)
+
+    assert _chain(state) == []
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_fix_cycle_settles_the_last_item_before_a_failing_push(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end shape of the reported gap: probe fails, then the push fails."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    worktrees_root = tmp_path / "worktrees"
+    # No ``.git`` metadata: the unpublished-repair rollback guard treats this as a
+    # unit seam and leaves the batch's local commits alone.
+    (worktrees_root / workspace_id).mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=worktrees_root,
+    )
+    state = MonitorState()
+
+    async def _no_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _start_head(**_kwargs: object) -> tuple[str, None]:
+        return (_BASE, None)
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return _FIRST
+
+    async def _address(**_kwargs: object) -> str:
+        # The item commits, but its own end-HEAD probe could not be read.
+        comment_repair_provenance._remember_unrecorded_item_commit(
+            state,
+            item_id="PRRT_last",
+            item_start_head=_BASE,
+            operation_id=_OPERATION_ID,
+        )
+        return "fix_committed"
+
+    async def _status(**_kwargs: object) -> PRStatus:
+        return PRStatus(
+            number=42,
+            head_sha=_BASE,
+            mergeable=MergeableState.MERGEABLE,
+            check_state=CheckState.SUCCESS,
+            unresolved_inline_threads=(),
+            unresolved_review_comments=(),
+            base_behind_count=0,
+            merge_state_status=MergeStateStatus.CLEAN,
+        )
+
+    async def _no_block(**_kwargs: object) -> None:
+        return None
+
+    async def _failed_push(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(
+            pushed=False,
+            failed=True,
+            returncode=1,
+            stderr="remote rejected",
+            reason_code="PUSH_FAILED",
+        )
+
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head)
+    monkeypatch.setattr(runner, "_rev_parse_head", _rev_parse_head)
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _status)
+    monkeypatch.setattr(runner, "_protected_scope_push_block", _no_block)
+    monkeypatch.setattr(runner, "_validated_git_push_result", _failed_push)
+
+    result = await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=_BASE,
+        initial_threads=(
+            ReviewThread(
+                thread_id="PRRT_last",
+                path="src/foo.py",
+                line=3,
+                body_excerpt="please fix",
+                author="reviewer",
+            ),
+        ),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        operation_id=_OPERATION_ID,
+    )
+
+    assert result.failed is True
+    # The failed push keeps the commit local; the record proving it is AWF's own
+    # work must be on the workspace row before a restart can read it.
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+    assert ws is not None
+    persisted = (ws.monitor_threads_addressed or {}).get(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY)
+    assert persisted is not None
+    assert [record["item_id"] for record in json.loads(persisted)] == ["PRRT_last"]
+    assert state.pending_item_commit_provenance is None

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_006.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_006.py
@@ -1,0 +1,335 @@
+"""Settling a pending item record before every fix-cycle early exit (#937, part 006).
+
+Part 005 pins the pre-push settle on the *normal* fall-through path. That call is
+never reached when a later item raises: ``_run_fix_cycle`` returns early from each
+``except`` arm of its item loops, and re-raises a permanent forge fault from the
+settle re-poll. The pending marker is memory-only, so a record held for the
+pre-push settle is lost on exactly those paths — after a restart the chain has a
+hole where recovery reads it and the accepted commit is parked (or discarded)
+instead of pushed. These tests pin the settle that now runs before each next item
+and before the re-raise.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.common.forge_errors import ForgeClientError
+from awf.common.github_client import RepoRef
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    PRStatus,
+    ReviewComment,
+    ReviewThread,
+)
+from awf.runtime.pr_monitor_runner import comment_repair_provenance
+from awf.runtime.pr_monitor_runner.comment_verdict import (
+    AgentVerdictProtocolError,
+    MonitorVerdictResult,
+)
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+_BASE = "a" * 40
+_FIRST = "b" * 40
+_OPERATION_ID = "op_comment_repair"
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+def _thread(thread_id: str) -> ReviewThread:
+    return ReviewThread(
+        thread_id=thread_id,
+        path="src/foo.py",
+        line=3,
+        body_excerpt="please fix",
+        author="reviewer",
+    )
+
+
+def _comment(comment_id: str) -> ReviewComment:
+    return ReviewComment(
+        comment_id=comment_id,
+        body_excerpt="please fix",
+        author="reviewer",
+    )
+
+
+def _settled_status() -> PRStatus:
+    return PRStatus(
+        number=42,
+        head_sha=_BASE,
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=(),
+        unresolved_review_comments=(),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+    )
+
+
+def _prepared_runner(
+    *,
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+    worktrees_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> object:
+    """A runner whose fix cycle reaches the item loop with a readable HEAD."""
+    (worktrees_root / workspace_id).mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=worktrees_root,
+    )
+
+    async def _no_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _start_head(**_kwargs: object) -> tuple[str, None]:
+        return (_BASE, None)
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return _FIRST
+
+    async def _no_block(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head)
+    monkeypatch.setattr(runner, "_rev_parse_head", _rev_parse_head)
+    monkeypatch.setattr(runner, "_protected_scope_push_block", _no_block)
+    return runner
+
+
+def _remember_pending(state: MonitorState, *, item_id: str) -> None:
+    comment_repair_provenance._remember_unrecorded_item_commit(
+        state,
+        item_id=item_id,
+        item_start_head=_BASE,
+        operation_id=_OPERATION_ID,
+    )
+
+
+async def _persisted_item_ids(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+) -> list[str]:
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+    assert ws is not None
+    persisted = (ws.monitor_threads_addressed or {}).get(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY)
+    assert persisted is not None
+    return [str(record["item_id"]) for record in json.loads(persisted)]
+
+
+@pytest.mark.unit
+async def test_thread_loop_settles_a_pending_record_before_a_failing_next_item(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A protocol failure on item 2 must not discard item 1's held record."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = _prepared_runner(
+        factory=factory,
+        workspace_id=workspace_id,
+        worktrees_root=tmp_path / "worktrees",
+        monkeypatch=monkeypatch,
+    )
+    state = MonitorState()
+    addressed: list[str] = []
+
+    async def _address(*, thread: ReviewThread, **_kwargs: object) -> str:
+        addressed.append(thread.thread_id)
+        if thread.thread_id == "PRRT_first":
+            # The item commits, but its own end-HEAD probe could not be read.
+            _remember_pending(state, item_id="PRRT_first")
+            return "fix_committed"
+        raise AgentVerdictProtocolError()
+
+    monkeypatch.setattr(runner, "_address_thread", _address)
+
+    result = await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=_BASE,
+        initial_threads=(_thread("PRRT_first"), _thread("PRRT_second")),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        operation_id=_OPERATION_ID,
+    )
+
+    assert result.failed is True
+    assert addressed == ["PRRT_first", "PRRT_second"]
+    assert await _persisted_item_ids(factory, workspace_id) == ["PRRT_first"]
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_review_loop_settles_a_pending_record_before_a_failing_next_item(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same gap on the review-comment loop, which exits through the same arms."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = _prepared_runner(
+        factory=factory,
+        workspace_id=workspace_id,
+        worktrees_root=tmp_path / "worktrees",
+        monkeypatch=monkeypatch,
+    )
+    state = MonitorState()
+
+    async def _address(*, comment: ReviewComment, **_kwargs: object) -> MonitorVerdictResult:
+        if comment.comment_id == "1001":
+            _remember_pending(state, item_id="1001")
+            return MonitorVerdictResult(verdict="fix_committed")
+        raise AgentVerdictProtocolError()
+
+    monkeypatch.setattr(runner, "_address_review_comment_result", _address)
+
+    result = await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=_BASE,
+        initial_threads=(),
+        initial_reviews=(_comment("1001"), _comment("1002")),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        operation_id=_OPERATION_ID,
+    )
+
+    assert result.failed is True
+    assert await _persisted_item_ids(factory, workspace_id) == ["1001"]
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_settle_repoll_reraise_settles_the_pending_record_first(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A permanent settle-poll fault leaves the batch unpushed — keep the record."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = _prepared_runner(
+        factory=factory,
+        workspace_id=workspace_id,
+        worktrees_root=tmp_path / "worktrees",
+        monkeypatch=monkeypatch,
+    )
+    state = MonitorState()
+
+    async def _address(*, thread: ReviewThread, **_kwargs: object) -> str:
+        _remember_pending(state, item_id=thread.thread_id)
+        return "fix_committed"
+
+    async def _permanent_fault(**_kwargs: object) -> PRStatus:
+        raise ForgeClientError("settle re-poll rejected")
+
+    async def _not_transient(*_args: object, **_kwargs: object) -> bool:
+        return False
+
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _permanent_fault)
+    monkeypatch.setattr(runner, "_wait_after_transient_forge_error", _not_transient)
+
+    with pytest.raises(ForgeClientError):
+        await runner._run_fix_cycle(
+            workspace_id=workspace_id,
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            pr_head_sha=_BASE,
+            initial_threads=(_thread("PRRT_only"),),
+            initial_reviews=(),
+            state=state,
+            remote_branch=f"awf/{workspace_id}",
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            operation_id=_OPERATION_ID,
+        )
+
+    assert await _persisted_item_ids(factory, workspace_id) == ["PRRT_only"]
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_settle_before_each_item_leaves_a_clean_batch_untouched(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No pending marker: the per-item settle costs nothing and records nothing."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = _prepared_runner(
+        factory=factory,
+        workspace_id=workspace_id,
+        worktrees_root=tmp_path / "worktrees",
+        monkeypatch=monkeypatch,
+    )
+    state = MonitorState()
+
+    async def _address(**_kwargs: object) -> str:
+        return "false_positive"
+
+    async def _status(**_kwargs: object) -> PRStatus:
+        return _settled_status()
+
+    async def _resolve(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _status)
+    monkeypatch.setattr(runner, "_record_pr_feedback_resolution", _resolve)
+
+    await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=_BASE,
+        initial_threads=(_thread("PRRT_only"),),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        operation_id=_OPERATION_ID,
+    )
+
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+    assert ws is not None
+    assert _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY not in (ws.monitor_threads_addressed or {})
+    assert state.pending_item_commit_provenance is None

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_006.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_006.py
@@ -13,6 +13,7 @@ and before the re-raise.
 from __future__ import annotations
 
 import json
+import shutil
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -95,12 +96,19 @@ def _prepared_runner(
     workspace_id: str,
     worktrees_root: Path,
     monkeypatch: pytest.MonkeyPatch,
+    cmd: FakeCommandRunner | None = None,
+    heads: list[str | None] | None = None,
 ) -> object:
-    """A runner whose fix cycle reaches the item loop with a readable HEAD."""
+    """A runner whose fix cycle reaches the item loop with a readable HEAD.
+
+    ``heads`` scripts consecutive ``_rev_parse_head`` answers (falling back to
+    ``_FIRST`` once exhausted) so a test can fail one specific HEAD probe; ``cmd``
+    lets a test script the ``git cat-file`` object probe the same way.
+    """
     (worktrees_root / workspace_id).mkdir(parents=True)
     runner = make_runner(
         factory=factory,
-        cmd=FakeCommandRunner(),
+        cmd=cmd if cmd is not None else FakeCommandRunner(),
         adapter=FakeAdapter(),
         sleep_fn=RecordedSleep(),
         worktrees_root=worktrees_root,
@@ -112,8 +120,10 @@ def _prepared_runner(
     async def _start_head(**_kwargs: object) -> tuple[str, None]:
         return (_BASE, None)
 
+    scripted_heads = list(heads or ())
+
     async def _rev_parse_head(_worktree_path: Path) -> str | None:
-        return _FIRST
+        return scripted_heads.pop(0) if scripted_heads else _FIRST
 
     async def _no_block(**_kwargs: object) -> None:
         return None
@@ -125,11 +135,11 @@ def _prepared_runner(
     return runner
 
 
-def _remember_pending(state: MonitorState, *, item_id: str) -> None:
+def _remember_pending(state: MonitorState, *, item_id: str, item_start_head: str = _BASE) -> None:
     comment_repair_provenance._remember_unrecorded_item_commit(
         state,
         item_id=item_id,
-        item_start_head=_BASE,
+        item_start_head=item_start_head,
         operation_id=_OPERATION_ID,
     )
 
@@ -328,6 +338,178 @@ async def test_settle_before_each_item_leaves_a_clean_batch_untouched(
         operation_id=_OPERATION_ID,
     )
 
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+    assert ws is not None
+    assert _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY not in (ws.monitor_threads_addressed or {})
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_unreadable_next_item_head_settles_the_pending_record_before_raising(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reading the *next* item's start head is itself fallible (#937).
+
+    ``_current_item_operation_start_head`` fails the cycle rather than guess, and
+    that raise is caught by the item loop's ``_MonitorHeadObjectMissingError`` arm
+    — an early exit that used to run *before* the settle, dropping item 1's held
+    record with the memory-only marker. HEAD is still readable here (only the
+    commit-object probe fails), so the record is recoverable and must be written.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    cat_file_probes = 0
+
+    def _second_cat_file(args: list[str]) -> bool:
+        nonlocal cat_file_probes
+        if "cat-file" not in args:
+            return False
+        cat_file_probes += 1
+        return cat_file_probes == 2
+
+    cmd = FakeCommandRunner()
+    cmd.respond_when(_second_cat_file, returncode=1, stderr="object missing")
+    cmd.respond_when(lambda args: "cat-file" in args, returncode=0)
+    runner = _prepared_runner(
+        factory=factory,
+        workspace_id=workspace_id,
+        worktrees_root=tmp_path / "worktrees",
+        monkeypatch=monkeypatch,
+        cmd=cmd,
+    )
+    state = MonitorState()
+    addressed: list[str] = []
+
+    async def _address(*, thread: ReviewThread, **_kwargs: object) -> str:
+        addressed.append(thread.thread_id)
+        _remember_pending(state, item_id="PRRT_first")
+        return "fix_committed"
+
+    monkeypatch.setattr(runner, "_address_thread", _address)
+
+    result = await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=_BASE,
+        initial_threads=(_thread("PRRT_first"), _thread("PRRT_second")),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        operation_id=_OPERATION_ID,
+    )
+
+    assert result.failed is True
+    # The second item never ran: its start-head probe failed first.
+    assert addressed == ["PRRT_first"]
+    assert await _persisted_item_ids(factory, workspace_id) == ["PRRT_first"]
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_pending_record_is_completed_from_the_head_already_probed(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A HEAD probe failing *after* the item's start head was read keeps the record.
+
+    The settle used to re-probe HEAD even though the item's start head had just
+    been read successfully — and nothing commits in between, so the two reads are
+    the same SHA. That redundant probe was a second chance to fail, and a failure
+    dropped a record the first read could already complete. Script the probe
+    following item 2's start head to fail; item 1's record must survive it.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = _prepared_runner(
+        factory=factory,
+        workspace_id=workspace_id,
+        worktrees_root=tmp_path / "worktrees",
+        monkeypatch=monkeypatch,
+        # item 1's start head, item 2's start head, then an unreadable probe.
+        heads=[_FIRST, _FIRST, None],
+    )
+    state = MonitorState()
+
+    async def _address(*, thread: ReviewThread, **_kwargs: object) -> str:
+        if thread.thread_id == "PRRT_first":
+            _remember_pending(state, item_id="PRRT_first")
+            return "fix_committed"
+        raise AgentVerdictProtocolError()
+
+    monkeypatch.setattr(runner, "_address_thread", _address)
+
+    result = await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=_BASE,
+        initial_threads=(_thread("PRRT_first"), _thread("PRRT_second")),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        operation_id=_OPERATION_ID,
+    )
+
+    assert result.failed is True
+    assert await _persisted_item_ids(factory, workspace_id) == ["PRRT_first"]
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_a_vanished_worktree_clears_the_marker_without_inventing_a_record(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a worktree the item's start head is the cycle-start fallback.
+
+    That SHA is *not* the pending item's end head — it predates it — so completing
+    the record from it would write a backwards range that
+    ``_item_provenance_chain_covers_range`` would then read as real. Keep the
+    settle's clearing semantics on this path.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    worktrees_root = tmp_path / "worktrees"
+    runner = _prepared_runner(
+        factory=factory,
+        workspace_id=workspace_id,
+        worktrees_root=worktrees_root,
+        monkeypatch=monkeypatch,
+    )
+    state = MonitorState()
+
+    async def _address(*, thread: ReviewThread, **_kwargs: object) -> str:
+        if thread.thread_id == "PRRT_first":
+            # An item whose start head had already advanced past the cycle start.
+            _remember_pending(state, item_id="PRRT_first", item_start_head=_FIRST)
+            shutil.rmtree(worktrees_root / workspace_id)
+            return "fix_committed"
+        raise AgentVerdictProtocolError()
+
+    monkeypatch.setattr(runner, "_address_thread", _address)
+
+    result = await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=_BASE,
+        initial_threads=(_thread("PRRT_first"), _thread("PRRT_second")),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        operation_id=_OPERATION_ID,
+    )
+
+    assert result.failed is True
     async with factory() as session:
         ws = await WorkspaceRepository(session).get(workspace_id)
     assert ws is not None

--- a/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_006.py
+++ b/tests/unit/runtime/test_comment_repair_item_provenance_parts/test_comment_repair_item_provenance_part_006.py
@@ -12,6 +12,7 @@ and before the re-raise.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import shutil
 from collections.abc import AsyncIterator
@@ -459,6 +460,58 @@ async def test_pending_record_is_completed_from_the_head_already_probed(
 
     assert result.failed is True
     assert await _persisted_item_ids(factory, workspace_id) == ["PRRT_first"]
+    assert state.pending_item_commit_provenance is None
+
+
+@pytest.mark.unit
+async def test_cancellation_in_the_settle_window_keeps_the_last_item_record(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The settle window is cancellable, and cancellation skips the pre-push settle.
+
+    ``sleep()`` and the settle re-poll can be interrupted by a worker stop/timeout:
+    ``CancelledError`` is a ``BaseException``, so it bypasses the ``ForgeClientError``
+    arm and never reaches the pre-push settle. With the marker memory-only, the
+    restart would read a chain with a hole and park the accepted commit. Settling
+    right after the items — before the window opens — closes that gap.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = _prepared_runner(
+        factory=factory,
+        workspace_id=workspace_id,
+        worktrees_root=tmp_path / "worktrees",
+        monkeypatch=monkeypatch,
+    )
+    state = MonitorState()
+
+    async def _address(*, thread: ReviewThread, **_kwargs: object) -> str:
+        _remember_pending(state, item_id=thread.thread_id)
+        return "fix_committed"
+
+    async def _cancelled_sleep(_seconds: float) -> None:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps, "sleep", _cancelled_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._run_fix_cycle(
+            workspace_id=workspace_id,
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            pr_head_sha=_BASE,
+            initial_threads=(_thread("PRRT_only"),),
+            initial_reviews=(),
+            state=state,
+            remote_branch=f"awf/{workspace_id}",
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            operation_id=_OPERATION_ID,
+        )
+
+    assert await _persisted_item_ids(factory, workspace_id) == ["PRRT_only"]
     assert state.pending_item_commit_provenance is None
 
 

--- a/tests/unit/runtime/test_pr_monitor_interrupted_repair_rollback.py
+++ b/tests/unit/runtime/test_pr_monitor_interrupted_repair_rollback.py
@@ -100,6 +100,14 @@ class _RollbackCommandRunner:
                 stdout="",
                 stderr="",
             )
+        if "log" in call:
+            # #935: the unpublished-repair disposition reads ``remote..HEAD`` subjects
+            # to name the preserved commits (and to spot legacy review-item fixes).
+            return CommandResult(
+                returncode=0,
+                stdout="deadbee chore: unrelated local work\n",
+                stderr="",
+            )
         if "diff" in call:
             return CommandResult(returncode=0, stdout="M\0src/example.py\0", stderr="")
         if "reset" in call:
@@ -839,7 +847,10 @@ async def test_ci_repair_unpublished_commit_is_not_reset_without_comment_provena
     assert all("reset" not in call for call in commands.calls)
     assert result is not None
     assert result.failed is True
-    assert result.terminal_monitor_failure is True
+    # #935: unattributable unpushed commits park for a human instead of failing
+    # the workspace — the preserved work must survive on disk.
+    assert result.parked_needs_human is True
+    assert result.terminal_monitor_failure is False
     assert result.reason_code == "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"
 
 

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_009.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_009.py
@@ -132,6 +132,8 @@ async def test_monitor_comment_diff_baseline_unavailable_terminates_with_diff_re
     cmd.queue_result(returncode=0, stdout="abc1234567890def\n")  # operation start HEAD
     cmd.queue_result(returncode=0, stdout="abc1234567890def\n")  # per-item HEAD
     cmd.queue_result(returncode=0)  # per-item HEAD object probe
+    # #935: post-item HEAD probe for commit-time comment-repair provenance.
+    cmd.queue_result(returncode=0, stdout="abc1234567890def\n")
     cmd.queue_result(returncode=0, stdout=pr_payload())  # settle-window status poll
     cmd.queue_result(returncode=128, stderr="network reset")  # committed-diff baseline fetch
     runner = make_runner(

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_016.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_016.py
@@ -586,11 +586,10 @@ async def test_deferred_capture_bitbucket_comment_failure_still_succeeds(
     # monitor), and capture still succeeds (returns True) with the issue recorded
     # as filed so a retry never opens a duplicate.
     from awf.common.bitbucket_client import BitbucketClientError
-    from awf.runtime.pr_monitor import _mark_review_thread_addressed
+    from awf.runtime.pr_monitor import _mark_review_thread_addressed, _review_thread_body_hash
     from awf.runtime.pr_monitor_runner.fix_cycle import (
         _capture_deferred_review_thread,
         _deferred_issue_filed_marker,
-        _review_thread_body_hash,
     )
 
     ws_id = await seed_monitoring_workspace(factory)

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_023.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_023.py
@@ -1,0 +1,127 @@
+"""``AddressComments`` park-for-a-human disposition in ``_execute`` (#935)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import replace
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import pytest_mock
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import RepoRef
+from awf.db.enums import OperationStatus, WorkspaceStatus
+from awf.db.repositories import OperationRepository, WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor import AddressComments, MonitorState, ReviewThread
+from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+from .test_pr_monitor_runner_part_004 import _green_status
+
+_PARK_REASON_CODE = "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+@pytest.mark.unit
+async def test_parked_comment_repair_keeps_the_workspace_monitoring_and_awaiting_human(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    thread = ReviewThread(
+        thread_id="PRRT_park",
+        path="src/app.py",
+        line=12,
+        body_excerpt="please fix",
+        author="reviewer",
+    )
+    status = replace(_green_status(), unresolved_inline_threads=(thread,))
+    park_result = _GitPushResult(
+        pushed=False,
+        failed=True,
+        returncode=1,
+        stderr="Preserved 2 unpushed comment-repair commits: 3195fc8, aa194c9.",
+        reason_code=_PARK_REASON_CODE,
+        parked_needs_human=True,
+        details={"phase": "comment_repair_recovery", "pushed": False},
+    )
+
+    async def _parked_fix_cycle(**_kwargs: object) -> _GitPushResult:
+        return park_result
+
+    mocker.patch.object(runner, "_run_fix_cycle", _parked_fix_cycle)
+
+    ended = await runner._execute(
+        action=AddressComments(threads=(thread,), review_comments=()),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=status,
+        state=MonitorState(started_at=0.0),
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert ended is True
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+        operations = await OperationRepository(session).list_all(workspace_id=workspace_id)
+    assert ws is not None
+    assert ws.status == WorkspaceStatus.monitoring_pr.value
+    assert isinstance(ws.awaiting_human_since, datetime)
+    operation = operations[0]
+    assert operation.status == OperationStatus.failed.value
+    assert operation.error_code == _PARK_REASON_CODE
+    assert operation.result is not None
+    assert operation.result["outcome"] == "comment_repair_unpublished_parked"
+    assert operation.result["reason_code"] == _PARK_REASON_CODE
+
+
+@pytest.mark.unit
+def test_parked_push_result_is_not_a_terminal_monitor_failure() -> None:
+    parked = _GitPushResult(
+        pushed=False,
+        failed=True,
+        returncode=1,
+        stderr="parked",
+        reason_code=_PARK_REASON_CODE,
+        parked_needs_human=True,
+    )
+    unparked = _GitPushResult(
+        pushed=False,
+        failed=True,
+        returncode=1,
+        stderr="missing provenance",
+        reason_code=_PARK_REASON_CODE,
+    )
+
+    assert parked.terminal_monitor_failure is False
+    # #935: the reason code itself must never terminally fail the workspace again.
+    assert unparked.terminal_monitor_failure is False

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_023.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_023.py
@@ -16,7 +16,7 @@ from awf.common.github_client import RepoRef
 from awf.db.enums import OperationStatus, WorkspaceStatus
 from awf.db.repositories import OperationRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
-from awf.runtime.pr_monitor import AddressComments, MonitorState, ReviewThread
+from awf.runtime.pr_monitor import AddressComments, MonitorState, ReviewThread, WaitForCI
 from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
 from tests.postgres import postgres_test_engine
 from tests.unit.runtime._monitor_runner_fixtures import (
@@ -44,11 +44,12 @@ async def test_parked_comment_repair_keeps_the_workspace_monitoring_and_awaiting
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     workspace_id = await seed_monitoring_workspace(factory)
+    sleep_fn = RecordedSleep()
     runner = make_runner(
         factory=factory,
         cmd=FakeCommandRunner(),
         adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
+        sleep_fn=sleep_fn,
         worktrees_root=tmp_path / "worktrees",
     )
     thread = ReviewThread(
@@ -89,7 +90,12 @@ async def test_parked_comment_repair_keeps_the_workspace_monitoring_and_awaiting
         monitor_log=None,
     )
 
-    assert ended is True
+    # NOT terminal: the parked wait is held inside this monitor's polling loop
+    # (one poll-interval sleep, like ``NotifyHuman``). Exiting the runner while the
+    # row stays ``monitoring_pr`` would let the worker reclaim it and restart a
+    # monitor every cycle, since monitor claims do not exclude awaiting-human rows.
+    assert ended is False
+    assert sleep_fn.calls == [runner._config.poll_interval_seconds]
     async with factory() as session:
         ws = await WorkspaceRepository(session).get(workspace_id)
         operations = await OperationRepository(session).list_all(workspace_id=workspace_id)
@@ -102,6 +108,103 @@ async def test_parked_comment_repair_keeps_the_workspace_monitoring_and_awaiting
     assert operation.result is not None
     assert operation.result["outcome"] == "comment_repair_unpublished_parked"
     assert operation.result["reason_code"] == _PARK_REASON_CODE
+
+
+@pytest.mark.unit
+async def test_parked_repair_keeps_one_attention_episode_across_polls(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """The parked monitor keeps polling ``AddressComments``, so the top-of-poll resume
+    clear must not null and re-stamp ``awaiting_human_since`` every poll — the operator
+    would see the wait restart forever (issue:5561887966)."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    thread = ReviewThread(
+        thread_id="PRRT_park",
+        path="src/app.py",
+        line=12,
+        body_excerpt="please fix",
+        author="reviewer",
+    )
+    status = replace(_green_status(), unresolved_inline_threads=(thread,))
+    park_result = _GitPushResult(
+        pushed=False,
+        failed=True,
+        returncode=1,
+        stderr="Preserved 1 unpushed local commit(s).",
+        reason_code=_PARK_REASON_CODE,
+        parked_needs_human=True,
+        details={"phase": "comment_repair_recovery", "pushed": False},
+    )
+    state = MonitorState(started_at=0.0)
+
+    async def _parked_fix_cycle(**kwargs: object) -> _GitPushResult:
+        # Mirrors the recovery path: parking marks the episode on the live state.
+        cycle_state = kwargs["state"]
+        assert isinstance(cycle_state, MonitorState)
+        cycle_state.mark_parked_unpublished_repair("no_comment_repair_provenance:bbb:aaa")
+        return park_result
+
+    mocker.patch.object(runner, "_run_fix_cycle", _parked_fix_cycle)
+
+    async def _poll() -> None:
+        await runner._execute(
+            action=AddressComments(threads=(thread,), review_comments=()),
+            workspace_id=workspace_id,
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            status=status,
+            state=state,
+            base_branch="development",
+            remote_branch=f"awf/{workspace_id}",
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            monitor_log=None,
+        )
+
+    await _poll()
+    async with factory() as session:
+        first = await WorkspaceRepository(session).get(workspace_id)
+    assert first is not None
+    awaiting_since = first.awaiting_human_since
+    assert isinstance(awaiting_since, datetime)
+
+    await _poll()
+    async with factory() as session:
+        second = await WorkspaceRepository(session).get(workspace_id)
+    assert second is not None
+    assert second.awaiting_human_since == awaiting_since
+
+    # Once ``decide()`` leaves the repair arm the episode is over: the marker is
+    # dropped and the normal resume clear retires the attention flag.
+    await runner._execute(
+        action=WaitForCI(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=status,
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+    assert state.parked_unpublished_repair is None
+    async with factory() as session:
+        third = await WorkspaceRepository(session).get(workspace_id)
+    assert third is not None
+    assert third.awaiting_human_since is None
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_023.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_023.py
@@ -208,6 +208,73 @@ async def test_parked_repair_keeps_one_attention_episode_across_polls(
 
 
 @pytest.mark.unit
+async def test_successful_repair_cycle_clears_a_stale_park_marker(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """A repair cycle that pushes ends the park episode (PRRT_kwDOSJAM6s6fu_-o).
+
+    After an operator follows the documented recovery, the next cycle can push
+    normally while unresolved feedback keeps ``decide()`` on ``AddressComments``.
+    The success path used to clear only the workflow-scope marker, so the obsolete
+    park marker kept gating this arm's attention clear and stranded
+    ``awaiting_human_since`` until the action itself changed.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    thread = ReviewThread(
+        thread_id="PRRT_park",
+        path="src/app.py",
+        line=12,
+        body_excerpt="please fix",
+        author="reviewer",
+    )
+    status = replace(_green_status(), unresolved_inline_threads=(thread,))
+    state = MonitorState(started_at=0.0)
+    state.mark_parked_unpublished_repair("no_comment_repair_provenance:bbb:aaa")
+    await runner._set_workspace_attention(workspace_id, reason="parked commits")
+
+    async def _pushed_fix_cycle(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=True, failed=False, returncode=0)
+
+    mocker.patch.object(runner, "_run_fix_cycle", _pushed_fix_cycle)
+
+    async def _poll() -> None:
+        await runner._execute(
+            action=AddressComments(threads=(thread,), review_comments=()),
+            workspace_id=workspace_id,
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            status=status,
+            state=state,
+            base_branch="development",
+            remote_branch=f"awf/{workspace_id}",
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            monitor_log=None,
+        )
+
+    await _poll()
+    assert state.parked_unpublished_repair is None
+
+    # The next poll stays on ``AddressComments``; with the marker retired the
+    # resume clear must now retire the stale attention episode too.
+    await _poll()
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+    assert ws is not None
+    assert ws.awaiting_human_since is None
+
+
+@pytest.mark.unit
 def test_parked_push_result_is_not_a_terminal_monitor_failure() -> None:
     parked = _GitPushResult(
         pushed=False,

--- a/tests/unit/runtime/test_pr_monitor_unpublished_repair_provenance.py
+++ b/tests/unit/runtime/test_pr_monitor_unpublished_repair_provenance.py
@@ -66,6 +66,14 @@ class _RollbackCommandRunner:
                 stdout="",
                 stderr="",
             )
+        if "log" in call:
+            # #935: the unpublished-repair disposition reads ``remote..HEAD`` subjects
+            # to name the preserved commits (and to spot legacy review-item fixes).
+            return CommandResult(
+                returncode=0,
+                stdout="deadbee chore: unrelated local work\n",
+                stderr="",
+            )
         if "diff" in call:
             return CommandResult(returncode=0, stdout="M\0src/example.py\0", stderr="")
         if "reset" in call:
@@ -182,7 +190,10 @@ async def test_operator_hint_unpublished_commit_is_not_reset_without_comment_pro
     assert all("reset" not in call for call in commands.calls)
     assert result is not None
     assert result.failed is True
-    assert result.terminal_monitor_failure is True
+    # #935: unattributable unpushed commits park for a human instead of failing
+    # the workspace — the preserved work must survive on disk.
+    assert result.parked_needs_human is True
+    assert result.terminal_monitor_failure is False
     assert result.reason_code == "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"
 
 
@@ -551,7 +562,10 @@ async def test_failed_comment_repair_without_terminal_head_is_not_reset(
     assert all("reset" not in call for call in commands.calls)
     assert result is not None
     assert result.failed is True
-    assert result.terminal_monitor_failure is True
+    # #935: unattributable unpushed commits park for a human instead of failing
+    # the workspace — the preserved work must survive on disk.
+    assert result.parked_needs_human is True
+    assert result.terminal_monitor_failure is False
     assert result.reason_code == "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"
 
 

--- a/tests/unit/runtime/test_pr_monitor_unpublished_repair_provenance.py
+++ b/tests/unit/runtime/test_pr_monitor_unpublished_repair_provenance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -14,6 +15,7 @@ from awf.db.enums import OperationStatus, OperationType
 from awf.db.models import Operation
 from awf.db.repositories import OperationRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
+from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
 from awf.runtime.pr_monitor import MonitorState
 from awf.runtime.pr_monitor_operations import build_monitor_operation_payload
 from awf.runtime.pr_monitor_runner import remote_repair_unpublished
@@ -28,10 +30,12 @@ class _RollbackCommandRunner:
         remote_head: str,
         local_head: str,
         ancestry: dict[tuple[str, str], bool] | None = None,
+        commit_log_stdout: str = "deadbee chore: unrelated local work\n",
     ) -> None:
         self.remote_head = remote_head
         self.local_head = local_head
         self.ancestry = ancestry
+        self.commit_log_stdout = commit_log_stdout
         self.calls: list[tuple[str, ...]] = []
 
     def _is_ancestor(self, ancestor: str, descendant: str) -> bool:
@@ -69,11 +73,7 @@ class _RollbackCommandRunner:
         if "log" in call:
             # #935: the unpublished-repair disposition reads ``remote..HEAD`` subjects
             # to name the preserved commits (and to spot legacy review-item fixes).
-            return CommandResult(
-                returncode=0,
-                stdout="deadbee chore: unrelated local work\n",
-                stderr="",
-            )
+            return CommandResult(returncode=0, stdout=self.commit_log_stdout, stderr="")
         if "diff" in call:
             return CommandResult(returncode=0, stdout="M\0src/example.py\0", stderr="")
         if "reset" in call:
@@ -567,6 +567,73 @@ async def test_failed_comment_repair_without_terminal_head_is_not_reset(
     assert result.parked_needs_human is True
     assert result.terminal_monitor_failure is False
     assert result.reason_code == "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"
+
+
+@pytest.mark.unit
+async def test_second_batch_after_a_push_resumes_via_the_chain_not_the_subject_fallback(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """#937: a restart in the batch AFTER a push must resume through the chain.
+
+    The first batch's commit was pushed, so the PR head is now ``pushed_head``;
+    the second batch committed one accepted item on top of it and the worker died
+    before its own push. A chain that outlived the first push is rooted at the
+    pre-push base, and its suffix is what describes ``pushed_head..HEAD``.
+    Without that, the disposition falls through to commit-subject matching — which
+    these subjects defeat — and parks resumable repair work.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    pre_push_base = "a" * 40
+    pushed_head = "b" * 40
+    unpublished_repair = "c" * 40
+    (tmp_path / workspace_id).mkdir()
+    (tmp_path / workspace_id / ".git").write_text("gitdir: test\n", encoding="utf-8")
+    commands = _RollbackCommandRunner(
+        remote_head=pushed_head,
+        local_head=unpublished_repair,
+        commit_log_stdout="deadbee test: address the flaky monitor poll\n",
+    )
+    runner = _runner(tmp_path, commands)
+    runner._deps.session_factory = factory
+    state = MonitorState()
+    state.mark_addressed(
+        _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY,
+        json.dumps(
+            [
+                {
+                    "item_id": "PRRT_first_batch",
+                    "item_start_head": pre_push_base,
+                    "head_sha": pushed_head,
+                    "operation_id": "op_first_batch",
+                },
+                {
+                    "item_id": "PRRT_second_batch",
+                    "item_start_head": pushed_head,
+                    "head_sha": unpublished_repair,
+                    "operation_id": "op_first_batch",
+                },
+            ],
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+    )
+
+    restored_head, result = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=tmp_path / workspace_id,
+        remote_branch="fix/review",
+        expected_remote_head=pushed_head,
+        local_head=unpublished_repair,
+        state=state,
+        current_operation_id="op_second_batch",
+    )
+
+    assert result is None
+    assert restored_head == unpublished_repair
+    assert commands.local_head == unpublished_repair
+    assert all("reset" not in call for call in commands.calls)
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_unpublished_repair_recovery_parts/test_pr_monitor_unpublished_repair_recovery_part_001.py
+++ b/tests/unit/runtime/test_pr_monitor_unpublished_repair_recovery_parts/test_pr_monitor_unpublished_repair_recovery_part_001.py
@@ -1,0 +1,439 @@
+"""Post-restart recovery preserves accepted comment-repair commits (#935, part 001).
+
+A control-plane restart mid ``AddressComments`` batch leaves accepted item commits
+local and unpushed. Recovery must resume the batch when those commits are provably
+AWF repair work, and otherwise park the workspace for a human with the worktree
+intact — never terminally fail it, never reset unknown commits.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from awf.common.commands import CommandResult
+from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
+from awf.runtime.pr_monitor import MonitorState
+from awf.runtime.pr_monitor_runner import remote_repair_unpublished
+
+_REMOTE_HEAD = "a" * 40
+_ADVANCED_REMOTE_HEAD = "f" * 40
+_LOCAL_HEAD = "b" * 40
+
+
+class _RecoveryCommandRunner:
+    """Command runner that models a worktree ahead of the fetched PR head."""
+
+    def __init__(
+        self,
+        *,
+        remote_head: str,
+        local_head: str,
+        ancestry: dict[tuple[str, str], bool] | None = None,
+        log_stdout: str = "",
+        log_ok: bool = True,
+    ) -> None:
+        self.remote_head = remote_head
+        self.local_head = local_head
+        self.ancestry = ancestry
+        self.log_stdout = log_stdout
+        self.log_ok = log_ok
+        self.calls: list[tuple[str, ...]] = []
+
+    def _resolve(self, ref: str) -> str:
+        if ref == "FETCH_HEAD":
+            return self.remote_head
+        if ref == "HEAD":
+            return self.local_head
+        return ref
+
+    def _is_ancestor(self, ancestor: str, descendant: str) -> bool:
+        if ancestor == descendant:
+            return True
+        if self.ancestry is not None:
+            return self.ancestry.get((ancestor, descendant), False)
+        return True
+
+    async def run(self, args: list[str], **_kwargs: object) -> CommandResult:
+        call = tuple(args)
+        self.calls.append(call)
+        if "rev-parse" in call:
+            return CommandResult(
+                returncode=0,
+                stdout=f"{self._resolve(call[call.index('rev-parse') + 1])}\n",
+                stderr="",
+            )
+        if "merge-base" in call and "--is-ancestor" in call:
+            index = call.index("--is-ancestor")
+            ok = self._is_ancestor(self._resolve(call[index + 1]), self._resolve(call[index + 2]))
+            return CommandResult(returncode=0 if ok else 1, stdout="", stderr="")
+        if "log" in call:
+            return CommandResult(
+                returncode=0 if self.log_ok else 128,
+                stdout=self.log_stdout,
+                stderr="" if self.log_ok else "fatal: bad revision",
+            )
+        if "diff" in call:
+            return CommandResult(returncode=0, stdout="M\0src/example.py\0", stderr="")
+        if "reset" in call:
+            self.local_head = self.remote_head
+            return CommandResult(returncode=0, stdout="", stderr="")
+        if "status" in call:
+            return CommandResult(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected command: {call}")
+
+
+class _RecoveryRunner(SimpleNamespace):
+    """Runner seam recording the operator-facing side effects of recovery."""
+
+
+def _runner(tmp_path: Path, commands: _RecoveryCommandRunner) -> _RecoveryRunner:
+    recorded: list[object] = []
+
+    async def _fetch(**_kwargs: object) -> CommandResult:
+        return CommandResult(returncode=0, stdout="", stderr="")
+
+    async def _append_events(*, workspace_id: str, events: list[object]) -> None:
+        del workspace_id
+        recorded.extend(events)
+
+    return _RecoveryRunner(
+        _worktrees_root=tmp_path,
+        _deps=SimpleNamespace(runner=commands),
+        _remote_branch_fetch_once=_fetch,
+        _append_workspace_events=_append_events,
+        appended_events=recorded,
+    )
+
+
+def _worktree(tmp_path: Path, workspace_id: str) -> Path:
+    worktree = tmp_path / workspace_id
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: test\n", encoding="utf-8")
+    return worktree
+
+
+def _chain_state(records: list[dict[str, object]]) -> MonitorState:
+    state = MonitorState()
+    state.mark_addressed(
+        _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY,
+        json.dumps(records, separators=(",", ":"), sort_keys=True),
+    )
+    return state
+
+
+@pytest.fixture(autouse=True)
+def _verified_layout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        remote_repair_unpublished,
+        "_verified_awf_comment_repair_worktree",
+        lambda **_kwargs: True,
+    )
+
+    async def _ownership_ok(**_kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(remote_repair_unpublished, "repair_agent_runtime_ownership", _ownership_ok)
+
+
+def _patch_operation_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    comment_repair: bool,
+    conflicting: bool,
+) -> None:
+    async def _comment(*_args: object, **_kwargs: object) -> bool:
+        return comment_repair
+
+    async def _conflicting(*_args: object, **_kwargs: object) -> bool:
+        return conflicting
+
+    monkeypatch.setattr(
+        remote_repair_unpublished,
+        "_unpublished_comment_repair_has_operation_provenance",
+        _comment,
+    )
+    monkeypatch.setattr(
+        remote_repair_unpublished,
+        "_unpublished_non_comment_repair_has_operation_provenance",
+        _conflicting,
+    )
+
+
+@pytest.mark.unit
+async def test_restart_mid_batch_with_item_chain_resumes_the_batch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = "ws_chain_resume"
+    _worktree(tmp_path, workspace_id)
+    commands = _RecoveryCommandRunner(remote_head=_REMOTE_HEAD, local_head=_LOCAL_HEAD)
+    runner = _runner(tmp_path, commands)
+    _patch_operation_provenance(monkeypatch, comment_repair=False, conflicting=False)
+    state = _chain_state(
+        [
+            {
+                "item_id": "PRRT_kwDOSJAM6s6fjOze",
+                "item_start_head": _REMOTE_HEAD,
+                "head_sha": _LOCAL_HEAD,
+                "operation_id": "op_comment_repair",
+            }
+        ]
+    )
+
+    restored_head, result = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=tmp_path / workspace_id,
+        remote_branch="fix/review",
+        expected_remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        state=state,
+        current_operation_id="op_comment_repair",
+    )
+
+    assert result is None
+    assert restored_head == _LOCAL_HEAD
+    assert commands.local_head == _LOCAL_HEAD
+    assert all("reset" not in call for call in commands.calls)
+    assert [event.reason_code for event in runner.appended_events] == [
+        "COMMENT_REPAIR_UNPUBLISHED_PRESERVED"
+    ]
+
+
+@pytest.mark.unit
+async def test_legacy_review_item_subjects_resume_the_batch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = "ws_legacy_resume"
+    _worktree(tmp_path, workspace_id)
+    commands = _RecoveryCommandRunner(
+        remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        log_stdout=(
+            "3195fc8 fix: address PR review thread PRRT_kwDOSJAM6s6fjOze\n"
+            "aa194c9 test: cover the new guard\n"
+        ),
+    )
+    runner = _runner(tmp_path, commands)
+    _patch_operation_provenance(monkeypatch, comment_repair=False, conflicting=False)
+
+    restored_head, result = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=tmp_path / workspace_id,
+        remote_branch="fix/review",
+        expected_remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        state=MonitorState(),
+        current_operation_id="op_comment_repair",
+    )
+
+    assert result is None
+    assert restored_head == _LOCAL_HEAD
+    assert all("reset" not in call for call in commands.calls)
+    assert [event.reason_code for event in runner.appended_events] == [
+        "COMMENT_REPAIR_UNPUBLISHED_PRESERVED"
+    ]
+
+
+@pytest.mark.unit
+async def test_unknown_local_commits_park_for_a_human_without_failing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = "ws_park"
+    _worktree(tmp_path, workspace_id)
+    commands = _RecoveryCommandRunner(
+        remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        log_stdout="3195fc8 chore: unrelated local work\n",
+    )
+    runner = _runner(tmp_path, commands)
+    _patch_operation_provenance(monkeypatch, comment_repair=False, conflicting=False)
+
+    restored_head, result = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=tmp_path / workspace_id,
+        remote_branch="fix/review",
+        expected_remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        state=MonitorState(),
+        current_operation_id="op_comment_repair",
+    )
+
+    assert restored_head == _LOCAL_HEAD
+    assert commands.local_head == _LOCAL_HEAD
+    assert all("reset" not in call and "checkout" not in call for call in commands.calls)
+    assert result is not None
+    assert result.failed is True
+    assert result.parked_needs_human is True
+    assert result.terminal_monitor_failure is False
+    assert result.reason_code == "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"
+    # The park reason names the preserved commits so the operator can inspect them.
+    assert "3195fc8" in result.stderr
+    assert "chore: unrelated local work" in result.stderr
+    assert [event.reason_code for event in runner.appended_events] == [
+        "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"
+    ]
+
+
+@pytest.mark.unit
+async def test_unreadable_commit_log_parks_instead_of_preserving(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = "ws_park_log_failed"
+    _worktree(tmp_path, workspace_id)
+    commands = _RecoveryCommandRunner(
+        remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        log_ok=False,
+    )
+    runner = _runner(tmp_path, commands)
+    _patch_operation_provenance(monkeypatch, comment_repair=False, conflicting=False)
+
+    _restored_head, result = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=tmp_path / workspace_id,
+        remote_branch="fix/review",
+        expected_remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        state=MonitorState(),
+        current_operation_id="op_comment_repair",
+    )
+
+    assert result is not None
+    assert result.parked_needs_human is True
+    assert all("reset" not in call for call in commands.calls)
+
+
+@pytest.mark.unit
+async def test_stale_snapshot_advance_with_chain_parks_instead_of_preserving(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The remote advanced past the batch base, so the preserved commits could not
+    fast-forward. Park rather than resume a push that cannot land."""
+    workspace_id = "ws_stale_snapshot"
+    _worktree(tmp_path, workspace_id)
+    commands = _RecoveryCommandRunner(
+        remote_head=_ADVANCED_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        ancestry={
+            (_REMOTE_HEAD, _ADVANCED_REMOTE_HEAD): True,
+            (_ADVANCED_REMOTE_HEAD, _LOCAL_HEAD): False,
+            (_LOCAL_HEAD, _ADVANCED_REMOTE_HEAD): False,
+            (_REMOTE_HEAD, _LOCAL_HEAD): True,
+        },
+        log_stdout="3195fc8 fix: address PR review thread PRRT_kwDOSJAM6s6fjOze\n",
+    )
+    runner = _runner(tmp_path, commands)
+    _patch_operation_provenance(monkeypatch, comment_repair=False, conflicting=False)
+    state = _chain_state(
+        [
+            {
+                "item_id": "PRRT_kwDOSJAM6s6fjOze",
+                "item_start_head": _REMOTE_HEAD,
+                "head_sha": _LOCAL_HEAD,
+                "operation_id": "op_comment_repair",
+            }
+        ]
+    )
+
+    _restored_head, result = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=tmp_path / workspace_id,
+        remote_branch="fix/review",
+        expected_remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        state=state,
+        current_operation_id="op_comment_repair",
+    )
+
+    assert result is not None
+    assert result.parked_needs_human is True
+    assert result.reason_code == "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"
+    assert all("reset" not in call for call in commands.calls)
+
+
+@pytest.mark.unit
+async def test_conflicting_repair_provenance_parks_and_never_resets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = "ws_conflicting"
+    _worktree(tmp_path, workspace_id)
+    commands = _RecoveryCommandRunner(
+        remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        log_stdout="3195fc8 fix: address PR review thread PRRT_kwDOSJAM6s6fjOze\n",
+    )
+    runner = _runner(tmp_path, commands)
+    _patch_operation_provenance(monkeypatch, comment_repair=True, conflicting=True)
+    state = _chain_state(
+        [
+            {
+                "item_id": "PRRT_kwDOSJAM6s6fjOze",
+                "item_start_head": _REMOTE_HEAD,
+                "head_sha": _LOCAL_HEAD,
+                "operation_id": "op_comment_repair",
+            }
+        ]
+    )
+
+    _restored_head, result = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=tmp_path / workspace_id,
+        remote_branch="fix/review",
+        expected_remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        state=state,
+        current_operation_id="op_comment_repair",
+    )
+
+    assert result is not None
+    assert result.parked_needs_human is True
+    assert commands.local_head == _LOCAL_HEAD
+    assert all("reset" not in call for call in commands.calls)
+
+
+@pytest.mark.unit
+async def test_operation_level_provenance_still_resets_as_before(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard: an operation-owned interrupted repair is still abandoned."""
+    workspace_id = "ws_operation_reset"
+    _worktree(tmp_path, workspace_id)
+    commands = _RecoveryCommandRunner(remote_head=_REMOTE_HEAD, local_head=_LOCAL_HEAD)
+    runner = _runner(tmp_path, commands)
+    runner._persist_state = _noop_persist_state
+    _patch_operation_provenance(monkeypatch, comment_repair=True, conflicting=False)
+
+    restored_head, result = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=tmp_path / workspace_id,
+        remote_branch="fix/review",
+        expected_remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        state=MonitorState(),
+        current_operation_id="op_comment_repair",
+    )
+
+    assert result is None
+    assert restored_head == _REMOTE_HEAD
+    assert any("reset" in call for call in commands.calls)
+
+
+async def _noop_persist_state(_workspace_id: str, _state: MonitorState) -> None:
+    return None

--- a/tests/unit/runtime/test_pr_monitor_unpublished_repair_recovery_parts/test_pr_monitor_unpublished_repair_recovery_part_001.py
+++ b/tests/unit/runtime/test_pr_monitor_unpublished_repair_recovery_parts/test_pr_monitor_unpublished_repair_recovery_part_001.py
@@ -435,5 +435,81 @@ async def test_operation_level_provenance_still_resets_as_before(
     assert any("reset" in call for call in commands.calls)
 
 
+@pytest.mark.unit
+async def test_re_parking_the_same_situation_audits_the_episode_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The monitor keeps polling while parked, so re-parking the SAME commits on a
+    later poll must not append another park event (issue:5561887966)."""
+    workspace_id = "ws_park_repeat"
+    _worktree(tmp_path, workspace_id)
+    commands = _RecoveryCommandRunner(
+        remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        log_stdout="3195fc8 chore: unrelated local work\n",
+    )
+    runner = _runner(tmp_path, commands)
+    _patch_operation_provenance(monkeypatch, comment_repair=False, conflicting=False)
+    state = MonitorState()
+
+    for _poll in range(3):
+        (
+            _restored_head,
+            result,
+        ) = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+            runner,
+            workspace_id=workspace_id,
+            worktree_path=tmp_path / workspace_id,
+            remote_branch="fix/review",
+            expected_remote_head=_REMOTE_HEAD,
+            local_head=_LOCAL_HEAD,
+            state=state,
+            current_operation_id="op_comment_repair",
+        )
+        # Every poll still parks (and never resets) — only the audit is deduped.
+        assert result is not None
+        assert result.parked_needs_human is True
+
+    assert state.parked_unpublished_repair is not None
+    assert [event.reason_code for event in runner.appended_events] == [
+        "COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING"
+    ]
+
+
+@pytest.mark.unit
+async def test_park_marker_is_dropped_once_the_commits_become_resumable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later poll that preserves (or resets) the range ends the parked episode, so
+    the runner stops holding the awaiting-human attention flag."""
+    workspace_id = "ws_park_then_resume"
+    _worktree(tmp_path, workspace_id)
+    commands = _RecoveryCommandRunner(
+        remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        log_stdout="3195fc8 fix: address PR review thread PRRT_kwDOSJAM6s6fjOze\n",
+    )
+    runner = _runner(tmp_path, commands)
+    _patch_operation_provenance(monkeypatch, comment_repair=False, conflicting=False)
+    state = MonitorState()
+    state.mark_parked_unpublished_repair("conflicting_repair_provenance:stale:stale")
+
+    _restored_head, result = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=tmp_path / workspace_id,
+        remote_branch="fix/review",
+        expected_remote_head=_REMOTE_HEAD,
+        local_head=_LOCAL_HEAD,
+        state=state,
+        current_operation_id="op_comment_repair",
+    )
+
+    assert result is None
+    assert state.parked_unpublished_repair is None
+
+
 async def _noop_persist_state(_workspace_id: str, _state: MonitorState) -> None:
     return None

--- a/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_002.py
+++ b/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_002.py
@@ -1061,3 +1061,36 @@ async def test_abandon_behind_remote_ff_leaves_push_tracking_on_refused_reset(
     assert result.failed is True
     assert state.last_push_sha == _ORPHANED_HOSTED_TERMINAL
     assert state.hosted_terminal_head_advanced is True
+
+
+@pytest.mark.unit
+async def test_matching_heads_clear_stale_parked_unpublished_repair_marker(
+    tmp_path: Path,
+) -> None:
+    """A resolved park range must retire its marker on the equality path.
+
+    Regression for PRRT_kwDOSJAM6s6fu_-o: when an operator follows the documented
+    recovery and resets (or pushes) the parked commits, local HEAD is back at the
+    accepted remote tip so there is nothing left to park. Unresolved feedback keeps
+    ``decide()`` on ``AddressComments``, and that arm's attention clear is gated on
+    the park marker — so leaving the marker set here strands the operator-visible
+    ``awaiting_human_since`` and park reason until the action itself changes.
+    """
+    worktree = _repair_worktree(tmp_path)
+    remote = _PUBLISHED_PR_HEAD
+    state = _hosted_orphan_monitor_state()
+    state.mark_parked_unpublished_repair(f"no_comment_repair_provenance:{'aa' * 20}:{remote}")
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout=f"{remote}\n")
+    restored, result = await remote_repair_unpublished._abandon_unpublished_comment_repairs(
+        _repair_runner(tmp_path, cmd),
+        workspace_id="ws_repair",
+        worktree_path=worktree,
+        remote_branch="fix/review",
+        expected_remote_head=remote,
+        local_head=remote,
+        state=state,
+    )
+    assert result is None
+    assert restored == remote
+    assert state.parked_unpublished_repair is None

--- a/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
+++ b/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
@@ -1,0 +1,258 @@
+"""Item-provenance chain coverage and legacy subject matching (part 004, #935)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
+from awf.runtime.pr_monitor import MonitorState
+from awf.runtime.pr_monitor_runner import comment_repair_provenance as _repair_provenance
+from awf.runtime.pr_monitor_runner import remote_repair_unpublished_provenance as _provenance
+
+_BASE = "a" * 40
+_FIRST = "b" * 40
+_SECOND = "c" * 40
+_FOREIGN = "d" * 40
+
+
+def _chain_state(records: list[dict[str, object]]) -> MonitorState:
+    state = MonitorState()
+    state.mark_addressed(
+        _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY,
+        json.dumps(records, separators=(",", ":"), sort_keys=True),
+    )
+    return state
+
+
+def _record(item_id: str, start: str, head: str) -> dict[str, object]:
+    return {
+        "item_id": item_id,
+        "item_start_head": start,
+        "head_sha": head,
+        "operation_id": "op_comment_repair",
+    }
+
+
+@pytest.mark.unit
+def test_chain_covers_exact_two_item_range() -> None:
+    state = _chain_state([_record("PRRT_one", _BASE, _FIRST), _record("PRRT_two", _FIRST, _SECOND)])
+
+    assert (
+        _provenance._item_provenance_chain_covers_range(
+            state,
+            base_head=_BASE.upper(),
+            head_sha=_SECOND,
+        )
+        is True
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("records", "base", "head"),
+    [
+        pytest.param(
+            [_record("PRRT_one", _BASE, _FIRST), _record("PRRT_two", _FOREIGN, _SECOND)],
+            _BASE,
+            _SECOND,
+            id="broken_link",
+        ),
+        pytest.param(
+            [_record("PRRT_one", _FOREIGN, _FIRST)],
+            _BASE,
+            _FIRST,
+            id="wrong_base",
+        ),
+        pytest.param(
+            [_record("PRRT_one", _BASE, _FIRST)],
+            _BASE,
+            _SECOND,
+            id="wrong_tip",
+        ),
+        pytest.param([], _BASE, _FIRST, id="empty_chain"),
+    ],
+)
+def test_chain_coverage_fails_closed(
+    records: list[dict[str, object]],
+    base: str,
+    head: str,
+) -> None:
+    state = _chain_state(records)
+
+    assert (
+        _provenance._item_provenance_chain_covers_range(state, base_head=base, head_sha=head)
+        is False
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw",
+    ["{not-json", json.dumps({"item_id": "x"}), json.dumps([{"item_id": "x"}]), "", "   "],
+)
+def test_chain_coverage_rejects_malformed_marker(raw: str) -> None:
+    state = MonitorState()
+    state.mark_addressed(_COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY, raw)
+
+    assert (
+        _provenance._item_provenance_chain_covers_range(state, base_head=_BASE, head_sha=_FIRST)
+        is False
+    )
+
+
+@pytest.mark.unit
+def test_chain_coverage_absent_marker_is_false() -> None:
+    assert (
+        _provenance._item_provenance_chain_covers_range(
+            MonitorState(),
+            base_head=_BASE,
+            head_sha=_FIRST,
+        )
+        is False
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "subject",
+    [
+        "fix: address PR review thread PRRT_kwDOSJAM6s6fjOze",
+        "fix: address PR review comment issue:4688598838",
+        "fix: address review comment issue:4688598838 — tighten the guard",
+        "fix: address PRRT_kwDOSJAM6s6fjOze — tighten the guard",
+        "fix: address PR review comment 4688598838",
+    ],
+)
+def test_review_item_commit_subject_matches_awf_shapes(subject: str) -> None:
+    assert _provenance._is_review_item_commit_subject(subject) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "subject",
+    [
+        "fix: address operator hint",
+        "fix: address PR #922 CI failure",
+        "chore: unrelated local work",
+        "fix: address the reviewer feedback",
+        "",
+    ],
+)
+def test_review_item_commit_subject_rejects_unrelated_subjects(subject: str) -> None:
+    assert _provenance._is_review_item_commit_subject(subject) is False
+
+
+@pytest.mark.unit
+def test_park_reason_names_short_shas_and_subjects() -> None:
+    reason = _provenance._unpublished_repair_park_reason(
+        (
+            ("3195fc8", "fix: address PRRT_kwDOSJAM6s6fjOze — guard"),
+            ("aa194c9", "test: cover the guard"),
+        )
+    )
+
+    assert "3195fc8" in reason
+    assert "aa194c9" in reason
+    assert "fix: address PRRT_kwDOSJAM6s6fjOze — guard" in reason
+
+
+@pytest.mark.unit
+def test_park_reason_without_commit_log_still_names_the_range() -> None:
+    reason = _provenance._unpublished_repair_park_reason(())
+
+    assert "unpushed" in reason.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("stdout", "expected"),
+    [
+        pytest.param("", (), id="empty"),
+        pytest.param(
+            "3195fc8 fix: address PRRT_one — guard\naa194c9 test: cover\n",
+            (
+                ("3195fc8", "fix: address PRRT_one — guard"),
+                ("aa194c9", "test: cover"),
+            ),
+            id="two_commits",
+        ),
+        pytest.param("deadbee\n", (("deadbee", ""),), id="subjectless"),
+        pytest.param("\n  \nabc1234 fix: x\n", (("abc1234", "fix: x"),), id="blank_lines"),
+    ],
+)
+def test_parse_commit_log_entries(stdout: str, expected: tuple[tuple[str, str], ...]) -> None:
+    assert _provenance._parse_commit_log_entries(stdout) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param(json.dumps(["not-a-mapping"]), id="non_mapping_entry"),
+        pytest.param(
+            json.dumps([{"item_id": 7, "item_start_head": _BASE, "head_sha": _FIRST}]),
+            id="non_string_item_id",
+        ),
+        pytest.param(
+            json.dumps([{"item_id": "  ", "item_start_head": _BASE, "head_sha": _FIRST}]),
+            id="blank_item_id",
+        ),
+    ],
+)
+def test_decode_chain_rejects_malformed_records(raw: str) -> None:
+    assert _repair_provenance.decode_item_commit_provenance_chain(raw) == ()
+
+
+@pytest.mark.unit
+def test_decode_chain_normalises_a_non_string_operation_id() -> None:
+    chain = _repair_provenance.decode_item_commit_provenance_chain(
+        json.dumps(
+            [
+                {
+                    "item_id": "PRRT_one",
+                    "item_start_head": f" {_BASE} ",
+                    "head_sha": _FIRST,
+                    "operation_id": 12,
+                }
+            ]
+        )
+    )
+
+    assert len(chain) == 1
+    assert chain[0].operation_id is None
+    assert chain[0].item_start_head == _BASE
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("base", "head"), [("", _FIRST), (_BASE, "")])
+def test_chain_coverage_rejects_blank_endpoints(base: str, head: str) -> None:
+    state = _chain_state([_record("PRRT_one", _BASE, _FIRST)])
+
+    assert (
+        _provenance._item_provenance_chain_covers_range(state, base_head=base, head_sha=head)
+        is False
+    )
+
+
+@pytest.mark.unit
+def test_park_reason_truncates_a_long_commit_list() -> None:
+    entries = tuple((f"sha{index:04d}", f"chore: change {index}") for index in range(13))
+
+    reason = _provenance._unpublished_repair_park_reason(entries)
+
+    assert "(+3 more)" in reason
+    assert "sha0012" not in reason
+
+
+@pytest.mark.unit
+async def test_disposition_event_without_an_event_sink_is_a_no_op() -> None:
+    await _provenance._append_disposition_event(
+        SimpleNamespace(),
+        workspace_id="ws_hosted",
+        event_type="monitor.comment_repair_unpublished_parked",
+        reason_code="COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING",
+        payload={"pushed": False},
+    )

--- a/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
+++ b/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
@@ -253,6 +253,61 @@ def test_decode_chain_normalises_a_non_string_operation_id() -> None:
 
 
 @pytest.mark.unit
+def test_chain_coverage_accepts_the_suffix_after_a_published_base() -> None:
+    """#937: a chain that outlived a push is rooted behind the current PR head.
+
+    The first record's commit is already on the remote, so only the records from
+    the fetched head onwards describe ``remote..HEAD`` — and they must be accepted
+    instead of defeating the chain path and falling back to subject matching.
+    """
+    state = _chain_state([_record("PRRT_one", _BASE, _FIRST), _record("PRRT_two", _FIRST, _SECOND)])
+
+    assert (
+        _provenance._item_provenance_chain_covers_range(
+            state,
+            base_head=_FIRST,
+            head_sha=_SECOND,
+        )
+        is True
+    )
+
+
+@pytest.mark.unit
+def test_chain_coverage_rejects_a_suffix_that_stops_short_of_head() -> None:
+    """The suffix must still end at the current HEAD, not merely start at the base."""
+    state = _chain_state([_record("PRRT_one", _BASE, _FIRST), _record("PRRT_two", _FIRST, _SECOND)])
+
+    assert (
+        _provenance._item_provenance_chain_covers_range(
+            state,
+            base_head=_FIRST,
+            head_sha=_FOREIGN,
+        )
+        is False
+    )
+
+
+@pytest.mark.unit
+def test_chain_coverage_rejects_a_broken_link_inside_the_suffix() -> None:
+    state = _chain_state(
+        [
+            _record("PRRT_one", _BASE, _FIRST),
+            _record("PRRT_two", _FIRST, _SECOND),
+            _record("PRRT_three", _FOREIGN, _BASE),
+        ]
+    )
+
+    assert (
+        _provenance._item_provenance_chain_covers_range(
+            state,
+            base_head=_FIRST,
+            head_sha=_BASE,
+        )
+        is False
+    )
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(("base", "head"), [("", _FIRST), (_BASE, "")])
 def test_chain_coverage_rejects_blank_endpoints(base: str, head: str) -> None:
     state = _chain_state([_record("PRRT_one", _BASE, _FIRST)])

--- a/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
+++ b/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
@@ -409,6 +409,80 @@ async def test_park_disposition_survives_a_failing_event_sink(error: Exception) 
     assert push_result.details["disposition"] == "conflicting_repair_provenance"
 
 
+class _FlakyEventSinkRunner:
+    """Runner whose audit-event sink fails the first ``failures`` writes."""
+
+    def __init__(self, *, failures: int) -> None:
+        self._failures = failures
+        self.appended: list[str] = []
+        self._deps = SimpleNamespace(runner=SimpleNamespace(run=self._run))
+
+    async def _run(self, _args: list[str], **_kwargs: object) -> CommandResult:
+        return CommandResult(
+            returncode=0,
+            stdout="deadbee chore: unrelated local work\n",
+            stderr="",
+        )
+
+    async def _append_workspace_events(self, *, workspace_id: str, events: list[object]) -> None:
+        del workspace_id
+        if self._failures > 0:
+            self._failures -= 1
+            raise SQLAlchemyError("event sink unavailable")
+        self.appended.extend(getattr(event, "event_type", "") for event in events)
+
+
+@pytest.mark.unit
+async def test_park_retries_the_audit_event_until_the_sink_accepts_it() -> None:
+    """A swallowed event write must not be deduped away by the park marker.
+
+    The marker is persisted by ``_finish_parked_comment_repair_cycle`` whatever
+    happens, so marking before the event is durable would make every later poll
+    see ``already_parked`` and drop the operator-facing park event permanently
+    (PRRT_kwDOSJAM6s6fu_-m).
+    """
+    runner = _FlakyEventSinkRunner(failures=1)
+    state = MonitorState()
+
+    async def _poll() -> tuple[str, object] | None:
+        return await _provenance._resolve_unpublished_comment_repair_disposition(
+            runner,
+            workspace_id="ws_park_retry",
+            worktree_path=Path("/tmp/ws_park_retry"),
+            state=state,
+            current_head=_SECOND,
+            fetched_head=_BASE,
+            provenance_remote_head=_BASE,
+            diff_range=f"{_BASE}..HEAD",
+            use_stale_snapshot_diff=False,
+            has_comment_repair_provenance=False,
+            has_conflicting_repair_provenance=True,
+            current_operation_id=None,
+        )
+
+    first = await _poll()
+    assert first is not None
+    assert first[1] is not None
+    assert first[1].parked_needs_human is True
+    assert runner.appended == []
+    # No durable event yet, so no marker: the next poll must retry the audit.
+    assert state.parked_unpublished_repair is None
+
+    second = await _poll()
+    assert second is not None
+    assert second[1] is not None
+    assert second[1].parked_needs_human is True
+    assert runner.appended == ["monitor.comment_repair_unpublished_parked"]
+    assert state.parked_unpublished_repair is not None
+
+    third = await _poll()
+    assert third is not None
+    assert third[1] is not None
+    assert third[1].parked_needs_human is True
+    # Durable now — the episode stays audited exactly once.
+    assert runner.appended == ["monitor.comment_repair_unpublished_parked"]
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize("error", _SINK_ERRORS)
 async def test_preserve_disposition_survives_a_failing_event_sink(error: Exception) -> None:

--- a/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
+++ b/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
@@ -505,3 +505,63 @@ async def test_preserve_disposition_survives_a_failing_event_sink(error: Excepti
     )
 
     assert disposition == (_SECOND, None)
+
+
+_SECRET_SUBJECT = "chore: wire token=ghp_abcdefghijklmnopqrstuvwxyz012345"
+
+
+@pytest.mark.unit
+def test_park_reason_redacts_secrets_in_commit_subjects() -> None:
+    reason = _provenance._unpublished_repair_park_reason((("deadbee", _SECRET_SUBJECT),))
+
+    assert "ghp_abcdefghijklmnopqrstuvwxyz012345" not in reason
+    assert "[redacted]" in reason
+    assert "deadbee" in reason
+
+
+class _CapturingEventSinkRunner:
+    """Runner whose ``git log`` returns a secret-bearing subject; records events."""
+
+    def __init__(self, stdout: str) -> None:
+        self._stdout = stdout
+        self.payloads: list[dict[str, object]] = []
+        self._deps = SimpleNamespace(runner=SimpleNamespace(run=self._run))
+
+    async def _run(self, _args: list[str], **_kwargs: object) -> CommandResult:
+        return CommandResult(returncode=0, stdout=self._stdout, stderr="")
+
+    async def _append_workspace_events(self, **kwargs: object) -> None:
+        events = kwargs["events"]
+        assert isinstance(events, list)
+        for event in events:
+            self.payloads.append(dict(event.payload))
+
+
+@pytest.mark.unit
+async def test_park_disposition_redacts_secrets_it_persists() -> None:
+    runner = _CapturingEventSinkRunner(f"deadbee {_SECRET_SUBJECT}\n")
+
+    disposition = await _provenance._resolve_unpublished_comment_repair_disposition(
+        runner,
+        workspace_id="ws_secret",
+        worktree_path=Path("/tmp/ws_secret"),
+        state=MonitorState(),
+        current_head=_SECOND,
+        fetched_head=_BASE,
+        provenance_remote_head=_BASE,
+        diff_range=f"{_BASE}..HEAD",
+        use_stale_snapshot_diff=False,
+        has_comment_repair_provenance=False,
+        has_conflicting_repair_provenance=True,
+        current_operation_id=None,
+    )
+
+    assert disposition is not None
+    push_result = disposition[1]
+    assert push_result is not None
+    # The park reason becomes ``awaiting_human_reason``; the payload reaches consumers.
+    assert "ghp_abcdefghijklmnopqrstuvwxyz012345" not in push_result.stderr
+    preserved = push_result.details["preserved_commits"]
+    assert preserved == ["deadbee chore: wire token=[redacted]"]
+    assert runner.payloads
+    assert runner.payloads[0]["preserved_commits"] == preserved

--- a/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
+++ b/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
@@ -154,7 +154,32 @@ def test_review_item_commit_subject_matches_bitbucket_shapes(subject: str) -> No
 @pytest.mark.parametrize(
     "subject",
     [
+        # A task-tagged workspace prefixes the same subjects with the workspace tag:
+        # bare for Jira issue keys, bracketed for Aira entity keys (PRRT_kwDOSJAM6s6fwa0B).
+        "PROJ-123 fix: address PR review thread PRRT_kwDOSJAM6s6fjOze",
+        "[PROJ-T123] fix: address PR review thread PRRT_kwDOSJAM6s6fjOze",
+        "PROJ-123 fix: address PRRT_kwDOSJAM6s6fjOze — tighten the guard",
+        "[PROJ-T123] fix: address review comment 4688598838 — tighten the guard",
+        "AIRA-T299 fix: address PR review comment issue:4688598838",
+        "[PROJ-123] fix: address PR review thread bbcomment:557058",
+    ],
+)
+def test_review_item_commit_subject_matches_task_tagged_shapes(subject: str) -> None:
+    assert _provenance._is_review_item_commit_subject(subject) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "subject",
+    [
         "fix: address operator hint",
+        # The tag prefix is only tolerated ahead of a review-item subject; it never
+        # makes an unattributable subject preservable on its own.
+        "PROJ-123 chore: unrelated local work",
+        "PROJ-123 fix: address 404 errors",
+        # Not a validated task-tag shape, so the subject stays unanchored and unmatched.
+        "wip fix: address PR review thread PRRT_kwDOSJAM6s6fjOze",
+        "Revert PROJ-123 fix: address PR review thread PRRT_kwDOSJAM6s6fjOze",
         "fix: address PR #922 CI failure",
         "chore: unrelated local work",
         "fix: address the reviewer feedback",

--- a/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
+++ b/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
@@ -127,6 +127,7 @@ def test_chain_coverage_absent_marker_is_false() -> None:
         "fix: address review comment issue:4688598838 — tighten the guard",
         "fix: address PRRT_kwDOSJAM6s6fjOze — tighten the guard",
         "fix: address PR review comment 4688598838",
+        "fix: address review comment 4688598838 — tighten the guard",
     ],
 )
 def test_review_item_commit_subject_matches_awf_shapes(subject: str) -> None:
@@ -157,6 +158,12 @@ def test_review_item_commit_subject_matches_bitbucket_shapes(subject: str) -> No
         "fix: address PR #922 CI failure",
         "chore: unrelated local work",
         "fix: address the reviewer feedback",
+        # A bare databaseId only counts behind the ``review thread|comment`` words:
+        # AWF never emits one unprefixed, and matching it there would preserve (and
+        # push) ordinary local commits that merely start with an HTTP status code.
+        "fix: address 404 errors",
+        "fix: address 500 in the parser",
+        "fix: address 4688598838 — tighten the guard",
         "",
     ],
 )

--- a/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
+++ b/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 
+from awf.common.commands import CommandResult
 from awf.runtime.monitor_state_keys import _COMMENT_REPAIR_ITEM_PROVENANCE_STATE_KEY
 from awf.runtime.pr_monitor import MonitorState
 from awf.runtime.pr_monitor_runner import comment_repair_provenance as _repair_provenance
@@ -272,3 +275,97 @@ async def test_disposition_event_without_an_event_sink_is_a_no_op() -> None:
         reason_code="COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING",
         payload={"pushed": False},
     )
+
+
+class _FailingEventSinkRunner:
+    """Runner whose audit-event sink fails; ``git log`` still answers."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+        self.append_calls = 0
+        self._deps = SimpleNamespace(runner=SimpleNamespace(run=self._run))
+
+    async def _run(self, _args: list[str], **_kwargs: object) -> CommandResult:
+        return CommandResult(
+            returncode=0,
+            stdout="deadbee chore: unrelated local work\n",
+            stderr="",
+        )
+
+    async def _append_workspace_events(self, **_kwargs: object) -> None:
+        self.append_calls += 1
+        raise self._error
+
+
+_SINK_ERRORS = [
+    pytest.param(SQLAlchemyError("db down"), id="sqlalchemy_error"),
+    pytest.param(OSError("socket closed"), id="os_error"),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("error", _SINK_ERRORS)
+async def test_disposition_event_survives_a_failing_event_sink(error: Exception) -> None:
+    runner = _FailingEventSinkRunner(error)
+
+    await _provenance._append_disposition_event(
+        runner,
+        workspace_id="ws_sink",
+        event_type="monitor.comment_repair_unpublished_parked",
+        reason_code="COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING",
+        payload={"pushed": False},
+    )
+
+    assert runner.append_calls == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("error", _SINK_ERRORS)
+async def test_park_disposition_survives_a_failing_event_sink(error: Exception) -> None:
+    runner = _FailingEventSinkRunner(error)
+
+    disposition = await _provenance._resolve_unpublished_comment_repair_disposition(
+        runner,
+        workspace_id="ws_park",
+        worktree_path=Path("/tmp/ws_park"),
+        state=MonitorState(),
+        current_head=_SECOND,
+        fetched_head=_BASE,
+        provenance_remote_head=_BASE,
+        diff_range=f"{_BASE}..HEAD",
+        use_stale_snapshot_diff=False,
+        has_comment_repair_provenance=False,
+        has_conflicting_repair_provenance=True,
+        current_operation_id=None,
+    )
+
+    assert disposition is not None
+    head, push_result = disposition
+    assert head == _SECOND
+    assert push_result is not None
+    assert push_result.parked_needs_human is True
+    assert push_result.details["disposition"] == "conflicting_repair_provenance"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("error", _SINK_ERRORS)
+async def test_preserve_disposition_survives_a_failing_event_sink(error: Exception) -> None:
+    runner = _FailingEventSinkRunner(error)
+    state = _chain_state([_record("PRRT_one", _BASE, _FIRST), _record("PRRT_two", _FIRST, _SECOND)])
+
+    disposition = await _provenance._resolve_unpublished_comment_repair_disposition(
+        runner,
+        workspace_id="ws_preserve",
+        worktree_path=Path("/tmp/ws_preserve"),
+        state=state,
+        current_head=_SECOND,
+        fetched_head=_BASE,
+        provenance_remote_head=_BASE,
+        diff_range=f"{_BASE}..HEAD",
+        use_stale_snapshot_diff=False,
+        has_comment_repair_provenance=False,
+        has_conflicting_repair_provenance=False,
+        current_operation_id=None,
+    )
+
+    assert disposition == (_SECOND, None)

--- a/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
+++ b/tests/unit/runtime/test_remote_repair_unpublished_helpers_parts/test_remote_repair_unpublished_helpers_part_004.py
@@ -134,6 +134,22 @@ def test_review_item_commit_subject_matches_awf_shapes(subject: str) -> None:
 @pytest.mark.parametrize(
     "subject",
     [
+        # The four identifier shapes ``bitbucket_client_parsing.py`` emits.
+        "fix: address PR review thread bb:acme/widgets#42:557058",
+        "fix: address PR review thread bbtask:acme/widgets#42:99",
+        "fix: address PR review comment bbcomment:557058",
+        "fix: address bbreview:557058:c7f1 — tighten the guard",
+        "fix: address review comment bbreview:Ada Lovelace — tighten the guard",
+    ],
+)
+def test_review_item_commit_subject_matches_bitbucket_shapes(subject: str) -> None:
+    assert _provenance._is_review_item_commit_subject(subject) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "subject",
+    [
         "fix: address operator hint",
         "fix: address PR #922 CI failure",
         "chore: unrelated local work",


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_1ced602be5b843c7a667329c` (agent: `claude_code`, model: `claude-opus-5`, effort: `high`).


### Task
Fix GitHub issue #935 (read it first: gh issue view 935). Two parts, both required, narrow scope. (1) Provenance at commit time: when a comment-repair item verdict is accepted with a commit (fix_committed, or a #925 correction outcome that preserves a commit), record provenance immediately (item id, item_start_head, resulting HEAD, operation id) so a restart, crash or timeout between items leaves an audit trail for every accepted commit - today the comment-repair operation record is only finalised at batch end. (2) In src/awf/runtime/pr_monitor_runner/remote_repair_unpublished.py the post-restart recovery must never fail the workspace over preserved work: local commits ahead of the PR head that descend from it and carry provenance (or, for legacy state, whose subjects name review items like 'fix: address PRRT_...') resume the batch and get pushed with the next cycle; if that cannot be established, park in needs_human with the worktree intact and a reason naming the commits. COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING must stop being a terminal workspace failure; keep the refusal to reset unknown commits. Strict TDD (failing tests first; ls test part directories and add NEW part files, never overwrite). Coverage gate 99 percent line+branch; files under 1500 lines (sibling modules, re-export with 'X as X'); catch specific exceptions; preserve reason codes. Run ruff check, ruff format --check, mypy and 'pytest tests -q -n 20' before pushing. Keep each agent run short: focused tests, commit, emit the AWF-VERDICT line; for review items put the fix hunk in the reviewed file at the reviewed line and never cite your own commit in a FALSE POSITIVE or DEFER. Reference 'Closes #935' in the PR body.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core PR-monitor comment-repair recovery, git worktree disposition, and persisted monitor state—incorrect provenance or park/resume logic could strand or wrongly push unpublish commits.
> 
> **Overview**
> **Comment-repair batches now record provenance on each accepted item commit** (item id, start head, resulting HEAD, operation id) in a durable chain on the workspace row, with audit events, instead of waiting until batch push. The fix cycle **settles incomplete records** when HEAD probes fail (next item’s start head or pre-push re-probe) and **clears the chain after a successful push** so the next batch does not link onto stale bases.
> 
> **After a restart, unpublished commits ahead of the PR head are no longer a terminal workspace failure.** Recovery **resumes** work when the commit-time chain or legacy review-item commit subjects match; **parks** unattributable commits for a human with the worktree untouched (`parked_needs_human`, updated `COMMENT_REPAIR_UNPUBLISHED_PROVENANCE_MISSING` semantics); and still **hard-resets** operation-owned abandoned repairs. The monitor loop keeps polling with awaiting-human attention while parked, similar to workflow-scope waits.
> 
> Supporting changes: **operator-facing docs/doctor text** for `COMMENT_REPAIR_UNPUBLISHED_PRESERVED` and revised provenance-missing guidance; **module splits** (CI classification, operator-hint loop, terminal provenance helpers, doctor comment-repair reasons) to satisfy file-line guardrails; **extensive unit tests** for chaining, compaction, pending completion, push clear, and recovery disposition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e08104e596a709b1607a6bdb7a579c513346ea1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->