### PR TITLE
Fix #938: guide directives retire needs_human on review threads

### DIFF
--- a/docs/PR_MONITOR_ADOPTION.md
+++ b/docs/PR_MONITOR_ADOPTION.md
@@ -232,11 +232,15 @@ mints a generated generation rather than reusing a stale owned slot.
 Seeding from the terminal predecessor: when a terminal row is superseded, AWF
 copies an allowlisted subset of its `monitor_threads_addressed` onto the fresh
 workspace so the successor does not re-disposition comments its predecessor
-already triaged. Exactly four marker classes cross that boundary — thread /
+already triaged. Exactly five marker classes cross that boundary — thread /
 review-comment / `issue:<id>` verdicts, `__review_comment_body_hash__:*` and
-`__review_thread_body_hash__:*` evidence, and `__deferred_issue_filed__:*`
-markers. Everything else (protected block state, awaiting-check timestamps,
-operator-hint bookkeeping, merge-block and workflow-scope markers) is
+`__review_thread_body_hash__:*` evidence, `__deferred_issue_filed__:*` markers,
+and the `__operator_decision__:*` ruling that un-parked a thread whose verdict
+the operator guide cleared (that thread crosses owed an answer, so the ruling
+travels with it instead of the successor re-prompting the agent with the
+reviewer text it already escalated on). Everything else (protected block state,
+awaiting-check timestamps, operator-hint cycle bookkeeping, merge-block and
+workflow-scope markers) is
 deliberately left behind and re-derived from the live PR. A copy appends a
 `workspace.pr_monitor_adoption_seeded` event with reason code
 `PR_ADOPTION_SEEDED_FROM_PREDECESSOR`, the predecessor workspace id, and the

--- a/docs/PR_MONITOR_ADOPTION.md
+++ b/docs/PR_MONITOR_ADOPTION.md
@@ -236,9 +236,11 @@ already triaged. Exactly five marker classes cross that boundary — thread /
 review-comment / `issue:<id>` verdicts, `__review_comment_body_hash__:*` and
 `__review_thread_body_hash__:*` evidence, `__deferred_issue_filed__:*` markers,
 and the `__operator_decision__:*` ruling that un-parked a thread whose verdict
-the operator guide cleared (that thread crosses owed an answer, so the ruling
-travels with it instead of the successor re-prompting the agent with the
-reviewer text it already escalated on). Everything else (protected block state,
+the operator guide cleared, carrying its `__operator_decision_at__:*` issue-time
+binding (that thread crosses owed an answer, so the ruling travels with it
+instead of the successor re-prompting the agent with the reviewer text it
+already escalated on — and the stamp keeps a reviewer reply that postdates the
+ruling able to retire it). Everything else (protected block state,
 awaiting-check timestamps, operator-hint cycle bookkeeping, merge-block and
 workflow-scope markers) is
 deliberately left behind and re-derived from the live PR. A copy appends a

--- a/src/awf/runtime/monitor_prompts.py
+++ b/src/awf/runtime/monitor_prompts.py
@@ -158,8 +158,15 @@ def address_thread_prompt(
     workspace_runtime_context: str = "",
     owned_paths: Sequence[str] = (),
     task_tag: str | None = None,
+    operator_decision: str | None = None,
 ) -> str:
-    """Prompt the CLI to address a single inline review thread."""
+    """Prompt the CLI to address a single inline review thread.
+
+    ``operator_decision`` carries the guide directive that un-parked a
+    ``needs_human`` verdict on this thread (issue #939). Without it the
+    re-addressed thread reads exactly like the first attempt and the agent can
+    repeat the fix the operator already rejected, then re-park.
+    """
     line_hint = (
         f"line {thread.line} of {thread.path}"
         if thread.path and thread.line
@@ -193,6 +200,7 @@ def address_thread_prompt(
         "Decide whether the current feedback is actionable, already fixed, a "
         "false positive, or genuinely needs human input:\n\n"
         f"{evidence}\n\n"
+        f"{_operator_decision_section(thread_id=thread.thread_id, decision=operator_decision)}"
         f"{_SAFETY_POLICY}\n"
         f"{_protected_file_policy(owned_paths)}\n"
         f"{_COMMENT_VERDICT_GUIDANCE}\n"
@@ -216,6 +224,35 @@ def address_thread_prompt(
         "PR.\n"
         "Do not write any PR comment for verdict bookkeeping.\n"
         f"{_commit_footer(task_tag)}{_VERDICT_OUTPUT_CONTRACT}"
+    )
+
+
+def _operator_decision_section(*, thread_id: str, decision: str | None) -> str:
+    """Quote the operator ruling that re-opened this thread, or nothing.
+
+    An operator guide is the only thing that clears a thread's ``needs_human``
+    without the agent recording a verdict, so this section exists exactly on the
+    re-addressed pass after such a guide. The directive is still external text —
+    render it through the untrusted-evidence envelope like every other operator
+    hint rather than splicing it into AWF's own instructions.
+    """
+    text = (decision or "").strip()
+    if not text:
+        return ""
+    evidence = render_untrusted_evidence(
+        UntrustedEvidence(
+            source_kind="operator_decision",
+            source_name="AWF operator decision",
+            source_id=thread_id,
+            text=text,
+        )
+    )
+    return (
+        "Operator decision for this thread: an operator already ruled on this "
+        "feedback and un-parked the thread for you. Follow that ruling — do not "
+        "repeat an approach it rejected, and do not escalate the same question "
+        "back to a human:\n\n"
+        f"{evidence}\n\n"
     )
 
 

--- a/src/awf/runtime/monitor_state_keys.py
+++ b/src/awf/runtime/monitor_state_keys.py
@@ -93,6 +93,24 @@ def _operator_decision_key(thread_id: str) -> str:
     return f"__operator_decision__:{thread_id}"
 
 
+def _operator_decision_issued_at_key(thread_id: str) -> str:
+    """Build state key stamping when an *unbindable* operator ruling was issued.
+
+    A stashed ruling only speaks to the conversation the operator read, so
+    ``_operator_decision_for_thread`` retires it once the thread's recorded
+    ``__review_thread_body_hash__`` snapshot stops matching the live thread. The
+    guide retirement path also clears ``needs_human`` rows that carry NO snapshot
+    (the ones outdated-thread hygiene seeds, PRRT_kwDOSJAM6s6fw5zx), and those
+    rulings have nothing to compare against: a reviewer reply landing between the
+    guide and the re-addressed pass would be replayed under an "operator already
+    ruled, do not escalate" heading. The retirement stamps such a ruling with its
+    issue time here instead, so reviewer activity newer than the ruling still
+    retires it (PRRT_kwDOSJAM6s6fxBwT). Written only when the snapshot is absent;
+    a thread that has one is bound by the hash and needs no stamp.
+    """
+    return f"__operator_decision_at__:{thread_id}"
+
+
 def _retired_operator_decision_key(thread_id: str) -> str:
     """Build state key parking the operator ruling a recorded verdict answered.
 

--- a/src/awf/runtime/monitor_state_keys.py
+++ b/src/awf/runtime/monitor_state_keys.py
@@ -85,6 +85,23 @@ def _operator_decision_key(thread_id: str) -> str:
     return f"__operator_decision__:{thread_id}"
 
 
+def _retired_operator_decision_key(thread_id: str) -> str:
+    """Build state key parking the operator ruling a recorded verdict answered.
+
+    Retirement of an ``__operator_decision__`` marker is only as durable as the
+    verdict that answered it. A fix-cycle rollback — push failure, mid-batch
+    abort, resolve retry — clears that unconfirmed verdict and the thread
+    re-enters ``AddressComments``, so a deleted ruling would leave the agent
+    re-reading only the reviewer text it already escalated on, free to repeat
+    the rejected approach and re-park (issue #939). The answered ruling is
+    parked here instead of dropped, and ``_clear_addressed_state_by_id``
+    restores it alongside the verdict it rolls back. A clear that means
+    "superseded by fresh reviewer feedback" drops it for good, because the new
+    feedback is not what the operator ruled on.
+    """
+    return f"__operator_decision_retired__:{thread_id}"
+
+
 def _initial_review_grace_wall_started_value(started_wall_seconds: float) -> str:
     return f"{started_wall_seconds:.6f}"
 

--- a/src/awf/runtime/monitor_state_keys.py
+++ b/src/awf/runtime/monitor_state_keys.py
@@ -69,6 +69,22 @@ def _outdated_resolve_requeued_key(thread_id: str) -> str:
     return f"__awf_outdated_resolve_requeued__:{thread_id}"
 
 
+def _operator_decision_key(thread_id: str) -> str:
+    """Build state key holding the operator directive that un-parked ``thread_id``.
+
+    When a guide directive retires a thread's ``needs_human`` (issue #938), the
+    verdict is cleared so the thread re-enters ``AddressComments``. Without the
+    operator's ruling in the follow-up comment-repair prompt the agent sees the
+    same reviewer text it already escalated on and can repeat the rejected fix
+    and re-park (issue #939). The directive is stashed here so
+    ``address_thread_prompt`` can quote it, and dropped again as soon as the
+    thread records a verdict other than ``agent_failed`` — that verdict is the
+    answer the decision was asking for, and replaying it on later, unrelated
+    feedback on the same thread would be stale guidance.
+    """
+    return f"__operator_decision__:{thread_id}"
+
+
 def _initial_review_grace_wall_started_value(started_wall_seconds: float) -> str:
     return f"{started_wall_seconds:.6f}"
 

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -53,6 +53,7 @@ from awf.runtime.feedback_policy import (
 )
 from awf.runtime.monitor_state_keys import (
     _merge_method_blocked_key,
+    _operator_decision_key,
     _outdated_resolve_requeued_key,
 )
 from awf.runtime.pr_monitor_actions import (
@@ -552,6 +553,12 @@ def _mark_review_thread_addressed(
         _review_thread_body_state_key(thread.thread_id),
         _review_thread_body_hash(thread),
     )
+    if verdict != "agent_failed":
+        # The operator ruling that un-parked this thread (issue #939) has now
+        # been answered by a real verdict, so retire it. ``agent_failed`` is not
+        # an answer — the thread is owed another attempt and must keep the
+        # decision in its prompt.
+        state.threads_addressed_ids.pop(_operator_decision_key(thread.thread_id), None)
 
 
 def _review_thread_needs_attention(state: MonitorState, thread: ReviewThread) -> bool:

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -45,6 +45,7 @@ from awf.runtime.feedback_policy import (
     needs_comment_attention,
     outdated_thread_has_fresh_feedback,
     preferred_duplicate_review_thread,
+    recorded_review_thread_body_matches,
     review_thread_body_hash,
     review_thread_body_state_key,
     review_thread_resolution_body,
@@ -549,11 +550,23 @@ def _mark_review_thread_addressed(
     thread: ReviewThread,
     verdict: str,
 ) -> None:
+    recorded_body = state.threads_addressed_ids.get(_review_thread_body_state_key(thread.thread_id))
+    body_superseded = recorded_body is not None and not recorded_review_thread_body_matches(
+        recorded_body, thread
+    )
     state.mark_addressed(thread.thread_id, verdict)
     state.mark_addressed(
         _review_thread_body_state_key(thread.thread_id),
         _review_thread_body_hash(thread),
     )
+    if body_superseded:
+        # This recording answers a body the previously parked ruling never spoke
+        # to. ``_drop_stale_review_thread_addressed_state`` performs that
+        # retire-for-good on the poll boundary, but a fix-cycle settle pass
+        # re-addresses a thread on fresh feedback without it — so drop the stale
+        # sidecar here too, or a rollback of THIS verdict would restore the
+        # previous body's ruling into the repair prompt.
+        state.threads_addressed_ids.pop(_retired_operator_decision_key(thread.thread_id), None)
     if verdict != "agent_failed":
         # The operator ruling that un-parked this thread (issue #939) has now
         # been answered by a real verdict, so retire it. ``agent_failed`` is not

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -55,6 +55,7 @@ from awf.runtime.monitor_state_keys import (
     _merge_method_blocked_key,
     _operator_decision_key,
     _outdated_resolve_requeued_key,
+    _retired_operator_decision_key,
 )
 from awf.runtime.pr_monitor_actions import (
     BOT_REVIEWER_LOGINS,
@@ -558,7 +559,14 @@ def _mark_review_thread_addressed(
         # been answered by a real verdict, so retire it. ``agent_failed`` is not
         # an answer — the thread is owed another attempt and must keep the
         # decision in its prompt.
-        state.threads_addressed_ids.pop(_operator_decision_key(thread.thread_id), None)
+        #
+        # The retirement is only as durable as the verdict that earned it: park
+        # the ruling in the retired sidecar so a rollback of this still
+        # unconfirmed verdict (``_clear_addressed_state_by_id``) restores it
+        # with the thread, instead of re-opening the thread without the ruling.
+        decision = state.threads_addressed_ids.pop(_operator_decision_key(thread.thread_id), None)
+        if decision is not None:
+            state.mark_addressed(_retired_operator_decision_key(thread.thread_id), decision)
 
 
 def _review_thread_needs_attention(state: MonitorState, thread: ReviewThread) -> bool:

--- a/src/awf/runtime/pr_monitor_runner/comments.py
+++ b/src/awf/runtime/pr_monitor_runner/comments.py
@@ -11,6 +11,10 @@ from awf.node.git_manager import (
     mirror_path_for_worktree,
     repair_mirror_hooks_path,
 )
+from awf.runtime.feedback_policy import (
+    recorded_review_thread_body_matches,
+    review_thread_body_state_key,
+)
 from awf.runtime.monitor_prompts import (
     address_review_comment_prompt,
     address_thread_prompt,
@@ -53,6 +57,41 @@ if TYPE_CHECKING:
 
 _log = get_logger(__name__)
 _GENERIC_HUMAN_BLOCKER_REASON = "human attention is required before AWF can continue"
+
+
+def _operator_decision_for_thread(
+    state: MonitorState | None,
+    thread: ReviewThread,
+) -> str | None:
+    """Return the operator ruling to quote for ``thread``, or ``None``.
+
+    A live ruling (issue #939) only speaks to the conversation the operator read.
+    When a reviewer replies afterwards — after a guide cleared the verdict but
+    before the next attempt, or after an attempt recorded ``agent_failed`` — the
+    recorded body hash diverges and the ruling is stale for the updated thread.
+    ``_drop_stale_review_thread_addressed_state`` already retires an *answered*
+    ruling on such a body change, but it skips threads whose verdict still needs
+    attention (missing / ``agent_failed``), which is exactly the state a live
+    ruling sits in. Quoting it anyway would tell the agent to follow guidance the
+    operator never gave for this feedback and not to re-escalate it.
+
+    The stale marker is dropped rather than merely skipped: left in place,
+    ``_mark_review_thread_addressed`` would park it in the retired sidecar and a
+    later verdict rollback would restore it into a subsequent repair prompt.
+    A thread with no recorded body hash cannot be compared, so it keeps the
+    ruling (mirroring ``_mark_review_thread_addressed``'s supersede check).
+    """
+    if state is None:
+        return None
+    decision_key = _operator_decision_key(thread.thread_id)
+    decision = state.threads_addressed_ids.get(decision_key)
+    if decision is None:
+        return None
+    recorded = state.threads_addressed_ids.get(review_thread_body_state_key(thread.thread_id))
+    if recorded is not None and not recorded_review_thread_body_matches(recorded, thread):
+        state.threads_addressed_ids.pop(decision_key, None)
+        return None
+    return decision
 
 
 async def _address_thread(
@@ -101,11 +140,7 @@ async def _address_thread(
     # An operator guide that retired this thread's ``needs_human`` stashed its
     # directive here (issue #939). Replay it so the re-addressed thread carries
     # the operator's ruling instead of reading like the first attempt.
-    operator_decision = (
-        state.threads_addressed_ids.get(_operator_decision_key(thread.thread_id))
-        if state is not None
-        else None
-    )
+    operator_decision = _operator_decision_for_thread(state, thread)
     prompt = address_thread_prompt(
         pr_number=pr_number,
         repo_slug=repo.slug(),

--- a/src/awf/runtime/pr_monitor_runner/comments.py
+++ b/src/awf/runtime/pr_monitor_runner/comments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,7 +21,10 @@ from awf.runtime.monitor_prompts import (
     address_thread_prompt,
     ready_to_merge_comment,
 )
-from awf.runtime.monitor_state_keys import _operator_decision_key
+from awf.runtime.monitor_state_keys import (
+    _operator_decision_issued_at_key,
+    _operator_decision_key,
+)
 from awf.runtime.ownership import (
     repair_agent_runtime_ownership,
 )
@@ -83,7 +87,9 @@ def _operator_decision_for_thread(
     The stale marker is dropped rather than merely skipped: left in place,
     ``_mark_review_thread_addressed`` would park it in the retired sidecar and a
     later verdict rollback would restore it into a subsequent repair prompt.
-    A thread with no recorded body hash cannot be compared, so it keeps the
+    A thread with no recorded body hash cannot be compared that way, so it falls
+    back to the ruling's issue-time stamp (see
+    :func:`_operator_ruling_superseded_by_reply`) and, failing that, keeps the
     ruling (mirroring ``_mark_review_thread_addressed``'s supersede check).
     """
     if state is None:
@@ -94,9 +100,54 @@ def _operator_decision_for_thread(
         return None
     recorded = state.threads_addressed_ids.get(review_thread_body_state_key(thread.thread_id))
     if recorded is not None and not recorded_review_thread_body_matches(recorded, thread):
-        state.threads_addressed_ids.pop(decision_key, None)
+        _drop_stale_operator_decision(state, thread.thread_id)
+        return None
+    if recorded is None and _operator_ruling_superseded_by_reply(state, thread):
+        _drop_stale_operator_decision(state, thread.thread_id)
         return None
     return decision
+
+
+def _drop_stale_operator_decision(state: MonitorState, thread_id: str) -> None:
+    """Retire a ruling the live conversation has outrun, stamp included."""
+    state.threads_addressed_ids.pop(_operator_decision_key(thread_id), None)
+    state.threads_addressed_ids.pop(_operator_decision_issued_at_key(thread_id), None)
+
+
+def _operator_ruling_superseded_by_reply(state: MonitorState, thread: ReviewThread) -> bool:
+    """True when reviewer activity postdates an unbindable ruling's issue time.
+
+    The guide retirement path clears ``needs_human`` rows that carry no body-hash
+    snapshot — the ones outdated-thread hygiene seeds — so their ruling has nothing
+    to compare against and the hash check above cannot see a reply that arrived
+    after the operator ruled. Those rulings are stamped with their issue time
+    instead (``__operator_decision_at__:``), and any reviewer comment created or
+    edited after that moment is feedback the operator never read
+    (PRRT_kwDOSJAM6s6fxBwT).
+
+    Only non-viewer activity counts (``_latest_reviewer_comment_at``): AWF's own
+    replies are not new feedback for the agent to re-triage. A missing stamp (the
+    pre-stamp rows an in-flight monitor carries, and every hash-bound ruling), an
+    unparseable one, or a thread whose comments carry no timestamps proves nothing
+    about ordering, so the ruling is kept — the same fail-open the rest of this
+    module takes when evidence is unavailable.
+    """
+    # Imported here, not at module scope: both modules sit downstream of
+    # ``comments`` in the runner's import graph.
+    from awf.runtime.pr_monitor_runner.helpers import _as_utc
+    from awf.runtime.pr_monitor_runner.outdated_resolution import _latest_reviewer_comment_at
+
+    stamped = state.threads_addressed_ids.get(_operator_decision_issued_at_key(thread.thread_id))
+    if not stamped:
+        return False
+    try:
+        issued_at = datetime.fromisoformat(stamped)
+    except ValueError:
+        return False
+    latest_reply_at = _latest_reviewer_comment_at(thread)
+    if latest_reply_at is None:
+        return False
+    return _as_utc(latest_reply_at) > _as_utc(issued_at)
 
 
 async def _address_thread(

--- a/src/awf/runtime/pr_monitor_runner/comments.py
+++ b/src/awf/runtime/pr_monitor_runner/comments.py
@@ -16,6 +16,7 @@ from awf.runtime.monitor_prompts import (
     address_thread_prompt,
     ready_to_merge_comment,
 )
+from awf.runtime.monitor_state_keys import _operator_decision_key
 from awf.runtime.ownership import (
     repair_agent_runtime_ownership,
 )
@@ -97,6 +98,14 @@ async def _address_thread(
         if isinstance(task_tag, _TaskTagUnset)
         else task_tag
     )
+    # An operator guide that retired this thread's ``needs_human`` stashed its
+    # directive here (issue #939). Replay it so the re-addressed thread carries
+    # the operator's ruling instead of reading like the first attempt.
+    operator_decision = (
+        state.threads_addressed_ids.get(_operator_decision_key(thread.thread_id))
+        if state is not None
+        else None
+    )
     prompt = address_thread_prompt(
         pr_number=pr_number,
         repo_slug=repo.slug(),
@@ -104,6 +113,7 @@ async def _address_thread(
         workspace_runtime_context=runner._workspace_runtime_context,
         owned_paths=prompt_owned_paths,
         task_tag=resolved_task_tag,
+        operator_decision=operator_decision,
     )
     try:
         result = await runner._invoke_cli_for_verdict_result(

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -309,6 +309,7 @@ def _clear_addressed_state_by_id(
     "rolled back": that feedback is not what the operator ruled on. A ruling the
     operator has since re-issued likewise wins over the parked copy.
     """
+    body_snapshot = state.threads_addressed_ids.get(_review_thread_body_state_key(item_id))
     state.threads_addressed_ids.pop(item_id, None)
     state.threads_addressed_ids.pop(_review_thread_body_state_key(item_id), None)
     state.threads_addressed_ids.pop(_review_comment_body_state_key(item_id), None)
@@ -327,6 +328,14 @@ def _clear_addressed_state_by_id(
         and _operator_decision_key(item_id) not in state.threads_addressed_ids
     ):
         state.mark_addressed(_operator_decision_key(item_id), retired_decision)
+    if body_snapshot is not None and _operator_decision_key(item_id) in state.threads_addressed_ids:
+        # A ruling that survives this clear — restored above, or the live one kept
+        # over it — keeps the body snapshot it was bound to. The clear deleted that
+        # hash, and ``_operator_decision_for_thread`` retains rulings it cannot
+        # compare, so a reviewer reply landing before the retry would otherwise
+        # replay stale guidance while telling the agent not to re-escalate. The
+        # verdict stays cleared, so the thread still re-enters ``AddressComments``.
+        state.mark_addressed(_review_thread_body_state_key(item_id), body_snapshot)
 
 
 def _drop_stale_review_thread_addressed_state(

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -306,7 +306,8 @@ def _clear_addressed_state_by_id(
     only the reviewer text the agent already escalated on and it can repeat the
     rejected approach and re-park. Pass ``restore_operator_decision=False``
     where the clear means "superseded by fresh reviewer feedback" rather than
-    "rolled back": that feedback is not what the operator ruled on.
+    "rolled back": that feedback is not what the operator ruled on. A ruling the
+    operator has since re-issued likewise wins over the parked copy.
     """
     state.threads_addressed_ids.pop(item_id, None)
     state.threads_addressed_ids.pop(_review_thread_body_state_key(item_id), None)
@@ -317,7 +318,14 @@ def _clear_addressed_state_by_id(
     retired_decision = state.threads_addressed_ids.pop(
         _retired_operator_decision_key(item_id), None
     )
-    if retired_decision is not None and restore_operator_decision:
+    if (
+        retired_decision is not None
+        and restore_operator_decision
+        # A live ruling is the operator's latest word on this thread — it was
+        # issued after the parked one was answered, so restoring the parked copy
+        # over it would quote superseded guidance in the repair prompt.
+        and _operator_decision_key(item_id) not in state.threads_addressed_ids
+    ):
         state.mark_addressed(_operator_decision_key(item_id), retired_decision)
 
 

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -66,7 +66,13 @@ from awf.runtime.monitor_state_keys import (
     _non_check_reviewer_settle_started_prefix as _non_check_reviewer_settle_started_prefix,
 )
 from awf.runtime.monitor_state_keys import (
+    _operator_decision_key as _operator_decision_key,
+)
+from awf.runtime.monitor_state_keys import (
     _outdated_resolve_requeued_key as _outdated_resolve_requeued_key,
+)
+from awf.runtime.monitor_state_keys import (
+    _retired_operator_decision_key as _retired_operator_decision_key,
 )
 from awf.runtime.pr_monitor import (
     CheckFailure,
@@ -285,14 +291,34 @@ def _mark_review_comment_addressed(
     )
 
 
-def _clear_addressed_state_by_id(state: MonitorState, item_id: str) -> None:
-    """Clear verdict, body, and reason markers for ``item_id``."""
+def _clear_addressed_state_by_id(
+    state: MonitorState,
+    item_id: str,
+    *,
+    restore_operator_decision: bool = True,
+) -> None:
+    """Clear verdict, body, and reason markers for ``item_id``.
+
+    Callers use this to roll back an *unconfirmed* verdict so the item re-enters
+    ``AddressComments``. When that verdict had answered an operator ruling
+    (issue #939), the rollback un-answers it too, so the parked ruling is
+    restored with it — otherwise the re-opened thread's repair prompt carries
+    only the reviewer text the agent already escalated on and it can repeat the
+    rejected approach and re-park. Pass ``restore_operator_decision=False``
+    where the clear means "superseded by fresh reviewer feedback" rather than
+    "rolled back": that feedback is not what the operator ruled on.
+    """
     state.threads_addressed_ids.pop(item_id, None)
     state.threads_addressed_ids.pop(_review_thread_body_state_key(item_id), None)
     state.threads_addressed_ids.pop(_review_comment_body_state_key(item_id), None)
     state.threads_addressed_ids.pop(_needs_human_reason_state_key(item_id), None)
     state.threads_addressed_ids.pop(_defer_reason_state_key(item_id), None)
     state.threads_addressed_ids.pop(_outdated_resolve_requeued_key(item_id), None)
+    retired_decision = state.threads_addressed_ids.pop(
+        _retired_operator_decision_key(item_id), None
+    )
+    if retired_decision is not None and restore_operator_decision:
+        state.mark_addressed(_operator_decision_key(item_id), retired_decision)
 
 
 def _drop_stale_review_thread_addressed_state(
@@ -307,7 +333,9 @@ def _drop_stale_review_thread_addressed_state(
         recorded = state.threads_addressed_ids.get(_review_thread_body_state_key(thread.thread_id))
         if recorded_review_thread_body_matches(recorded, thread):
             continue
-        _clear_addressed_state_by_id(state, thread.thread_id)
+        # Fresh reviewer feedback supersedes the answered operator ruling rather
+        # than rolling its verdict back, so the parked ruling retires for good.
+        _clear_addressed_state_by_id(state, thread.thread_id, restore_operator_decision=False)
         changed = True
     return changed
 

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
@@ -70,9 +70,13 @@ _OPERATOR_HINT_REVIEW_THREAD_ID_RE = re.compile(
 # Cap on the operator directive stashed under ``__operator_decision__:<thread>``
 # for replay into the thread's next comment-repair prompt (issue #939).
 _OPERATOR_DECISION_MAX_CHARS = 1500
+# Context kept ahead of the named thread id when the cap forces a window: enough
+# to carry the sentence that introduces the ruling without pushing the ruling
+# itself out of the tail.
+_OPERATOR_DECISION_ANCHOR_LEAD_CHARS = 200
 
 
-def _operator_decision_marker_text(text: str) -> str:
+def _operator_decision_marker_text(text: str, *, anchor: str | None = None) -> str:
     """Bound and redact the directive stored for a re-opened thread (issue #939).
 
     The stored copy is replayed verbatim into the next comment-repair prompt, so
@@ -80,11 +84,26 @@ def _operator_decision_marker_text(text: str) -> str:
     feedback the agent has to read (and bloat persisted monitor state). Secrets
     are stripped because this text becomes durable DB state, not just prompt
     input.
+
+    ``anchor`` is the thread id this copy is stored for. A multi-thread guide can
+    name a thread only past the cap, and a plain leading-prefix truncation would
+    then stash a ruling meant for a *different* thread while the prompt tells the
+    agent to follow it and not re-escalate (PRRT_kwDOSJAM6s6fxBwP). So when the
+    directive overflows, the window is positioned on the anchor's first mention —
+    with a little lead-in context — instead of on the head of the text. Elided
+    sides are marked with ``…`` so the agent can see the copy is partial. Without
+    an anchor (or when the id does not survive redaction) the head window is kept.
     """
     decision = redact_secrets(text).strip()
     if len(decision) <= _OPERATOR_DECISION_MAX_CHARS:
         return decision
-    return f"{decision[:_OPERATOR_DECISION_MAX_CHARS]}…"
+    found = decision.find(anchor) if anchor else -1
+    start = max(0, found - _OPERATOR_DECISION_ANCHOR_LEAD_CHARS) if found != -1 else 0
+    end = min(len(decision), start + _OPERATOR_DECISION_MAX_CHARS)
+    start = max(0, end - _OPERATOR_DECISION_MAX_CHARS)
+    head = "…" if start > 0 else ""
+    tail = "…" if end < len(decision) else ""
+    return f"{head}{decision[start:end]}{tail}"
 
 
 def _operator_hint_feedback_body_hash_key(item_id: str) -> str:

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
@@ -74,6 +74,19 @@ _OPERATOR_DECISION_MAX_CHARS = 1500
 # to carry the sentence that introduces the ruling without pushing the ruling
 # itself out of the tail.
 _OPERATOR_DECISION_ANCHOR_LEAD_CHARS = 200
+# Characters that continue a thread key past the anchor. A plain substring search
+# would let a shorter key (``bb:acme/widgets#12:345``) anchor on a longer sibling
+# (``…:3456``) and stash the sibling's ruling (PRRT_kwDOSJAM6s6fxier), so the
+# anchor only counts where the id actually ends.
+_OPERATOR_DECISION_ANCHOR_TAIL_RE = r"(?![0-9A-Za-z_-])"
+
+
+def _operator_decision_anchor_offset(decision: str, anchor: str | None) -> int:
+    """First mention of the whole ``anchor`` id in ``decision``, or ``-1``."""
+    if not anchor:
+        return -1
+    match = re.search(re.escape(anchor) + _OPERATOR_DECISION_ANCHOR_TAIL_RE, decision)
+    return match.start() if match else -1
 
 
 def _operator_decision_marker_text(text: str, *, anchor: str | None = None) -> str:
@@ -89,15 +102,16 @@ def _operator_decision_marker_text(text: str, *, anchor: str | None = None) -> s
     name a thread only past the cap, and a plain leading-prefix truncation would
     then stash a ruling meant for a *different* thread while the prompt tells the
     agent to follow it and not re-escalate (PRRT_kwDOSJAM6s6fxBwP). So when the
-    directive overflows, the window is positioned on the anchor's first mention —
-    with a little lead-in context — instead of on the head of the text. Elided
+    directive overflows, the window is positioned on the anchor's first *whole-id*
+    mention — with a little lead-in context — instead of on the head of the text.
+    A mention that merely prefixes a longer sibling id does not count. Elided
     sides are marked with ``…`` so the agent can see the copy is partial. Without
     an anchor (or when the id does not survive redaction) the head window is kept.
     """
     decision = redact_secrets(text).strip()
     if len(decision) <= _OPERATOR_DECISION_MAX_CHARS:
         return decision
-    found = decision.find(anchor) if anchor else -1
+    found = _operator_decision_anchor_offset(decision, anchor)
     start = max(0, found - _OPERATOR_DECISION_ANCHOR_LEAD_CHARS) if found != -1 else 0
     end = min(len(decision), start + _OPERATOR_DECISION_MAX_CHARS)
     start = max(0, end - _OPERATOR_DECISION_MAX_CHARS)

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
@@ -115,15 +115,20 @@ def _operator_decision_windows(decision: str, offsets: tuple[int, ...]) -> list[
     around each. Whichever mention the ruling sits beside, it survives the cap
     (PRRT_kwDOSJAM6s6fx7kx). Mentions close enough for their slices to touch are
     merged so one ruling is never chopped into two elided fragments, and with a
-    single mention this is exactly the old whole-budget window. Past
-    ``_OPERATOR_DECISION_MIN_SLICE_CHARS`` per mention the earliest mentions are
-    dropped: an introductory index is by construction at the head, so the tail
-    mentions are the likelier rulings.
+    single mention this is exactly the old whole-budget window.
+
+    ``_OPERATOR_DECISION_MIN_SLICE_CHARS`` bounds how many mentions the budget is
+    split across, so a guide that names one thread more often than that still has
+    to drop some. It drops from the middle, keeping the earliest mention and then
+    the latest ones: a ruling can equally be stated up front and merely
+    cross-referenced below, or indexed up front and ruled on below, and neither
+    end is decidable from the text (PRRT_kwDOSJAM6s6fyCVT).
     """
     budget = _OPERATOR_DECISION_MAX_CHARS
     if not offsets:
         return [(0, min(len(decision), budget))]
-    kept = offsets[-max(1, budget // _OPERATOR_DECISION_MIN_SLICE_CHARS) :]
+    limit = max(1, budget // _OPERATOR_DECISION_MIN_SLICE_CHARS)
+    kept = offsets if len(offsets) <= limit else (offsets[0], *offsets[len(offsets) - limit + 1 :])
     share = budget // len(kept)
     lead = min(_OPERATOR_DECISION_ANCHOR_LEAD_CHARS, share // 4)
     windows: list[tuple[int, int]] = []

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
@@ -74,10 +74,14 @@ _OPERATOR_DECISION_MAX_CHARS = 1500
 # to carry the sentence that introduces the ruling without pushing the ruling
 # itself out of the tail.
 _OPERATOR_DECISION_ANCHOR_LEAD_CHARS = 200
+# Smallest slice worth keeping around a single mention of the thread id. It caps
+# how many mentions the budget is split across, so a guide that names one thread
+# dozens of times yields a few readable slices instead of unusable confetti.
+_OPERATOR_DECISION_MIN_SLICE_CHARS = 200
 
 
-def _operator_decision_anchor_offset(decision: str, anchor: str | None) -> int:
-    """First whole-key mention of ``anchor`` in ``decision``, or ``-1``.
+def _operator_decision_anchor_offsets(decision: str, anchor: str | None) -> tuple[int, ...]:
+    """Offsets of every whole-key mention of ``anchor`` in ``decision``, in order.
 
     The scan tokenizes ``decision`` with the same thread-key grammar that pulled
     the id out of the directive in the first place and keeps only a token that
@@ -88,13 +92,49 @@ def _operator_decision_anchor_offset(decision: str, anchor: str | None) -> int:
     copy on the sibling's ruling while the prompt forbids re-escalation
     (PRRT_kwDOSJAM6s6fxier). Deriving the boundaries from the key grammar bounds
     both sides at once and keeps one definition of what a thread key is.
+
+    Every mention is returned, not just the first: a guide can list the id in an
+    introductory index and repeat it beside the ruling much further down
+    (PRRT_kwDOSJAM6s6fx7kx).
     """
     if not anchor:
-        return -1
-    for match in _OPERATOR_HINT_REVIEW_THREAD_ID_RE.finditer(decision):
-        if match.group(0) == anchor:
-            return match.start()
-    return -1
+        return ()
+    return tuple(
+        match.start()
+        for match in _OPERATOR_HINT_REVIEW_THREAD_ID_RE.finditer(decision)
+        if match.group(0) == anchor
+    )
+
+
+def _operator_decision_windows(decision: str, offsets: tuple[int, ...]) -> list[tuple[int, int]]:
+    """Slices of ``decision`` to keep, in text order, totalling at most the cap.
+
+    Which mention carries the ruling is not decidable from the text — an index
+    line and the ruling itself name the id identically — so rather than guess one
+    occurrence, the budget is split evenly across the mentions and a slice is kept
+    around each. Whichever mention the ruling sits beside, it survives the cap
+    (PRRT_kwDOSJAM6s6fx7kx). Mentions close enough for their slices to touch are
+    merged so one ruling is never chopped into two elided fragments, and with a
+    single mention this is exactly the old whole-budget window. Past
+    ``_OPERATOR_DECISION_MIN_SLICE_CHARS`` per mention the earliest mentions are
+    dropped: an introductory index is by construction at the head, so the tail
+    mentions are the likelier rulings.
+    """
+    budget = _OPERATOR_DECISION_MAX_CHARS
+    if not offsets:
+        return [(0, min(len(decision), budget))]
+    kept = offsets[-max(1, budget // _OPERATOR_DECISION_MIN_SLICE_CHARS) :]
+    share = budget // len(kept)
+    lead = min(_OPERATOR_DECISION_ANCHOR_LEAD_CHARS, share // 4)
+    windows: list[tuple[int, int]] = []
+    for offset in kept:
+        end = min(len(decision), max(0, offset - lead) + share)
+        start = max(0, end - share)
+        if windows and start <= windows[-1][1]:
+            windows[-1] = (windows[-1][0], max(windows[-1][1], end))
+            continue
+        windows.append((start, end))
+    return windows
 
 
 def _operator_decision_marker_text(text: str, *, anchor: str | None = None) -> str:
@@ -110,22 +150,31 @@ def _operator_decision_marker_text(text: str, *, anchor: str | None = None) -> s
     name a thread only past the cap, and a plain leading-prefix truncation would
     then stash a ruling meant for a *different* thread while the prompt tells the
     agent to follow it and not re-escalate (PRRT_kwDOSJAM6s6fxBwP). So when the
-    directive overflows, the window is positioned on the anchor's first *whole-id*
-    mention — with a little lead-in context — instead of on the head of the text.
-    A mention that only sits inside a longer sibling id does not count. Elided
-    sides are marked with ``…`` so the agent can see the copy is partial. Without
-    an anchor (or when the id does not survive redaction) the head window is kept.
+    directive overflows, the copy is windowed on the anchor's *whole-id* mentions
+    — with a little lead-in context — instead of on the head of the text. A
+    mention that only sits inside a longer sibling id does not count, and every
+    mention is windowed rather than only the first, so an id that a guide indexes
+    up front and repeats beside its ruling further down still carries the ruling
+    (PRRT_kwDOSJAM6s6fx7kx). Elided stretches are marked with ``…`` so the agent
+    can see the copy is partial. Without an anchor (or when the id does not
+    survive redaction) the head window is kept.
     """
     decision = redact_secrets(text).strip()
     if len(decision) <= _OPERATOR_DECISION_MAX_CHARS:
         return decision
-    found = _operator_decision_anchor_offset(decision, anchor)
-    start = max(0, found - _OPERATOR_DECISION_ANCHOR_LEAD_CHARS) if found != -1 else 0
-    end = min(len(decision), start + _OPERATOR_DECISION_MAX_CHARS)
-    start = max(0, end - _OPERATOR_DECISION_MAX_CHARS)
-    head = "…" if start > 0 else ""
-    tail = "…" if end < len(decision) else ""
-    return f"{head}{decision[start:end]}{tail}"
+    windows = _operator_decision_windows(
+        decision, _operator_decision_anchor_offsets(decision, anchor)
+    )
+    parts: list[str] = []
+    previous_end = 0
+    for start, end in windows:
+        if start > previous_end:
+            parts.append("…")
+        parts.append(decision[start:end])
+        previous_end = end
+    if previous_end < len(decision):
+        parts.append("…")
+    return "".join(parts)
 
 
 def _operator_hint_feedback_body_hash_key(item_id: str) -> str:

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
@@ -74,19 +74,27 @@ _OPERATOR_DECISION_MAX_CHARS = 1500
 # to carry the sentence that introduces the ruling without pushing the ruling
 # itself out of the tail.
 _OPERATOR_DECISION_ANCHOR_LEAD_CHARS = 200
-# Characters that continue a thread key past the anchor. A plain substring search
-# would let a shorter key (``bb:acme/widgets#12:345``) anchor on a longer sibling
-# (``…:3456``) and stash the sibling's ruling (PRRT_kwDOSJAM6s6fxier), so the
-# anchor only counts where the id actually ends.
-_OPERATOR_DECISION_ANCHOR_TAIL_RE = r"(?![0-9A-Za-z_-])"
 
 
 def _operator_decision_anchor_offset(decision: str, anchor: str | None) -> int:
-    """First mention of the whole ``anchor`` id in ``decision``, or ``-1``."""
+    """First whole-key mention of ``anchor`` in ``decision``, or ``-1``.
+
+    The scan tokenizes ``decision`` with the same thread-key grammar that pulled
+    the id out of the directive in the first place and keeps only a token that
+    equals ``anchor``, rather than searching for the id text itself. A raw
+    substring search matches a key embedded in a longer sibling id — on the tail
+    (``bb:acme/widgets#12:345`` inside ``…#12:3456``) and equally on the head
+    (``PRRT_a`` inside ``PRRT_zPRRT_a``) — and would window this thread's stored
+    copy on the sibling's ruling while the prompt forbids re-escalation
+    (PRRT_kwDOSJAM6s6fxier). Deriving the boundaries from the key grammar bounds
+    both sides at once and keeps one definition of what a thread key is.
+    """
     if not anchor:
         return -1
-    match = re.search(re.escape(anchor) + _OPERATOR_DECISION_ANCHOR_TAIL_RE, decision)
-    return match.start() if match else -1
+    for match in _OPERATOR_HINT_REVIEW_THREAD_ID_RE.finditer(decision):
+        if match.group(0) == anchor:
+            return match.start()
+    return -1
 
 
 def _operator_decision_marker_text(text: str, *, anchor: str | None = None) -> str:
@@ -104,7 +112,7 @@ def _operator_decision_marker_text(text: str, *, anchor: str | None = None) -> s
     agent to follow it and not re-escalate (PRRT_kwDOSJAM6s6fxBwP). So when the
     directive overflows, the window is positioned on the anchor's first *whole-id*
     mention — with a little lead-in context — instead of on the head of the text.
-    A mention that merely prefixes a longer sibling id does not count. Elided
+    A mention that only sits inside a longer sibling id does not count. Elided
     sides are marked with ``…`` so the agent can see the copy is partial. Without
     an anchor (or when the id does not survive redaction) the head window is kept.
     """

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_parsing.py
@@ -1,0 +1,136 @@
+"""Pure parsing helpers for operator remonitor hint directives.
+
+Split out of ``operator_hints.py`` so that module stays under the first-party
+line cap enforced by
+``tests/unit/test_core_decomposition_maintainability.py``. Everything here is
+I/O-free text handling: recognizing the feedback/thread keys an operator can
+name in a guide directive, and bounding the directive copy replayed into a
+re-opened thread's next comment-repair prompt.
+"""
+
+from __future__ import annotations
+
+import re
+
+from awf.common.redaction import redact_secrets
+
+# Recognize the persisted review-comment key forms surfaced back to operators.
+# ``issue:<databaseId>`` is already an explicit feedback key; bare databaseIds
+# and Bitbucket ``bbcomment:<id>`` keys are already explicit feedback keys; bare
+# databaseIds must appear with feedback/comment id context so unrelated numbers
+# do not retire stale review waits.
+_OPERATOR_HINT_ISSUE_FEEDBACK_ID_RE = re.compile(r"\bissue:\d+\b", re.IGNORECASE)
+_OPERATOR_HINT_BITBUCKET_FEEDBACK_ID_RE = re.compile(r"\bbbcomment:\d+\b", re.IGNORECASE)
+_OPERATOR_HINT_BARE_FEEDBACK_ID_RE = re.compile(
+    r"""
+    \b
+    (?:
+        feedback
+        | review(?:[\s_-]+comment)?
+        | comment
+    )
+    [\s_-]*id[\s:#-]*
+    (?P<id>\d+)
+    \b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+# Recognize the forge-neutral review-THREAD key forms an operator can name in a
+# guide directive: the GitHub GraphQL review-thread node id and the Bitbucket
+# thread/task encodings from ``awf.common.bitbucket_client_parsing``. The shapes
+# mirror the adoption-seeding contract (``awf.service.pr_monitor_adoption_seed``)
+# so both layers agree on what counts as a thread key.
+#
+# Matching is CASE-SENSITIVE, unlike the comment regexes above (which lowercase
+# their match): GraphQL node ids and Bitbucket owner/repo slugs are
+# case-significant and the extracted text is used as a literal state-map key, so
+# a case-folded id would simply miss. ``bbcomment:<id>`` is deliberately absent —
+# it is a comment id and stays on the comment path.
+#
+# The owner/repo segments accept the SAME broad shape as the decoder and the
+# adoption contract (``[^/]+/[^#]+``) rather than a narrower slug whitelist: a key
+# whose owner/repo carries anything outside ``[A-Za-z0-9._-]`` (for example the
+# percent-encoded ``bb:acme/widgets%20legacy#12:345``) is a legal thread key, and
+# failing to extract it would leave the named thread parked at ``needs_human`` so
+# the monitor returns straight to the same human wait. Whitespace is the one extra
+# exclusion: this regex SCANS free-form directive prose (the decoder full-matches a
+# stored key), so segments stay token-local and prose like ``bb:acme/widgets, see
+# PR #12:345`` cannot be stitched into a key.
+_OPERATOR_HINT_REVIEW_THREAD_ID_RE = re.compile(
+    r"""
+    \b
+    (?:
+        PRRT_[A-Za-z0-9_-]+
+        | bbtask:[^\s/\#]+/[^\s\#]+\#\d+:\d+
+        | bb:[^\s/\#]+/[^\s\#]+\#\d+:\d+
+    )
+    """,
+    re.VERBOSE,
+)
+# Cap on the operator directive stashed under ``__operator_decision__:<thread>``
+# for replay into the thread's next comment-repair prompt (issue #939).
+_OPERATOR_DECISION_MAX_CHARS = 1500
+
+
+def _operator_decision_marker_text(text: str) -> str:
+    """Bound and redact the directive stored for a re-opened thread (issue #939).
+
+    The stored copy is replayed verbatim into the next comment-repair prompt, so
+    it is capped: an unbounded operator directive would crowd out the reviewer
+    feedback the agent has to read (and bloat persisted monitor state). Secrets
+    are stripped because this text becomes durable DB state, not just prompt
+    input.
+    """
+    decision = redact_secrets(text).strip()
+    if len(decision) <= _OPERATOR_DECISION_MAX_CHARS:
+        return decision
+    return f"{decision[:_OPERATOR_DECISION_MAX_CHARS]}…"
+
+
+def _operator_hint_feedback_body_hash_key(item_id: str) -> str:
+    return f"__review_comment_body_hash__:{item_id}"
+
+
+def _operator_hint_feedback_id_candidates(text: str) -> tuple[str, ...]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+    matches: list[tuple[int, str]] = []
+    matches.extend(
+        (match.start(), match.group(0).lower())
+        for match in _OPERATOR_HINT_ISSUE_FEEDBACK_ID_RE.finditer(text)
+    )
+    matches.extend(
+        (match.start(), match.group(0).lower())
+        for match in _OPERATOR_HINT_BITBUCKET_FEEDBACK_ID_RE.finditer(text)
+    )
+    matches.extend(
+        (match.start("id"), match.group("id"))
+        for match in _OPERATOR_HINT_BARE_FEEDBACK_ID_RE.finditer(text)
+    )
+    for _, item_id in sorted(matches, key=lambda candidate: candidate[0]):
+        if item_id in seen:
+            continue
+        seen.add(item_id)
+        candidates.append(item_id)
+    return tuple(candidates)
+
+
+def _operator_hint_review_thread_id_candidates(text: str) -> tuple[str, ...]:
+    """Review-thread ids named in ``text``, deduped in first-occurrence order."""
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for match in _OPERATOR_HINT_REVIEW_THREAD_ID_RE.finditer(text):
+        thread_id = match.group(0)
+        if thread_id in seen:
+            continue
+        seen.add(thread_id)
+        candidates.append(thread_id)
+    return tuple(candidates)
+
+
+def _operator_hint_feedback_storage_key_candidates(referenced_id: str) -> tuple[str, ...]:
+    if referenced_id.isdigit():
+        if len(referenced_id) < 6:
+            return (referenced_id,)
+        return (referenced_id, f"issue:{referenced_id}")
+    return (referenced_id,)

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
@@ -97,6 +97,19 @@ def _mark_referenced_needs_human_feedback_answered(
       crosses whether or not head continuity is established -- it disposes of
       the *feedback* rather than asserting what the branch contains.
 
+    A thread cleared this way is deliberately verdict-less until the agent
+    re-triages it, which is exactly the shape outdated-thread hygiene reads as
+    "never seeded". Both pre-decision seeding steps in
+    :mod:`awf.runtime.pr_monitor_runner.outdated_resolution` therefore exempt a
+    thread whose stashed ruling is still live
+    (``_thread_has_live_operator_decision``), so
+    ``_seed_outdated_thread_verdicts_from_branch_evidence`` cannot re-derive the
+    ``needs_human`` this clear just retired — nor resolve the thread as
+    ``fix_committed`` — behind the operator's back. The exemption ends with the
+    ruling: it keys on the live ``__operator_decision__:`` marker only, which
+    ``_mark_review_thread_addressed`` drops once a real verdict answers it
+    (PRRT_kwDOSJAM6s6fwt3a).
+
     ``hint.reason`` can be audit context for approve-and-keep grant-only resumes,
     which skip the CLI entirely. Callers pass ``acted_text`` when a directiveless
     reason was actually presented to the agent; otherwise only a directive counts.
@@ -153,6 +166,10 @@ def _mark_referenced_needs_human_feedback_answered(
             continue
         state.threads_addressed_ids.pop(thread_id, None)
         state.threads_addressed_ids.pop(f"__needs_human_reason__:{thread_id}", None)
+        # While this marker is live the now verdict-less thread is exempt from
+        # ``outdated_resolution._seed_outdated_thread_verdicts_from_branch_evidence``
+        # (and its in-memory sibling), so hygiene cannot re-seed a verdict over
+        # the operator's ruling before the agent re-triages the thread.
         state.mark_addressed(
             _operator_decision_key(thread_id),
             _operator_decision_marker_text(text, anchor=thread_id),

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
@@ -130,8 +130,9 @@ def _mark_referenced_needs_human_feedback_answered(
     ``__operator_decision_at__:<thread id>`` instead: the replay path retires the
     ruling when reviewer activity postdates that stamp, so an untouched
     conversation still quotes it and a replied-to one re-triages from scratch. The
-    residual window is a reply between the operator writing the guide and AWF
-    consuming it, which no locally recorded evidence can order.
+    stamp is the operator's own ``requested_at`` (see
+    :func:`_operator_ruling_issued_at`), not the moment AWF consumed the guide, so
+    a reply that lands while the guide is queued counts as unread too.
     """
     if hint is None:
         return
@@ -163,5 +164,36 @@ def _mark_referenced_needs_human_feedback_answered(
             continue
         state.mark_addressed(
             _operator_decision_issued_at_key(thread_id),
-            datetime.now(UTC).isoformat(),
+            _operator_ruling_issued_at(hint),
         )
+
+
+def _operator_ruling_issued_at(hint: OperatorHint) -> str:
+    """ISO-8601 UTC moment the operator issued ``hint``.
+
+    The stamp answers "which conversation did the operator read?", so it must be
+    the moment they wrote the guide, not the moment AWF consumed it. Hints carry
+    that as ``requested_at`` (stamped by the ``guide``/``remonitor`` controls at
+    request time and preserved verbatim across the ``needs_human`` /
+    ``agent_failed`` re-wraps in :mod:`awf.runtime.operator_hints`), and a guide
+    can sit queued for a whole monitor cycle — long enough for a reply to land in
+    between. Dating the ruling from consumption would silently adopt that reply as
+    something the operator had ruled on (PRRT_kwDOSJAM6s6fxBwT).
+
+    Naive values are read as UTC, matching ``_as_utc`` on the comparison side. A
+    hint with no ``requested_at`` (older persisted payloads, and the direct
+    constructions in tests) or an unparseable one falls back to now: that is the
+    latest the ruling can possibly have been issued, which keeps the pre-existing
+    replay behavior rather than retiring rulings on invented evidence.
+    """
+    requested_at = hint.requested_at
+    if requested_at:
+        try:
+            issued_at = datetime.fromisoformat(requested_at)
+        except ValueError:
+            issued_at = None
+        if issued_at is not None:
+            if issued_at.tzinfo is None:
+                issued_at = issued_at.replace(tzinfo=UTC)
+            return issued_at.astimezone(UTC).isoformat()
+    return datetime.now(UTC).isoformat()

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
@@ -1,0 +1,129 @@
+"""Retirement of operator-answered ``needs_human`` feedback.
+
+Split out of ``operator_hints.py`` so that module stays under the first-party
+line cap enforced by
+``tests/unit/test_core_decomposition_maintainability.py``. Everything here is
+monitor-state bookkeeping for a settled operator guide: marking the hint
+processed, dropping the protected-block preserved-head marker, and retiring the
+review-level ``needs_human`` verdicts the guide explicitly answered.
+"""
+
+from __future__ import annotations
+
+from awf.runtime.feedback_policy import review_thread_body_state_key
+from awf.runtime.monitor_state_keys import _operator_decision_key
+from awf.runtime.operator_hints import mark_operator_hint_processed
+from awf.runtime.pr_monitor import (
+    _PROTECTED_BLOCK_PRESERVED_HEAD_STATE_KEY,
+    MonitorState,
+    OperatorHint,
+)
+from awf.runtime.pr_monitor_runner.operator_hint_parsing import (
+    _operator_decision_marker_text,
+    _operator_hint_feedback_body_hash_key,
+    _operator_hint_feedback_id_candidates,
+    _operator_hint_feedback_storage_key_candidates,
+    _operator_hint_review_thread_id_candidates,
+)
+
+
+def _finalize_processed_operator_hint(
+    state: MonitorState,
+    *,
+    hint: OperatorHint | None = None,
+    acted_feedback_text: str | None = None,
+) -> None:
+    """Mark the operator hint processed and drop the protected-block preserved-head
+    marker.
+
+    The marker (``_PROTECTED_BLOCK_PRESERVED_HEAD_STATE_KEY``) is recorded at block
+    time and powers the divergence-recovery / restart-after-consume short-circuits
+    for THIS resume only. Once the resume is finalized it has served its purpose;
+    leaving it in persisted monitor state would let a later plain remonitor (no
+    directive, no grant) whose old preserved commit is still on the remote take the
+    restart-recovery shortcut and skip the CLI — silently ignoring the operator's
+    new repair request (PRRT_kwDOSJAM6s6KE2BX). A fresh block re-records the marker.
+    """
+    pending_hint = getattr(state, "pending_operator_hint", None)
+    active_hint = pending_hint or hint
+    _mark_referenced_needs_human_feedback_answered(
+        state, hint=active_hint, acted_text=acted_feedback_text
+    )
+    state.threads_addressed_ids.pop(_PROTECTED_BLOCK_PRESERVED_HEAD_STATE_KEY, None)
+    if hasattr(state, "pending_operator_hint") and pending_hint is None and active_hint is not None:
+        state.pending_operator_hint = active_hint
+    mark_operator_hint_processed(state)
+
+
+def _mark_referenced_needs_human_feedback_answered(
+    state: MonitorState,
+    *,
+    hint: OperatorHint | None = None,
+    acted_text: str | None = None,
+) -> None:
+    """Retire review-level ``needs_human`` verdicts a guide explicitly answered.
+
+    Operator guides are the sanctioned path for resolving a monitor HUMAN_WAIT.
+    Two id classes are recognized, and they are retired differently:
+
+    * **Review comments** (``issue:<id>`` / ``bbcomment:<id>`` / contextual bare
+      ids). There is no forge thread to resolve, so a consumed guide that names
+      the original feedback id in the acted-on text must itself update the
+      persisted verdict, flipping it to ``false_positive``. Otherwise the hint is
+      marked processed and the next ``decide()`` poll immediately re-enters the
+      same stale HUMAN_WAIT.
+    * **Review threads** (``PRRT_...`` and the Bitbucket ``bb:``/``bbtask:``
+      keys). Here the verdict is *cleared* rather than flipped: an absent verdict
+      makes ``needs_comment_attention`` True, so the thread re-enters
+      ``AddressComments`` on the next poll and the agent records the real
+      verdict (issue #938). Flipping it to ``false_positive`` would assert a
+      verdict on the operator's behalf and let the merge gate pass without the
+      agent ever re-reading the thread. The directive is also stashed under
+      ``__operator_decision__:<thread id>`` so the re-addressed thread's repair
+      prompt quotes the ruling instead of replaying only the reviewer text the
+      agent already escalated on (issue #939); ``_mark_review_thread_addressed``
+      drops it once a verdict other than ``agent_failed`` answers it. The stash
+      also survives PR re-adoption: ``__operator_decision__:`` is on the copied
+      marker allowlist in :mod:`awf.service.pr_monitor_adoption_seed`, so a
+      successor workspace that adopts the PR before the re-queued thread is
+      addressed still quotes the ruling. Like the head-independent verdicts it
+      crosses whether or not head continuity is established -- it disposes of
+      the *feedback* rather than asserting what the branch contains.
+
+    ``hint.reason`` can be audit context for approve-and-keep grant-only resumes,
+    which skip the CLI entirely. Callers pass ``acted_text`` when a directiveless
+    reason was actually presented to the agent; otherwise only a directive counts.
+
+    This helper intentionally leaves any stored ``__review_comment_body_hash__`` /
+    ``__review_thread_body_hash__`` marker unchanged because it does not receive
+    the live ``ReviewComment``/``ReviewThread`` needed to recompute the hash. To
+    keep the retirement durable across the next stale-state sweep, it only retires
+    rows that already have body-hash sidecar state. Legacy rows without that
+    marker remain ``needs_human`` until a path holding the live item can snapshot
+    the body. For a cleared thread the snapshot is also what keeps a later
+    ``defer``/``needs_human`` re-queueable, so it must survive the clear.
+    """
+    if hint is None:
+        return
+    text = acted_text if acted_text is not None else hint.directive
+    if not text:
+        return
+    for referenced_id in _operator_hint_feedback_id_candidates(text):
+        for item_id in _operator_hint_feedback_storage_key_candidates(referenced_id):
+            if state.threads_addressed_ids.get(item_id) != "needs_human":
+                continue
+            if not state.threads_addressed_ids.get(_operator_hint_feedback_body_hash_key(item_id)):
+                continue
+            state.mark_addressed(item_id, "false_positive")
+            state.threads_addressed_ids.pop(f"__needs_human_reason__:{item_id}", None)
+            break
+    for thread_id in _operator_hint_review_thread_id_candidates(text):
+        if state.threads_addressed_ids.get(thread_id) != "needs_human":
+            continue
+        if not state.threads_addressed_ids.get(review_thread_body_state_key(thread_id)):
+            continue
+        state.threads_addressed_ids.pop(thread_id, None)
+        state.threads_addressed_ids.pop(f"__needs_human_reason__:{thread_id}", None)
+        state.mark_addressed(
+            _operator_decision_key(thread_id), _operator_decision_marker_text(text)
+        )

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
@@ -10,7 +10,6 @@ review-level ``needs_human`` verdicts the guide explicitly answered.
 
 from __future__ import annotations
 
-from awf.runtime.feedback_policy import review_thread_body_state_key
 from awf.runtime.monitor_state_keys import _operator_decision_key
 from awf.runtime.operator_hints import mark_operator_hint_processed
 from awf.runtime.pr_monitor import (
@@ -96,12 +95,25 @@ def _mark_referenced_needs_human_feedback_answered(
 
     This helper intentionally leaves any stored ``__review_comment_body_hash__`` /
     ``__review_thread_body_hash__`` marker unchanged because it does not receive
-    the live ``ReviewComment``/``ReviewThread`` needed to recompute the hash. To
-    keep the retirement durable across the next stale-state sweep, it only retires
-    rows that already have body-hash sidecar state. Legacy rows without that
-    marker remain ``needs_human`` until a path holding the live item can snapshot
-    the body. For a cleared thread the snapshot is also what keeps a later
-    ``defer``/``needs_human`` re-queueable, so it must survive the clear.
+    the live ``ReviewComment``/``ReviewThread`` needed to recompute the hash. For a
+    cleared thread the snapshot is also what keeps a later ``defer``/``needs_human``
+    re-queueable, so it must survive the clear.
+
+    The comment arm requires an existing body-hash sidecar so the ``false_positive``
+    it *asserts* is durable across the next stale-state sweep. The thread arm does
+    not, because it asserts nothing: a hashless row is exactly what
+    ``_drop_stale_review_thread_addressed_state`` would clear on its own, and
+    requiring the sidecar would park monitor-seeded rows forever
+    (PRRT_kwDOSJAM6s6fw5zx). Outdated-thread hygiene deliberately records bare
+    ``needs_human`` verdicts with no snapshot (``outdated_resolution``: post-fix
+    reviewer activity, and the mixed-verdict blocking-sibling promotion); an
+    unchanged ``needs_human`` never re-enters ``AddressComments``, so no later path
+    holds the live thread to add the missing hash, and the guide — already marked
+    processed — would leave ``decide`` returning to ``NotifyHuman`` forever. The
+    clear is not a merge-gate weakening: it routes the thread back through
+    ``AddressComments`` for a real verdict, and ``_operator_decision_for_thread``
+    keeps the stashed ruling it cannot compare, so the repair prompt still quotes
+    it.
     """
     if hint is None:
         return
@@ -119,8 +131,6 @@ def _mark_referenced_needs_human_feedback_answered(
             break
     for thread_id in _operator_hint_review_thread_id_candidates(text):
         if state.threads_addressed_ids.get(thread_id) != "needs_human":
-            continue
-        if not state.threads_addressed_ids.get(review_thread_body_state_key(thread_id)):
             continue
         state.threads_addressed_ids.pop(thread_id, None)
         state.threads_addressed_ids.pop(f"__needs_human_reason__:{thread_id}", None)

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
@@ -80,8 +80,10 @@ def _mark_referenced_needs_human_feedback_answered(
       agent ever re-reading the thread. The directive is also stashed under
       ``__operator_decision__:<thread id>`` so the re-addressed thread's repair
       prompt quotes the ruling instead of replaying only the reviewer text the
-      agent already escalated on (issue #939); ``_mark_review_thread_addressed``
-      drops it once a verdict other than ``agent_failed`` answers it. The stash
+      agent already escalated on (issue #939); the stash is windowed on the
+      thread id so an over-cap multi-thread guide keeps each thread's own ruling
+      (PRRT_kwDOSJAM6s6fxBwP), and ``_mark_review_thread_addressed`` drops it
+      once a verdict other than ``agent_failed`` answers it. The stash
       also survives PR re-adoption: ``__operator_decision__:`` is on the copied
       marker allowlist in :mod:`awf.service.pr_monitor_adoption_seed`, so a
       successor workspace that adopts the PR before the re-queued thread is
@@ -135,5 +137,6 @@ def _mark_referenced_needs_human_feedback_answered(
         state.threads_addressed_ids.pop(thread_id, None)
         state.threads_addressed_ids.pop(f"__needs_human_reason__:{thread_id}", None)
         state.mark_addressed(
-            _operator_decision_key(thread_id), _operator_decision_marker_text(text)
+            _operator_decision_key(thread_id),
+            _operator_decision_marker_text(text, anchor=thread_id),
         )

--- a/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hint_retirement.py
@@ -10,7 +10,13 @@ review-level ``needs_human`` verdicts the guide explicitly answered.
 
 from __future__ import annotations
 
-from awf.runtime.monitor_state_keys import _operator_decision_key
+from datetime import UTC, datetime
+
+from awf.runtime.feedback_policy import review_thread_body_state_key
+from awf.runtime.monitor_state_keys import (
+    _operator_decision_issued_at_key,
+    _operator_decision_key,
+)
 from awf.runtime.operator_hints import mark_operator_hint_processed
 from awf.runtime.pr_monitor import (
     _PROTECTED_BLOCK_PRESERVED_HEAD_STATE_KEY,
@@ -113,9 +119,19 @@ def _mark_referenced_needs_human_feedback_answered(
     holds the live thread to add the missing hash, and the guide — already marked
     processed — would leave ``decide`` returning to ``NotifyHuman`` forever. The
     clear is not a merge-gate weakening: it routes the thread back through
-    ``AddressComments`` for a real verdict, and ``_operator_decision_for_thread``
-    keeps the stashed ruling it cannot compare, so the repair prompt still quotes
-    it.
+    ``AddressComments`` for a real verdict.
+
+    A ruling stashed for such a hashless row has no snapshot to be bound to, and
+    ``_operator_decision_for_thread`` keeps rulings it cannot compare — so a
+    reviewer reply landing between this guide and the re-addressed pass would be
+    handed to the agent under "an operator already ruled on this feedback … do not
+    escalate", which is guidance the operator never gave for it
+    (PRRT_kwDOSJAM6s6fxBwT). Stamp the ruling's issue time under
+    ``__operator_decision_at__:<thread id>`` instead: the replay path retires the
+    ruling when reviewer activity postdates that stamp, so an untouched
+    conversation still quotes it and a replied-to one re-triages from scratch. The
+    residual window is a reply between the operator writing the guide and AWF
+    consuming it, which no locally recorded evidence can order.
     """
     if hint is None:
         return
@@ -139,4 +155,13 @@ def _mark_referenced_needs_human_feedback_answered(
         state.mark_addressed(
             _operator_decision_key(thread_id),
             _operator_decision_marker_text(text, anchor=thread_id),
+        )
+        if state.threads_addressed_ids.get(review_thread_body_state_key(thread_id)):
+            # The snapshot binds the ruling on its own; a stamp left over from an
+            # earlier hashless ruling on this thread would only mis-date this one.
+            state.threads_addressed_ids.pop(_operator_decision_issued_at_key(thread_id), None)
+            continue
+        state.mark_addressed(
+            _operator_decision_issued_at_key(thread_id),
+            datetime.now(UTC).isoformat(),
         )

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from awf.common.github_client import RepoRef
+from awf.common.redaction import redact_secrets
 from awf.control.blocked_transition import (
     MONITOR_PROTECTED_SCOPE_PUSH_RESUME_PHASE,
     MONITOR_PROTECTED_SCOPE_SYNC_BASE_RESUME_PHASE,
@@ -19,6 +20,7 @@ from awf.db.repositories import WorkspaceRepository
 from awf.runtime.feedback_policy import review_thread_body_state_key
 from awf.runtime.logs import WorkspaceLogSink
 from awf.runtime.monitor_prompts import operator_hint_prompt
+from awf.runtime.monitor_state_keys import _operator_decision_key
 from awf.runtime.operator_hints import (
     mark_operator_hint_agent_failed,
     mark_operator_hint_needs_human,
@@ -93,6 +95,9 @@ _OPERATOR_HINT_REVIEW_THREAD_ID_RE = re.compile(
     """,
     re.VERBOSE,
 )
+# Cap on the operator directive stashed under ``__operator_decision__:<thread>``
+# for replay into the thread's next comment-repair prompt (issue #939).
+_OPERATOR_DECISION_MAX_CHARS = 1500
 _PROTECTED_HISTORY_DIRECTIVE_REBLOCK_PREFIX = "__awf_protected_history_directive_reblocked__:"
 
 
@@ -1231,10 +1236,14 @@ def _mark_referenced_needs_human_feedback_answered(
     * **Review threads** (``PRRT_...`` and the Bitbucket ``bb:``/``bbtask:``
       keys). Here the verdict is *cleared* rather than flipped: an absent verdict
       makes ``needs_comment_attention`` True, so the thread re-enters
-      ``AddressComments`` on the next poll with the directive in context and the
-      agent records the real verdict (issue #938). Flipping it to
-      ``false_positive`` would assert a verdict on the operator's behalf and let
-      the merge gate pass without the agent ever re-reading the thread.
+      ``AddressComments`` on the next poll and the agent records the real
+      verdict (issue #938). Flipping it to ``false_positive`` would assert a
+      verdict on the operator's behalf and let the merge gate pass without the
+      agent ever re-reading the thread. The directive is also stashed under
+      ``__operator_decision__:<thread id>`` so the re-addressed thread's repair
+      prompt quotes the ruling instead of replaying only the reviewer text the
+      agent already escalated on (issue #939); ``_mark_review_thread_addressed``
+      drops it once a verdict other than ``agent_failed`` answers it.
 
     ``hint.reason`` can be audit context for approve-and-keep grant-only resumes,
     which skip the CLI entirely. Callers pass ``acted_text`` when a directiveless
@@ -1270,6 +1279,24 @@ def _mark_referenced_needs_human_feedback_answered(
             continue
         state.threads_addressed_ids.pop(thread_id, None)
         state.threads_addressed_ids.pop(f"__needs_human_reason__:{thread_id}", None)
+        state.mark_addressed(
+            _operator_decision_key(thread_id), _operator_decision_marker_text(text)
+        )
+
+
+def _operator_decision_marker_text(text: str) -> str:
+    """Bound and redact the directive stored for a re-opened thread (issue #939).
+
+    The stored copy is replayed verbatim into the next comment-repair prompt, so
+    it is capped: an unbounded operator directive would crowd out the reviewer
+    feedback the agent has to read (and bloat persisted monitor state). Secrets
+    are stripped because this text becomes durable DB state, not just prompt
+    input.
+    """
+    decision = redact_secrets(text).strip()
+    if len(decision) <= _OPERATOR_DECISION_MAX_CHARS:
+        return decision
+    return f"{decision[:_OPERATOR_DECISION_MAX_CHARS]}…"
 
 
 def _operator_hint_feedback_body_hash_key(item_id: str) -> str:

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -84,13 +84,23 @@ _OPERATOR_HINT_BARE_FEEDBACK_ID_RE = re.compile(
 # case-significant and the extracted text is used as a literal state-map key, so
 # a case-folded id would simply miss. ``bbcomment:<id>`` is deliberately absent —
 # it is a comment id and stays on the comment path.
+#
+# The owner/repo segments accept the SAME broad shape as the decoder and the
+# adoption contract (``[^/]+/[^#]+``) rather than a narrower slug whitelist: a key
+# whose owner/repo carries anything outside ``[A-Za-z0-9._-]`` (for example the
+# percent-encoded ``bb:acme/widgets%20legacy#12:345``) is a legal thread key, and
+# failing to extract it would leave the named thread parked at ``needs_human`` so
+# the monitor returns straight to the same human wait. Whitespace is the one extra
+# exclusion: this regex SCANS free-form directive prose (the decoder full-matches a
+# stored key), so segments stay token-local and prose like ``bb:acme/widgets, see
+# PR #12:345`` cannot be stitched into a key.
 _OPERATOR_HINT_REVIEW_THREAD_ID_RE = re.compile(
     r"""
     \b
     (?:
         PRRT_[A-Za-z0-9_-]+
-        | bbtask:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+\#\d+:\d+
-        | bb:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+\#\d+:\d+
+        | bbtask:[^\s/\#]+/[^\s\#]+\#\d+:\d+
+        | bb:[^\s/\#]+/[^\s\#]+\#\d+:\d+
     )
     """,
     re.VERBOSE,

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import hashlib
-import re
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
 
 from awf.common.github_client import RepoRef
-from awf.common.redaction import redact_secrets
 from awf.control.blocked_transition import (
     MONITOR_PROTECTED_SCOPE_PUSH_RESUME_PHASE,
     MONITOR_PROTECTED_SCOPE_SYNC_BASE_RESUME_PHASE,
@@ -40,6 +38,13 @@ from awf.runtime.pr_monitor_runner.constants import (
     _GIT_PUSH_REJECTED_NON_FAST_FORWARD_REASON,
     _PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
 )
+from awf.runtime.pr_monitor_runner.operator_hint_parsing import (
+    _operator_decision_marker_text,
+    _operator_hint_feedback_body_hash_key,
+    _operator_hint_feedback_id_candidates,
+    _operator_hint_feedback_storage_key_candidates,
+    _operator_hint_review_thread_id_candidates,
+)
 from awf.runtime.pr_monitor_runner.pre_push_validation_constants import (
     _PRE_PUSH_VALIDATION_FAILED_REASON,
 )
@@ -52,62 +57,6 @@ from awf.runtime.pr_monitor_runner.types import (
     _MonitorPolicyBlockedError,
 )
 
-# Recognize the persisted review-comment key forms surfaced back to operators.
-# ``issue:<databaseId>`` is already an explicit feedback key; bare databaseIds
-# and Bitbucket ``bbcomment:<id>`` keys are already explicit feedback keys; bare
-# databaseIds must appear with feedback/comment id context so unrelated numbers
-# do not retire stale review waits.
-_OPERATOR_HINT_ISSUE_FEEDBACK_ID_RE = re.compile(r"\bissue:\d+\b", re.IGNORECASE)
-_OPERATOR_HINT_BITBUCKET_FEEDBACK_ID_RE = re.compile(r"\bbbcomment:\d+\b", re.IGNORECASE)
-_OPERATOR_HINT_BARE_FEEDBACK_ID_RE = re.compile(
-    r"""
-    \b
-    (?:
-        feedback
-        | review(?:[\s_-]+comment)?
-        | comment
-    )
-    [\s_-]*id[\s:#-]*
-    (?P<id>\d+)
-    \b
-    """,
-    re.IGNORECASE | re.VERBOSE,
-)
-# Recognize the forge-neutral review-THREAD key forms an operator can name in a
-# guide directive: the GitHub GraphQL review-thread node id and the Bitbucket
-# thread/task encodings from ``awf.common.bitbucket_client_parsing``. The shapes
-# mirror the adoption-seeding contract (``awf.service.pr_monitor_adoption_seed``)
-# so both layers agree on what counts as a thread key.
-#
-# Matching is CASE-SENSITIVE, unlike the comment regexes above (which lowercase
-# their match): GraphQL node ids and Bitbucket owner/repo slugs are
-# case-significant and the extracted text is used as a literal state-map key, so
-# a case-folded id would simply miss. ``bbcomment:<id>`` is deliberately absent —
-# it is a comment id and stays on the comment path.
-#
-# The owner/repo segments accept the SAME broad shape as the decoder and the
-# adoption contract (``[^/]+/[^#]+``) rather than a narrower slug whitelist: a key
-# whose owner/repo carries anything outside ``[A-Za-z0-9._-]`` (for example the
-# percent-encoded ``bb:acme/widgets%20legacy#12:345``) is a legal thread key, and
-# failing to extract it would leave the named thread parked at ``needs_human`` so
-# the monitor returns straight to the same human wait. Whitespace is the one extra
-# exclusion: this regex SCANS free-form directive prose (the decoder full-matches a
-# stored key), so segments stay token-local and prose like ``bb:acme/widgets, see
-# PR #12:345`` cannot be stitched into a key.
-_OPERATOR_HINT_REVIEW_THREAD_ID_RE = re.compile(
-    r"""
-    \b
-    (?:
-        PRRT_[A-Za-z0-9_-]+
-        | bbtask:[^\s/\#]+/[^\s\#]+\#\d+:\d+
-        | bb:[^\s/\#]+/[^\s\#]+\#\d+:\d+
-    )
-    """,
-    re.VERBOSE,
-)
-# Cap on the operator directive stashed under ``__operator_decision__:<thread>``
-# for replay into the thread's next comment-repair prompt (issue #939).
-_OPERATOR_DECISION_MAX_CHARS = 1500
 _PROTECTED_HISTORY_DIRECTIVE_REBLOCK_PREFIX = "__awf_protected_history_directive_reblocked__:"
 
 # Verdicts that END the resume without a push: each one parks the hint for a human
@@ -1442,70 +1391,6 @@ def _mark_referenced_needs_human_feedback_answered(
         state.mark_addressed(
             _operator_decision_key(thread_id), _operator_decision_marker_text(text)
         )
-
-
-def _operator_decision_marker_text(text: str) -> str:
-    """Bound and redact the directive stored for a re-opened thread (issue #939).
-
-    The stored copy is replayed verbatim into the next comment-repair prompt, so
-    it is capped: an unbounded operator directive would crowd out the reviewer
-    feedback the agent has to read (and bloat persisted monitor state). Secrets
-    are stripped because this text becomes durable DB state, not just prompt
-    input.
-    """
-    decision = redact_secrets(text).strip()
-    if len(decision) <= _OPERATOR_DECISION_MAX_CHARS:
-        return decision
-    return f"{decision[:_OPERATOR_DECISION_MAX_CHARS]}…"
-
-
-def _operator_hint_feedback_body_hash_key(item_id: str) -> str:
-    return f"__review_comment_body_hash__:{item_id}"
-
-
-def _operator_hint_feedback_id_candidates(text: str) -> tuple[str, ...]:
-    candidates: list[str] = []
-    seen: set[str] = set()
-    matches: list[tuple[int, str]] = []
-    matches.extend(
-        (match.start(), match.group(0).lower())
-        for match in _OPERATOR_HINT_ISSUE_FEEDBACK_ID_RE.finditer(text)
-    )
-    matches.extend(
-        (match.start(), match.group(0).lower())
-        for match in _OPERATOR_HINT_BITBUCKET_FEEDBACK_ID_RE.finditer(text)
-    )
-    matches.extend(
-        (match.start("id"), match.group("id"))
-        for match in _OPERATOR_HINT_BARE_FEEDBACK_ID_RE.finditer(text)
-    )
-    for _, item_id in sorted(matches, key=lambda candidate: candidate[0]):
-        if item_id in seen:
-            continue
-        seen.add(item_id)
-        candidates.append(item_id)
-    return tuple(candidates)
-
-
-def _operator_hint_review_thread_id_candidates(text: str) -> tuple[str, ...]:
-    """Review-thread ids named in ``text``, deduped in first-occurrence order."""
-    candidates: list[str] = []
-    seen: set[str] = set()
-    for match in _OPERATOR_HINT_REVIEW_THREAD_ID_RE.finditer(text):
-        thread_id = match.group(0)
-        if thread_id in seen:
-            continue
-        seen.add(thread_id)
-        candidates.append(thread_id)
-    return tuple(candidates)
-
-
-def _operator_hint_feedback_storage_key_candidates(referenced_id: str) -> tuple[str, ...]:
-    if referenced_id.isdigit():
-        if len(referenced_id) < 6:
-            return (referenced_id,)
-        return (referenced_id, f"issue:{referenced_id}")
-    return (referenced_id,)
 
 
 def _operator_hint_block_reason(

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -1253,7 +1253,13 @@ def _mark_referenced_needs_human_feedback_answered(
       ``__operator_decision__:<thread id>`` so the re-addressed thread's repair
       prompt quotes the ruling instead of replaying only the reviewer text the
       agent already escalated on (issue #939); ``_mark_review_thread_addressed``
-      drops it once a verdict other than ``agent_failed`` answers it.
+      drops it once a verdict other than ``agent_failed`` answers it. The stash
+      also survives PR re-adoption: ``__operator_decision__:`` is on the copied
+      marker allowlist in :mod:`awf.service.pr_monitor_adoption_seed`, so a
+      successor workspace that adopts the PR before the re-queued thread is
+      addressed still quotes the ruling. Like the head-independent verdicts it
+      crosses whether or not head continuity is established -- it disposes of
+      the *feedback* rather than asserting what the branch contains.
 
     ``hint.reason`` can be audit context for approve-and-keep grant-only resumes,
     which skip the CLI entirely. Callers pass ``acted_text`` when a directiveless

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -15,14 +15,11 @@ from awf.control.blocked_transition import (
 from awf.control.quality_gates import QualityGateViolation
 from awf.db.enums import FailureReason
 from awf.db.repositories import WorkspaceRepository
-from awf.runtime.feedback_policy import review_thread_body_state_key
 from awf.runtime.logs import WorkspaceLogSink
 from awf.runtime.monitor_prompts import operator_hint_prompt
-from awf.runtime.monitor_state_keys import _operator_decision_key
 from awf.runtime.operator_hints import (
     mark_operator_hint_agent_failed,
     mark_operator_hint_needs_human,
-    mark_operator_hint_processed,
 )
 from awf.runtime.pr_monitor import (
     _PROTECTED_BLOCK_PRESERVED_HEAD_STATE_KEY,
@@ -38,12 +35,11 @@ from awf.runtime.pr_monitor_runner.constants import (
     _GIT_PUSH_REJECTED_NON_FAST_FORWARD_REASON,
     _PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
 )
-from awf.runtime.pr_monitor_runner.operator_hint_parsing import (
-    _operator_decision_marker_text,
-    _operator_hint_feedback_body_hash_key,
-    _operator_hint_feedback_id_candidates,
-    _operator_hint_feedback_storage_key_candidates,
-    _operator_hint_review_thread_id_candidates,
+from awf.runtime.pr_monitor_runner.operator_hint_retirement import (
+    _finalize_processed_operator_hint as _finalize_processed_operator_hint,
+)
+from awf.runtime.pr_monitor_runner.operator_hint_retirement import (
+    _mark_referenced_needs_human_feedback_answered as _mark_referenced_needs_human_feedback_answered,
 )
 from awf.runtime.pr_monitor_runner.pre_push_validation_constants import (
     _PRE_PUSH_VALIDATION_FAILED_REASON,
@@ -1289,108 +1285,6 @@ async def _finalize_operator_hint_resume(
     await self._clear_preserved_marker_and_consume_grants_durably(workspace_id)
     await self._clear_block_resume_phase(workspace_id)
     _finalize_processed_operator_hint(state, hint=hint, acted_feedback_text=acted_feedback_text)
-
-
-def _finalize_processed_operator_hint(
-    state: MonitorState,
-    *,
-    hint: OperatorHint | None = None,
-    acted_feedback_text: str | None = None,
-) -> None:
-    """Mark the operator hint processed and drop the protected-block preserved-head
-    marker.
-
-    The marker (``_PROTECTED_BLOCK_PRESERVED_HEAD_STATE_KEY``) is recorded at block
-    time and powers the divergence-recovery / restart-after-consume short-circuits
-    for THIS resume only. Once the resume is finalized it has served its purpose;
-    leaving it in persisted monitor state would let a later plain remonitor (no
-    directive, no grant) whose old preserved commit is still on the remote take the
-    restart-recovery shortcut and skip the CLI — silently ignoring the operator's
-    new repair request (PRRT_kwDOSJAM6s6KE2BX). A fresh block re-records the marker.
-    """
-    pending_hint = getattr(state, "pending_operator_hint", None)
-    active_hint = pending_hint or hint
-    _mark_referenced_needs_human_feedback_answered(
-        state, hint=active_hint, acted_text=acted_feedback_text
-    )
-    state.threads_addressed_ids.pop(_PROTECTED_BLOCK_PRESERVED_HEAD_STATE_KEY, None)
-    if hasattr(state, "pending_operator_hint") and pending_hint is None and active_hint is not None:
-        state.pending_operator_hint = active_hint
-    mark_operator_hint_processed(state)
-
-
-def _mark_referenced_needs_human_feedback_answered(
-    state: MonitorState,
-    *,
-    hint: OperatorHint | None = None,
-    acted_text: str | None = None,
-) -> None:
-    """Retire review-level ``needs_human`` verdicts a guide explicitly answered.
-
-    Operator guides are the sanctioned path for resolving a monitor HUMAN_WAIT.
-    Two id classes are recognized, and they are retired differently:
-
-    * **Review comments** (``issue:<id>`` / ``bbcomment:<id>`` / contextual bare
-      ids). There is no forge thread to resolve, so a consumed guide that names
-      the original feedback id in the acted-on text must itself update the
-      persisted verdict, flipping it to ``false_positive``. Otherwise the hint is
-      marked processed and the next ``decide()`` poll immediately re-enters the
-      same stale HUMAN_WAIT.
-    * **Review threads** (``PRRT_...`` and the Bitbucket ``bb:``/``bbtask:``
-      keys). Here the verdict is *cleared* rather than flipped: an absent verdict
-      makes ``needs_comment_attention`` True, so the thread re-enters
-      ``AddressComments`` on the next poll and the agent records the real
-      verdict (issue #938). Flipping it to ``false_positive`` would assert a
-      verdict on the operator's behalf and let the merge gate pass without the
-      agent ever re-reading the thread. The directive is also stashed under
-      ``__operator_decision__:<thread id>`` so the re-addressed thread's repair
-      prompt quotes the ruling instead of replaying only the reviewer text the
-      agent already escalated on (issue #939); ``_mark_review_thread_addressed``
-      drops it once a verdict other than ``agent_failed`` answers it. The stash
-      also survives PR re-adoption: ``__operator_decision__:`` is on the copied
-      marker allowlist in :mod:`awf.service.pr_monitor_adoption_seed`, so a
-      successor workspace that adopts the PR before the re-queued thread is
-      addressed still quotes the ruling. Like the head-independent verdicts it
-      crosses whether or not head continuity is established -- it disposes of
-      the *feedback* rather than asserting what the branch contains.
-
-    ``hint.reason`` can be audit context for approve-and-keep grant-only resumes,
-    which skip the CLI entirely. Callers pass ``acted_text`` when a directiveless
-    reason was actually presented to the agent; otherwise only a directive counts.
-
-    This helper intentionally leaves any stored ``__review_comment_body_hash__`` /
-    ``__review_thread_body_hash__`` marker unchanged because it does not receive
-    the live ``ReviewComment``/``ReviewThread`` needed to recompute the hash. To
-    keep the retirement durable across the next stale-state sweep, it only retires
-    rows that already have body-hash sidecar state. Legacy rows without that
-    marker remain ``needs_human`` until a path holding the live item can snapshot
-    the body. For a cleared thread the snapshot is also what keeps a later
-    ``defer``/``needs_human`` re-queueable, so it must survive the clear.
-    """
-    if hint is None:
-        return
-    text = acted_text if acted_text is not None else hint.directive
-    if not text:
-        return
-    for referenced_id in _operator_hint_feedback_id_candidates(text):
-        for item_id in _operator_hint_feedback_storage_key_candidates(referenced_id):
-            if state.threads_addressed_ids.get(item_id) != "needs_human":
-                continue
-            if not state.threads_addressed_ids.get(_operator_hint_feedback_body_hash_key(item_id)):
-                continue
-            state.mark_addressed(item_id, "false_positive")
-            state.threads_addressed_ids.pop(f"__needs_human_reason__:{item_id}", None)
-            break
-    for thread_id in _operator_hint_review_thread_id_candidates(text):
-        if state.threads_addressed_ids.get(thread_id) != "needs_human":
-            continue
-        if not state.threads_addressed_ids.get(review_thread_body_state_key(thread_id)):
-            continue
-        state.threads_addressed_ids.pop(thread_id, None)
-        state.threads_addressed_ids.pop(f"__needs_human_reason__:{thread_id}", None)
-        state.mark_addressed(
-            _operator_decision_key(thread_id), _operator_decision_marker_text(text)
-        )
 
 
 def _operator_hint_block_reason(

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -16,6 +16,7 @@ from awf.control.blocked_transition import (
 from awf.control.quality_gates import QualityGateViolation
 from awf.db.enums import FailureReason
 from awf.db.repositories import WorkspaceRepository
+from awf.runtime.feedback_policy import review_thread_body_state_key
 from awf.runtime.logs import WorkspaceLogSink
 from awf.runtime.monitor_prompts import operator_hint_prompt
 from awf.runtime.operator_hints import (
@@ -69,6 +70,28 @@ _OPERATOR_HINT_BARE_FEEDBACK_ID_RE = re.compile(
     \b
     """,
     re.IGNORECASE | re.VERBOSE,
+)
+# Recognize the forge-neutral review-THREAD key forms an operator can name in a
+# guide directive: the GitHub GraphQL review-thread node id and the Bitbucket
+# thread/task encodings from ``awf.common.bitbucket_client_parsing``. The shapes
+# mirror the adoption-seeding contract (``awf.service.pr_monitor_adoption_seed``)
+# so both layers agree on what counts as a thread key.
+#
+# Matching is CASE-SENSITIVE, unlike the comment regexes above (which lowercase
+# their match): GraphQL node ids and Bitbucket owner/repo slugs are
+# case-significant and the extracted text is used as a literal state-map key, so
+# a case-folded id would simply miss. ``bbcomment:<id>`` is deliberately absent —
+# it is a comment id and stays on the comment path.
+_OPERATOR_HINT_REVIEW_THREAD_ID_RE = re.compile(
+    r"""
+    \b
+    (?:
+        PRRT_[A-Za-z0-9_-]+
+        | bbtask:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+\#\d+:\d+
+        | bb:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+\#\d+:\d+
+    )
+    """,
+    re.VERBOSE,
 )
 _PROTECTED_HISTORY_DIRECTIVE_REBLOCK_PREFIX = "__awf_protected_history_directive_reblocked__:"
 
@@ -1197,22 +1220,34 @@ def _mark_referenced_needs_human_feedback_answered(
     """Retire review-level ``needs_human`` verdicts a guide explicitly answered.
 
     Operator guides are the sanctioned path for resolving a monitor HUMAN_WAIT.
-    For review-level comments there is no GitHub thread to resolve, so a consumed
-    guide that names the original issue/review feedback id in the acted-on text
-    must also update the persisted verdict. Otherwise the hint is marked
-    processed and the next ``decide()`` poll immediately re-enters the same stale
-    HUMAN_WAIT.
+    Two id classes are recognized, and they are retired differently:
+
+    * **Review comments** (``issue:<id>`` / ``bbcomment:<id>`` / contextual bare
+      ids). There is no forge thread to resolve, so a consumed guide that names
+      the original feedback id in the acted-on text must itself update the
+      persisted verdict, flipping it to ``false_positive``. Otherwise the hint is
+      marked processed and the next ``decide()`` poll immediately re-enters the
+      same stale HUMAN_WAIT.
+    * **Review threads** (``PRRT_...`` and the Bitbucket ``bb:``/``bbtask:``
+      keys). Here the verdict is *cleared* rather than flipped: an absent verdict
+      makes ``needs_comment_attention`` True, so the thread re-enters
+      ``AddressComments`` on the next poll with the directive in context and the
+      agent records the real verdict (issue #938). Flipping it to
+      ``false_positive`` would assert a verdict on the operator's behalf and let
+      the merge gate pass without the agent ever re-reading the thread.
 
     ``hint.reason`` can be audit context for approve-and-keep grant-only resumes,
     which skip the CLI entirely. Callers pass ``acted_text`` when a directiveless
     reason was actually presented to the agent; otherwise only a directive counts.
 
-    This helper intentionally leaves any stored ``__review_comment_body_hash__``
-    marker unchanged because it does not receive the live ``ReviewComment`` needed
-    to recompute the hash. To keep the retirement durable across the next
-    stale-state sweep, it only retires rows that already have body-hash sidecar
-    state. Legacy rows without that marker remain ``needs_human`` until a path
-    holding the live comment can snapshot the body.
+    This helper intentionally leaves any stored ``__review_comment_body_hash__`` /
+    ``__review_thread_body_hash__`` marker unchanged because it does not receive
+    the live ``ReviewComment``/``ReviewThread`` needed to recompute the hash. To
+    keep the retirement durable across the next stale-state sweep, it only retires
+    rows that already have body-hash sidecar state. Legacy rows without that
+    marker remain ``needs_human`` until a path holding the live item can snapshot
+    the body. For a cleared thread the snapshot is also what keeps a later
+    ``defer``/``needs_human`` re-queueable, so it must survive the clear.
     """
     if hint is None:
         return
@@ -1228,6 +1263,13 @@ def _mark_referenced_needs_human_feedback_answered(
             state.mark_addressed(item_id, "false_positive")
             state.threads_addressed_ids.pop(f"__needs_human_reason__:{item_id}", None)
             break
+    for thread_id in _operator_hint_review_thread_id_candidates(text):
+        if state.threads_addressed_ids.get(thread_id) != "needs_human":
+            continue
+        if not state.threads_addressed_ids.get(review_thread_body_state_key(thread_id)):
+            continue
+        state.threads_addressed_ids.pop(thread_id, None)
+        state.threads_addressed_ids.pop(f"__needs_human_reason__:{thread_id}", None)
 
 
 def _operator_hint_feedback_body_hash_key(item_id: str) -> str:
@@ -1255,6 +1297,19 @@ def _operator_hint_feedback_id_candidates(text: str) -> tuple[str, ...]:
             continue
         seen.add(item_id)
         candidates.append(item_id)
+    return tuple(candidates)
+
+
+def _operator_hint_review_thread_id_candidates(text: str) -> tuple[str, ...]:
+    """Review-thread ids named in ``text``, deduped in first-occurrence order."""
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for match in _OPERATOR_HINT_REVIEW_THREAD_ID_RE.finditer(text):
+        thread_id = match.group(0)
+        if thread_id in seen:
+            continue
+        seen.add(thread_id)
+        candidates.append(thread_id)
     return tuple(candidates)
 
 

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -107,6 +107,13 @@ def _thread_has_live_operator_decision(state: MonitorState, thread: ReviewThread
     a verdict other than ``agent_failed`` (``_mark_review_thread_addressed``) or
     when a reviewer reply makes the ruling stale (``_operator_decision_for_thread``),
     and any recorded verdict already excludes the thread from both steps.
+
+    That is why this keys on the LIVE marker only. The *retired* sidecar
+    (``__retired_operator_decision__``) deliberately outlives the verdict that
+    answered the ruling so a rollback can restore it, so honoring it here would
+    make the exemption permanent — hygiene would skip the thread forever and the
+    merge gate would hold at ``NotifyHuman`` on an invisible conversation, the
+    very #484 wedge seeding exists to prevent.
     """
     return state.threads_addressed_ids.get(_operator_decision_key(thread.thread_id)) is not None
 

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -33,7 +33,10 @@ from awf.common.forge_errors import ForgeClientError
 from awf.common.github_client import GitHubClientError, RepoRef
 from awf.runtime.feedback_policy import preferred_duplicate_review_thread
 from awf.runtime.logs import WorkspaceLogSink
-from awf.runtime.monitor_state_keys import _outdated_resolve_requeued_key
+from awf.runtime.monitor_state_keys import (
+    _operator_decision_key,
+    _outdated_resolve_requeued_key,
+)
 from awf.runtime.pr_monitor import (
     MergeStateStatus,
     MonitorState,
@@ -82,6 +85,30 @@ def _outdated_thread_is_resolvable(state: MonitorState, thread: ReviewThread) ->
     if verdict != "defer":
         return False
     return _deferred_issue_already_filed(state, thread)
+
+
+def _thread_has_live_operator_decision(state: MonitorState, thread: ReviewThread) -> bool:
+    """True while a guide's operator ruling still owns this thread's next pass (#939).
+
+    A guide that answers a parked ``needs_human`` *clears* the thread verdict and
+    stashes the directive under ``__operator_decision__:<thread id>`` so the
+    thread re-enters ``AddressComments`` and the agent re-triages it with the
+    ruling quoted. Both pre-decision hygiene steps below key on "no ``thread_id``
+    verdict", so an outdated thread in exactly that window looks unseeded to
+    them. Left alone they would seed a verdict from the branch/comment evidence
+    the operator just ruled on — ``needs_human`` (straight back to the same human
+    wait, ruling unread) when a reviewer reply postdates the earlier ``fix:
+    address <thread id>`` commit, or ``fix_committed`` (thread resolved without
+    the requested re-triage) otherwise. Neither is hygiene's call while a live
+    ruling is pending, so both steps skip these threads and the guide-created
+    requeue owns the next pass (PRRT_kwDOSJAM6s6fwt3a).
+
+    The exemption is self-limiting: the marker is dropped once the thread records
+    a verdict other than ``agent_failed`` (``_mark_review_thread_addressed``) or
+    when a reviewer reply makes the ruling stale (``_operator_decision_for_thread``),
+    and any recorded verdict already excludes the thread from both steps.
+    """
+    return state.threads_addressed_ids.get(_operator_decision_key(thread.thread_id)) is not None
 
 
 def _thread_identifier_set(thread: ReviewThread) -> set[str]:
@@ -276,6 +303,9 @@ async def _seed_outdated_thread_verdicts_from_branch_evidence(
     suppress AddressComments while never calling ``resolve_thread``, letting a
     CLEAN snapshot merge over an open forge thread — or required-conversation
     protection loop on NotifyHuman (PRRT_kwDOSJAM6s6dfPZ2).
+
+    Threads carrying a live operator ruling are excluded too — see
+    ``_thread_has_live_operator_decision`` (#939 / PRRT_kwDOSJAM6s6fwt3a).
     """
     active_thread_ids = {t.thread_id for t in status.unresolved_inline_threads}
     unseeded = [
@@ -283,6 +313,10 @@ async def _seed_outdated_thread_verdicts_from_branch_evidence(
         for thread in status.outdated_unresolved_inline_threads
         if thread.thread_id not in active_thread_ids
         and state.threads_addressed_ids.get(thread.thread_id) is None
+        # #939: a guide-cleared thread carrying a live operator ruling is awaiting
+        # re-triage through ``AddressComments``, not a verdict reconstructed from
+        # the evidence the operator just ruled on (PRRT_kwDOSJAM6s6fwt3a).
+        and not _thread_has_live_operator_decision(state, thread)
         # #548: never seed ``fix_committed`` from branch evidence onto a thread
         # that already holds a blocking sibling comment verdict (``needs_human`` /
         # ``agent_failed`` / ``defer``). The matching ``fix: address`` commit for a
@@ -432,13 +466,22 @@ def _reconcile_comment_keyed_outdated_verdicts(
     Dual-feed IDs are skipped for the same reason as branch-evidence seeding
     (PRRT_kwDOSJAM6s6dfPZ2): promoting a resolvable verdict onto a shared id
     before hygiene's active-wins skip suppresses AddressComments without ever
-    resolving the forge thread. Active-path ownership handles those IDs.
+    resolving the forge thread. Active-path ownership handles those IDs. Threads
+    carrying a live operator ruling are skipped as well — see
+    ``_thread_has_live_operator_decision`` (#939 / PRRT_kwDOSJAM6s6fwt3a).
     """
     active_thread_ids = {t.thread_id for t in status.unresolved_inline_threads}
     for thread in status.outdated_unresolved_inline_threads:
         if thread.thread_id in active_thread_ids:
             continue
         if state.threads_addressed_ids.get(thread.thread_id) is not None:
+            continue
+        # #939: an operator guide cleared this thread's ``needs_human`` and stashed
+        # its ruling; the requeue it created owns the next pass. Promoting a
+        # comment-keyed verdict (or the mixed-verdict ``needs_human`` below) here
+        # would resolve the thread — or re-park it — without the agent ever reading
+        # the directive (PRRT_kwDOSJAM6s6fwt3a).
+        if _thread_has_live_operator_decision(state, thread):
             continue
         # #548: a thread can hold mixed per-comment verdicts — e.g. one comment
         # ``fix_committed`` and a reply ``needs_human``. Promoting the resolvable

--- a/src/awf/service/pr_monitor_adoption_seed.py
+++ b/src/awf/service/pr_monitor_adoption_seed.py
@@ -10,9 +10,10 @@ and ``issue:5549805025`` after ``ws_8742af8348794904b3ce5ac5`` had already marke
 them ``false_positive``).
 
 This module owns the pure, I/O-free policy for what may cross that boundary. It
-is an **allowlist**, not a denylist: only comment/thread verdicts and the three
-evidence-marker classes that keep those verdicts honest are copied, so a marker
-class added later is dropped by default rather than silently inherited.
+is an **allowlist**, not a denylist: only comment/thread verdicts and the
+evidence-marker classes that keep those verdicts (and the re-queues they imply)
+honest are copied, so a marker class added later is dropped by default rather
+than silently inherited.
 
 The allowlist is additionally gated on *head continuity*: ``fix_committed`` and
 ``false_positive`` are both claims about the code at one particular head -- the fix
@@ -22,8 +23,10 @@ adopted head is the head the predecessor processed. The remaining verdicts judge
 the feedback rather than the code and cross either way.
 
 Deliberately never copied: protected-block state, awaiting-required-checks
-timestamps, operator-hint bookkeeping, awaiting-workflow-scope / merge-block
-markers, notify/settle/grace bookkeeping, and defer/needs-human reason text.
+timestamps, operator-hint *cycle* bookkeeping (the pending-hint record and its
+processed markers -- as opposed to the per-thread operator decision below),
+awaiting-workflow-scope / merge-block markers, notify/settle/grace bookkeeping,
+and defer/needs-human reason text.
 Those describe the *previous run's* position on a PR that has since moved; the
 fresh monitor must re-derive them from the live PR.
 """
@@ -97,10 +100,26 @@ _VERDICT_KEY_RE = re.compile(
 # triaged it (and, when present, keep an unchanged seeded verdict from being
 # treated as stale on the successor's first poll). The deferred-issue marker
 # prevents filing a duplicate follow-up issue.
+#
+# ``__operator_decision__:<thread id>`` (``awf.runtime.monitor_state_keys``) is
+# the ruling that un-parked a ``needs_human`` thread: the guide *clears* the
+# verdict (issue #938), so such a thread crosses this boundary as a body hash
+# with no verdict and the successor re-queues it into ``AddressComments``.
+# Without the ruling the repair prompt is rebuilt from the reviewer text alone
+# and the agent can repeat the rejected approach and re-park -- exactly the loop
+# issue #939 exists to break. It is copied regardless of head continuity: like
+# ``defer``/``needs_human`` it disposes of the *feedback* rather than asserting
+# what the branch contains, it never suppresses feedback nor unblocks the merge
+# gate, and it reaches the agent only as quoted untrusted evidence in the repair
+# prompt. It is redacted and length-capped where it is written, so no unbounded
+# or secret-bearing text crosses. A thread that records any verdict other than
+# ``agent_failed`` drops the marker at the source, so a marker that survives to
+# adoption always belongs to a thread still owed an answer.
 _COPIED_MARKER_PREFIXES = (
     "__review_comment_body_hash__:",
     "__review_thread_body_hash__:",
     "__deferred_issue_filed__:",
+    "__operator_decision__:",
 )
 
 # A head SHA counts as continuity evidence only in its full 40-hex form. An

--- a/src/awf/service/pr_monitor_adoption_seed.py
+++ b/src/awf/service/pr_monitor_adoption_seed.py
@@ -120,9 +120,17 @@ _VERDICT_KEY_RE = re.compile(
 # because a verdict answered it, held so a rollback of that still-unconfirmed
 # verdict restores it with the thread. It carries the same bounded, redacted text
 # and the same "quoted evidence only" reach, so it crosses on the same terms --
-# and adoption dropping a head-dependent verdict is itself such a rollback, so
+# and adoption dropping a verdict is itself such a rollback, so
 # :func:`_restore_orphaned_operator_decisions` un-parks it when its verdict does
-# not cross.
+# not cross *and* head continuity holds. Unlike the live marker, un-parking is
+# gated on continuity: this ruling was already consumed once and the verdict it
+# produced is exactly the head-dependent verdict the boundary just discarded, so
+# replaying it as a live directive ("follow that ruling, do not escalate") on a
+# head that moved would re-manufacture the discarded verdict against code that
+# may no longer support it -- and neither ``fix_committed`` nor ``false_positive``
+# blocks the merge gate (PRRT_kwDOSJAM6s6fyCVP). Without continuity the parked
+# ruling is dropped rather than left in place, so a later rollback on the
+# successor cannot revive it against the new head either.
 #
 # ``__operator_decision_at__:<thread id>`` is the issue-time binding for a ruling
 # that crossed with no body hash (the hygiene-seeded ``needs_human`` rows a guide
@@ -192,8 +200,10 @@ def seedable_monitor_state(
     ``head_continuity`` states whether the head the successor adopts still carries
     the predecessor's processed head (:func:`head_continuity_established`). It
     fails closed: without it, the head-dependent ``fix_committed`` /
-    ``false_positive`` verdicts are dropped and re-triaged, while the
-    head-independent dispositions still cross.
+    ``false_positive`` verdicts are dropped and re-triaged -- along with any
+    parked operator ruling they answered, which would otherwise be replayed as a
+    live directive and recreate the dropped verdict -- while the head-independent
+    dispositions still cross.
 
     The result is key-sorted (deterministic ``copied_keys`` in the seeded event)
     and is always a fresh dict, so callers may mutate it -- e.g. to arm a pending
@@ -210,25 +220,44 @@ def seedable_monitor_state(
             or _is_copied_marker(key, value)
         )
     }
-    return dict(sorted(_restore_orphaned_operator_decisions(seeded).items()))
+    return dict(
+        sorted(
+            _restore_orphaned_operator_decisions(seeded, head_continuity=head_continuity).items()
+        )
+    )
 
 
-def _restore_orphaned_operator_decisions(seeded: dict[str, str]) -> dict[str, str]:
+def _restore_orphaned_operator_decisions(
+    seeded: dict[str, str], *, head_continuity: bool
+) -> dict[str, str]:
     """Un-park a ruling whose answering verdict did not cross the boundary.
 
     ``_mark_review_thread_addressed`` parks the operator ruling under
     ``__operator_decision_retired__:<id>`` when a verdict answers it, and
     ``_clear_addressed_state_by_id`` un-parks it whenever that still-unconfirmed
-    verdict is rolled back. Dropping a head-dependent verdict here is the same
-    rollback: the successor re-queues the unchanged thread into
-    ``AddressComments``, so it must carry the ruling or the agent re-reads only
-    the reviewer text it already escalated on and can repeat the rejected
-    approach and re-park (issue #939).
+    verdict is rolled back. Dropping a verdict here is the same rollback: the
+    successor re-queues the unchanged thread into ``AddressComments``, so it must
+    carry the ruling or the agent re-reads only the reviewer text it already
+    escalated on and can repeat the rejected approach and re-park (issue #939).
 
     A ruling therefore stays parked only alongside the verdict it answered. With
     that verdict gone it is promoted back to a live decision -- unless the
     operator has since issued a fresh one, which is their latest word on the
     thread and supersedes the parked copy.
+
+    That promotion requires head continuity. A ruling reaches this sidecar only
+    by having already produced a verdict, and on a moved head the verdict it
+    produced is the head-dependent one this boundary just dropped as no longer
+    provably true of the branch. Quoting the ruling as a live directive -- the
+    repair prompt tells the agent to follow it and not to re-escalate -- would
+    recreate that verdict against code that may have been force-pushed away, and
+    ``fix_committed`` / ``false_positive`` neither re-enter ``AddressComments``
+    nor block the merge gate, so the PR could merge over still-valid feedback
+    (PRRT_kwDOSJAM6s6fyCVP). Without continuity the ruling is therefore dropped
+    outright rather than left parked: a parked copy would otherwise be revived
+    against the new head by the successor's own next verdict rollback. The
+    successor re-triages the thread from the reviewer text alone and escalates
+    again if it must -- the same conservative re-triage the dropped verdict buys.
     """
     restored = dict(seeded)
     for key, value in seeded.items():
@@ -238,6 +267,8 @@ def _restore_orphaned_operator_decisions(seeded: dict[str, str]) -> dict[str, st
         if item_id in seeded:
             continue
         del restored[key]
+        if not head_continuity:
+            continue
         live_key = f"{_OPERATOR_DECISION_PREFIX}{item_id}"
         if live_key not in seeded:
             restored[live_key] = value

--- a/src/awf/service/pr_monitor_adoption_seed.py
+++ b/src/awf/service/pr_monitor_adoption_seed.py
@@ -115,11 +115,22 @@ _VERDICT_KEY_RE = re.compile(
 # or secret-bearing text crosses. A thread that records any verdict other than
 # ``agent_failed`` drops the marker at the source, so a marker that survives to
 # adoption always belongs to a thread still owed an answer.
+#
+# ``__operator_decision_retired__:<thread id>`` is the same ruling *parked*
+# because a verdict answered it, held so a rollback of that still-unconfirmed
+# verdict restores it with the thread. It carries the same bounded, redacted text
+# and the same "quoted evidence only" reach, so it crosses on the same terms --
+# and adoption dropping a head-dependent verdict is itself such a rollback, so
+# :func:`_restore_orphaned_operator_decisions` un-parks it when its verdict does
+# not cross.
+_OPERATOR_DECISION_PREFIX = "__operator_decision__:"
+_RETIRED_OPERATOR_DECISION_PREFIX = "__operator_decision_retired__:"
 _COPIED_MARKER_PREFIXES = (
     "__review_comment_body_hash__:",
     "__review_thread_body_hash__:",
     "__deferred_issue_filed__:",
-    "__operator_decision__:",
+    _OPERATOR_DECISION_PREFIX,
+    _RETIRED_OPERATOR_DECISION_PREFIX,
 )
 
 # A head SHA counts as continuity evidence only in its full 40-hex form. An
@@ -189,7 +200,38 @@ def seedable_monitor_state(
             or _is_copied_marker(key, value)
         )
     }
-    return dict(sorted(seeded.items()))
+    return dict(sorted(_restore_orphaned_operator_decisions(seeded).items()))
+
+
+def _restore_orphaned_operator_decisions(seeded: dict[str, str]) -> dict[str, str]:
+    """Un-park a ruling whose answering verdict did not cross the boundary.
+
+    ``_mark_review_thread_addressed`` parks the operator ruling under
+    ``__operator_decision_retired__:<id>`` when a verdict answers it, and
+    ``_clear_addressed_state_by_id`` un-parks it whenever that still-unconfirmed
+    verdict is rolled back. Dropping a head-dependent verdict here is the same
+    rollback: the successor re-queues the unchanged thread into
+    ``AddressComments``, so it must carry the ruling or the agent re-reads only
+    the reviewer text it already escalated on and can repeat the rejected
+    approach and re-park (issue #939).
+
+    A ruling therefore stays parked only alongside the verdict it answered. With
+    that verdict gone it is promoted back to a live decision -- unless the
+    operator has since issued a fresh one, which is their latest word on the
+    thread and supersedes the parked copy.
+    """
+    restored = dict(seeded)
+    for key, value in seeded.items():
+        if not key.startswith(_RETIRED_OPERATOR_DECISION_PREFIX):
+            continue
+        item_id = key[len(_RETIRED_OPERATOR_DECISION_PREFIX) :]
+        if item_id in seeded:
+            continue
+        del restored[key]
+        live_key = f"{_OPERATOR_DECISION_PREFIX}{item_id}"
+        if live_key not in seeded:
+            restored[live_key] = value
+    return restored
 
 
 def _is_verdict_entry(key: str, value: str, *, head_continuity: bool) -> bool:

--- a/src/awf/service/pr_monitor_adoption_seed.py
+++ b/src/awf/service/pr_monitor_adoption_seed.py
@@ -123,13 +123,23 @@ _VERDICT_KEY_RE = re.compile(
 # and adoption dropping a head-dependent verdict is itself such a rollback, so
 # :func:`_restore_orphaned_operator_decisions` un-parks it when its verdict does
 # not cross.
+#
+# ``__operator_decision_at__:<thread id>`` is the issue-time binding for a ruling
+# that crossed with no body hash (the hygiene-seeded ``needs_human`` rows a guide
+# clears): it is what lets the successor retire the ruling when a reviewer replied
+# after the operator read the thread. It travels with the ruling for the same
+# reason body hashes travel with verdicts -- left behind, the successor would quote
+# guidance the reviewer's reply already outran (PRRT_kwDOSJAM6s6fxBwT). The value is
+# an ISO-8601 timestamp AWF wrote itself, so nothing untrusted crosses with it.
 _OPERATOR_DECISION_PREFIX = "__operator_decision__:"
+_OPERATOR_DECISION_ISSUED_AT_PREFIX = "__operator_decision_at__:"
 _RETIRED_OPERATOR_DECISION_PREFIX = "__operator_decision_retired__:"
 _COPIED_MARKER_PREFIXES = (
     "__review_comment_body_hash__:",
     "__review_thread_body_hash__:",
     "__deferred_issue_filed__:",
     _OPERATOR_DECISION_PREFIX,
+    _OPERATOR_DECISION_ISSUED_AT_PREFIX,
     _RETIRED_OPERATOR_DECISION_PREFIX,
 )
 

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -172,6 +172,30 @@ def test_bounded_directive_ignores_prefix_sibling_thread_ids() -> None:
 
 
 @pytest.mark.unit
+def test_bounded_directive_ignores_embedding_sibling_thread_ids() -> None:
+    """A key embedded in a longer sibling id anchors nothing, head side included.
+
+    Guarding only the end of the id still lets an anchor that a longer sibling
+    *ends* with (``PRRT_a`` inside ``PRRT_zPRRT_a``) window the shorter thread's
+    stored copy on the sibling's ruling (PRRT_kwDOSJAM6s6fxier). Only a mention
+    the thread-key grammar tokenizes as the whole anchor counts.
+    """
+    sibling_id = f"PRRT_kwDOSJAM6s6{THREAD_ID}"
+    state = _parked_state(THREAD_ID, sibling_id)
+    sibling_ruling = f"For {sibling_id}: the reviewer is wrong; record FALSE POSITIVE. " + (
+        "x" * (_OPERATOR_DECISION_MAX_CHARS * 2)
+    )
+    ruling = f"For {THREAD_ID}: rework the guard and record FIXED."
+    directive = f"{sibling_ruling}\n{ruling}"
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(directive))
+
+    stored = state.threads_addressed_ids[DECISION_KEY]
+    assert ruling in stored
+    assert "FALSE POSITIVE" not in stored
+
+
+@pytest.mark.unit
 def test_retirement_leaves_unnamed_threads_untouched() -> None:
     """Only the thread the directive names gains a decision marker."""
     state = _parked_state(THREAD_ID, OTHER_THREAD_ID)

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -401,6 +401,62 @@ def test_rolled_back_verdict_restores_the_operator_decision(verdict: str) -> Non
 
 
 @pytest.mark.unit
+def test_rollback_keeps_the_restored_ruling_for_the_unchanged_body() -> None:
+    """The restored ruling stays bound to the conversation it covered.
+
+    The rollback deletes the thread's body snapshot along with the verdict, so
+    without re-recording it the restored ruling would carry no hash to compare —
+    and ``_operator_decision_for_thread`` deliberately keeps rulings it cannot
+    compare. On an unchanged conversation the ruling is still the operator's word.
+    """
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+    thread = _thread()
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+
+    _clear_addressed_state_by_id(state, THREAD_ID)
+
+    assert comments._operator_decision_for_thread(state, thread) == DIRECTIVE
+
+
+@pytest.mark.unit
+def test_rollback_restored_ruling_is_dropped_by_a_reviewer_reply() -> None:
+    """A reply arriving before the retry supersedes the restored ruling.
+
+    Without the preserved snapshot the un-comparable ruling would be replayed
+    into the repair prompt as guidance for feedback the operator never read,
+    while telling the agent not to re-escalate.
+    """
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+    thread = _thread()
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+
+    _clear_addressed_state_by_id(state, THREAD_ID)
+
+    replied = replace(thread, body_excerpt="new reviewer reply")
+    assert comments._operator_decision_for_thread(state, replied) is None
+    assert DECISION_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_rollback_keeps_a_live_ruling_comparable_to_the_new_feedback() -> None:
+    """A live ruling the rollback preserves keeps its body binding too.
+
+    The clear drops the snapshot for every item; a live ruling that survives it
+    would otherwise become un-comparable in exactly the same way as a restored one.
+    """
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+    thread = _thread()
+    _mark_review_thread_addressed(state, thread, "needs_human")
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(SECOND_DIRECTIVE))
+
+    _clear_addressed_state_by_id(state, THREAD_ID)
+
+    replied = replace(thread, body_excerpt="new reviewer reply")
+    assert comments._operator_decision_for_thread(state, replied) is None
+    assert DECISION_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
 def test_rollback_without_a_retired_decision_adds_nothing() -> None:
     """A thread that never had a ruling gains no marker from a rollback."""
     state = MonitorState(threads_addressed_ids={})

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -54,12 +54,15 @@ SECOND_DIRECTIVE = (
 _REPO = RepoRef(owner="dimileeh", name="agent-workspace-fabric")
 
 
+GUIDE_REQUESTED_AT = "2026-09-06T21:00:00+00:00"
+
+
 def _guide(directive: str) -> OperatorHint:
     return OperatorHint(
         reason="operator guide",
         directive=directive,
         operation_id="op_guide_939",
-        requested_at="2026-09-06T21:00:00+00:00",
+        requested_at=GUIDE_REQUESTED_AT,
         reason_code="OPERATOR_GUIDE",
     )
 
@@ -625,13 +628,57 @@ def _replied_thread(*, at: datetime | None, viewer_did_author: bool = False) -> 
 
 @pytest.mark.unit
 def test_hashless_retirement_stamps_the_ruling_issue_time() -> None:
-    """A ruling with no snapshot to bind it to records when it was issued."""
-    before = datetime.now(UTC)
+    """The stamp is when the operator wrote the guide, not when AWF consumed it.
 
+    A guide can sit queued for a monitor cycle; dating the ruling from consumption
+    would adopt a reply that landed in between as feedback the operator ruled on.
+    """
     state = _hashless_ruling_state()
 
     stamped = datetime.fromisoformat(state.threads_addressed_ids[ISSUED_AT_KEY])
+    assert stamped == datetime.fromisoformat(GUIDE_REQUESTED_AT)
+
+
+@pytest.mark.unit
+def test_naive_requested_at_is_stamped_as_utc() -> None:
+    """An offsetless hint timestamp still orders against forge timestamps."""
+    state = MonitorState(threads_addressed_ids={THREAD_ID: "needs_human"})
+    naive = replace(_guide(DIRECTIVE), requested_at="2026-09-06T21:00:00")
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=naive)
+
+    assert state.threads_addressed_ids[ISSUED_AT_KEY] == GUIDE_REQUESTED_AT
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("requested_at", [None, "", "not-a-timestamp"])
+def test_undatable_guide_stamps_the_consume_time(requested_at: str | None) -> None:
+    """Without a usable request time, now is the latest the ruling can be from."""
+    before = datetime.now(UTC)
+    state = MonitorState(threads_addressed_ids={THREAD_ID: "needs_human"})
+    undatable = replace(_guide(DIRECTIVE), requested_at=requested_at)
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=undatable)
+
+    stamped = datetime.fromisoformat(state.threads_addressed_ids[ISSUED_AT_KEY])
     assert before <= stamped <= datetime.now(UTC)
+
+
+@pytest.mark.unit
+def test_reply_while_the_guide_was_queued_retires_the_ruling() -> None:
+    """The window between writing the guide and consuming it is now covered.
+
+    This reply predates the retirement pass, so a consume-time stamp would have
+    kept the ruling and replayed it over feedback the operator never read
+    (PRRT_kwDOSJAM6s6fxBwT).
+    """
+    state = _hashless_ruling_state()
+    queued_reply = _replied_thread(
+        at=datetime.fromisoformat(GUIDE_REQUESTED_AT) + timedelta(minutes=5)
+    )
+
+    assert comments._operator_decision_for_thread(state, queued_reply) is None
+    assert DECISION_KEY not in state.threads_addressed_ids
 
 
 @pytest.mark.unit
@@ -665,7 +712,7 @@ def test_reply_after_a_hashless_ruling_retires_it() -> None:
 def test_unchanged_conversation_keeps_the_hashless_ruling() -> None:
     """Activity the operator already read does not retire their ruling."""
     state = _hashless_ruling_state()
-    unchanged = _replied_thread(at=datetime.now(UTC) - timedelta(hours=1))
+    unchanged = _replied_thread(at=datetime.fromisoformat(GUIDE_REQUESTED_AT) - timedelta(hours=1))
 
     assert comments._operator_decision_for_thread(state, unchanged) == DIRECTIVE
     assert state.threads_addressed_ids[ISSUED_AT_KEY]

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -12,6 +12,7 @@ and dropped once the thread records a real verdict.
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -20,9 +21,12 @@ import pytest
 from awf.common.github_client import RepoRef
 from awf.runtime.feedback_policy import review_thread_body_hash, review_thread_body_state_key
 from awf.runtime.monitor_prompts import address_thread_prompt
-from awf.runtime.monitor_state_keys import _operator_decision_key
+from awf.runtime.monitor_state_keys import (
+    _operator_decision_issued_at_key,
+    _operator_decision_key,
+)
 from awf.runtime.pr_monitor import MonitorState, OperatorHint, _mark_review_thread_addressed
-from awf.runtime.pr_monitor_models import ReviewThread
+from awf.runtime.pr_monitor_models import ReviewThread, ReviewThreadComment
 from awf.runtime.pr_monitor_runner import comments
 from awf.runtime.pr_monitor_runner.comment_verdict import VerdictResult
 from awf.runtime.pr_monitor_runner.helpers import (
@@ -33,10 +37,12 @@ from awf.runtime.pr_monitor_runner.operator_hint_parsing import _OPERATOR_DECISI
 from awf.runtime.pr_monitor_runner.operator_hints import (
     _mark_referenced_needs_human_feedback_answered,
 )
+from awf.service.pr_monitor_adoption_seed import seedable_monitor_state
 
 THREAD_ID = "PRRT_kwDOSJAM6s6fsqcA"
 OTHER_THREAD_ID = "PRRT_kwDOSJAM6s6fsqcB"
 DECISION_KEY = _operator_decision_key(THREAD_ID)
+ISSUED_AT_KEY = _operator_decision_issued_at_key(THREAD_ID)
 DIRECTIVE = (
     f"For {THREAD_ID}: the off-anchor edit was wrong. Fix the guard at the "
     "reviewer's line and record FIXED; do not re-escalate."
@@ -593,3 +599,146 @@ def test_recorded_verdict_leaves_other_threads_decisions_alone() -> None:
     _mark_review_thread_addressed(state, _thread(), "fix_committed")
 
     assert state.threads_addressed_ids[other_key] == DIRECTIVE
+
+
+def _hashless_ruling_state() -> MonitorState:
+    """A guide-retired thread seeded by hygiene, i.e. with no body snapshot."""
+    state = MonitorState(threads_addressed_ids={THREAD_ID: "needs_human"})
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(DIRECTIVE))
+    return state
+
+
+def _replied_thread(*, at: datetime | None, viewer_did_author: bool = False) -> ReviewThread:
+    return replace(
+        _thread(),
+        comments=(
+            ReviewThreadComment(
+                comment_id="4688598838",
+                body="the guard still misses the empty case",
+                author="reviewer",
+                created_at=at,
+                viewer_did_author=viewer_did_author,
+            ),
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_hashless_retirement_stamps_the_ruling_issue_time() -> None:
+    """A ruling with no snapshot to bind it to records when it was issued."""
+    before = datetime.now(UTC)
+
+    state = _hashless_ruling_state()
+
+    stamped = datetime.fromisoformat(state.threads_addressed_ids[ISSUED_AT_KEY])
+    assert before <= stamped <= datetime.now(UTC)
+
+
+@pytest.mark.unit
+def test_hash_bound_retirement_records_no_stamp() -> None:
+    """A snapshot binds the ruling on its own; a stale stamp is cleared with it."""
+    state = _parked_state()
+    state.threads_addressed_ids[ISSUED_AT_KEY] = "2026-09-06T20:00:00+00:00"
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(DIRECTIVE))
+
+    assert ISSUED_AT_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_reply_after_a_hashless_ruling_retires_it() -> None:
+    """A reply landing before the re-addressed pass supersedes the ruling.
+
+    The hygiene-seeded row carries no body hash, so the snapshot comparison cannot
+    see this reply; without the issue-time stamp the repair prompt would quote a
+    ruling made before the feedback under "do not escalate" (PRRT_kwDOSJAM6s6fxBwT).
+    """
+    state = _hashless_ruling_state()
+    replied = _replied_thread(at=datetime.now(UTC) + timedelta(hours=1))
+
+    assert comments._operator_decision_for_thread(state, replied) is None
+    assert DECISION_KEY not in state.threads_addressed_ids
+    assert ISSUED_AT_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_unchanged_conversation_keeps_the_hashless_ruling() -> None:
+    """Activity the operator already read does not retire their ruling."""
+    state = _hashless_ruling_state()
+    unchanged = _replied_thread(at=datetime.now(UTC) - timedelta(hours=1))
+
+    assert comments._operator_decision_for_thread(state, unchanged) == DIRECTIVE
+    assert state.threads_addressed_ids[ISSUED_AT_KEY]
+
+
+@pytest.mark.unit
+def test_awf_reply_after_a_hashless_ruling_keeps_it() -> None:
+    """AWF's own follow-up is not reviewer feedback the operator failed to read."""
+    state = _hashless_ruling_state()
+    own_reply = _replied_thread(at=datetime.now(UTC) + timedelta(hours=1), viewer_did_author=True)
+
+    assert comments._operator_decision_for_thread(state, own_reply) == DIRECTIVE
+
+
+@pytest.mark.unit
+def test_naive_reply_timestamp_is_read_as_utc() -> None:
+    """A forge timestamp without an offset still orders against the stamp."""
+    state = _hashless_ruling_state()
+    replied = _replied_thread(at=datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=1))
+
+    assert comments._operator_decision_for_thread(state, replied) is None
+
+
+@pytest.mark.unit
+def test_untimestamped_conversation_keeps_the_hashless_ruling() -> None:
+    """Ordering is unprovable without comment timestamps, so the ruling stands."""
+    state = _hashless_ruling_state()
+
+    assert comments._operator_decision_for_thread(state, _replied_thread(at=None)) == DIRECTIVE
+
+
+@pytest.mark.unit
+def test_unparseable_stamp_keeps_the_hashless_ruling() -> None:
+    """A stamp AWF cannot read proves nothing about ordering — fail open."""
+    state = _hashless_ruling_state()
+    state.threads_addressed_ids[ISSUED_AT_KEY] = "not-a-timestamp"
+    replied = _replied_thread(at=datetime.now(UTC) + timedelta(hours=1))
+
+    assert comments._operator_decision_for_thread(state, replied) == DIRECTIVE
+
+
+@pytest.mark.unit
+def test_unstamped_hashless_ruling_is_still_kept() -> None:
+    """Rows written before the stamp existed keep the pre-existing behavior."""
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+    replied = _replied_thread(at=datetime.now(UTC) + timedelta(hours=1))
+
+    assert comments._operator_decision_for_thread(state, replied) == DIRECTIVE
+
+
+@pytest.mark.unit
+def test_stale_hash_bound_ruling_drops_its_stamp_too() -> None:
+    """A ruling retired by the snapshot check leaves no orphan stamp behind."""
+    state = _hashless_ruling_state()
+    thread = _thread()
+    state.threads_addressed_ids[review_thread_body_state_key(THREAD_ID)] = review_thread_body_hash(
+        thread
+    )
+
+    replied = replace(thread, body_excerpt="new reviewer reply")
+    assert comments._operator_decision_for_thread(state, replied) is None
+    assert ISSUED_AT_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_adoption_seeds_the_ruling_with_its_issue_time_binding() -> None:
+    """The stamp crosses re-adoption with the ruling it binds.
+
+    Left behind, the successor would hold an unbindable ruling again and quote it
+    over a reply the operator never read.
+    """
+    seeded = seedable_monitor_state(
+        {DECISION_KEY: DIRECTIVE, ISSUED_AT_KEY: "2026-09-07T02:00:00+00:00"}
+    )
+
+    assert seeded == {DECISION_KEY: DIRECTIVE, ISSUED_AT_KEY: "2026-09-07T02:00:00+00:00"}

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -11,6 +11,7 @@ and dropped once the thread records a real verdict.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -24,6 +25,10 @@ from awf.runtime.pr_monitor import MonitorState, OperatorHint, _mark_review_thre
 from awf.runtime.pr_monitor_models import ReviewThread
 from awf.runtime.pr_monitor_runner import comments
 from awf.runtime.pr_monitor_runner.comment_verdict import VerdictResult
+from awf.runtime.pr_monitor_runner.helpers import (
+    _clear_addressed_state_by_id,
+    _drop_stale_review_thread_addressed_state,
+)
 from awf.runtime.pr_monitor_runner.operator_hints import (
     _OPERATOR_DECISION_MAX_CHARS,
     _mark_referenced_needs_human_feedback_answered,
@@ -272,6 +277,57 @@ def test_agent_failure_keeps_the_operator_decision() -> None:
     _mark_review_thread_addressed(state, _thread(), "agent_failed")
 
     assert state.threads_addressed_ids[DECISION_KEY] == DIRECTIVE
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("verdict", ["fix_committed", "false_positive", "defer", "needs_human"])
+def test_rolled_back_verdict_restores_the_operator_decision(verdict: str) -> None:
+    """A cleared, unconfirmed verdict un-answers the ruling, so it comes back.
+
+    Fix-cycle rollbacks (push failure, mid-batch abort, resolve retry) drop the
+    verdict so the thread re-enters ``AddressComments``. Retirement was tied to
+    that verdict, so the ruling that un-parked the thread must return with it —
+    otherwise the agent re-reads only the reviewer text it already escalated on
+    and can repeat the rejected approach and re-park (issue #939).
+    """
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+    _mark_review_thread_addressed(state, _thread(), verdict)
+
+    _clear_addressed_state_by_id(state, THREAD_ID)
+
+    assert state.threads_addressed_ids[DECISION_KEY] == DIRECTIVE
+    assert THREAD_ID not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_rollback_without_a_retired_decision_adds_nothing() -> None:
+    """A thread that never had a ruling gains no marker from a rollback."""
+    state = MonitorState(threads_addressed_ids={})
+    _mark_review_thread_addressed(state, _thread(), "fix_committed")
+
+    _clear_addressed_state_by_id(state, THREAD_ID)
+
+    assert DECISION_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_fresh_reviewer_feedback_does_not_replay_the_answered_decision() -> None:
+    """A superseding body change retires the ruling for good, not provisionally.
+
+    Unlike a rollback, a changed body means new reviewer feedback the ruling
+    never spoke to; replaying it there would be stale guidance.
+    """
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+    thread = _thread()
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+    status = SimpleNamespace(
+        unresolved_inline_threads=(replace(thread, body_excerpt="new reviewer reply"),)
+    )
+
+    assert _drop_stale_review_thread_addressed_state(status, state) is True
+
+    assert DECISION_KEY not in state.threads_addressed_ids
+    assert THREAD_ID not in state.threads_addressed_ids
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -331,6 +331,55 @@ def test_fresh_reviewer_feedback_does_not_replay_the_answered_decision() -> None
 
 
 @pytest.mark.unit
+def test_settle_re_address_on_new_feedback_drops_the_parked_decision() -> None:
+    """A settle pass re-addressing new feedback retires the parked ruling too.
+
+    ``_drop_stale_review_thread_addressed_state`` only runs on the poll boundary,
+    so a fix-cycle settle pass can re-address the same thread on a changed body
+    without it. Without dropping the parked ruling here, a later rollback of the
+    *new* verdict would restore guidance that spoke to the previous body.
+    """
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+    thread = _thread()
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+
+    _mark_review_thread_addressed(
+        state, replace(thread, body_excerpt="new reviewer reply"), "fix_committed"
+    )
+    _clear_addressed_state_by_id(state, THREAD_ID)
+
+    assert DECISION_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_settle_re_address_on_the_same_body_keeps_the_parked_decision() -> None:
+    """Re-recording the same body is not fresh feedback — the ruling stays parked."""
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+    thread = _thread()
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+
+    _mark_review_thread_addressed(state, thread, "defer")
+    _clear_addressed_state_by_id(state, THREAD_ID)
+
+    assert state.threads_addressed_ids[DECISION_KEY] == DIRECTIVE
+
+
+@pytest.mark.unit
+def test_agent_failure_on_new_feedback_drops_the_parked_decision() -> None:
+    """``agent_failed`` keeps the live ruling, but a superseded parked one still goes."""
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+    thread = _thread()
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+
+    _mark_review_thread_addressed(
+        state, replace(thread, body_excerpt="new reviewer reply"), "agent_failed"
+    )
+    _clear_addressed_state_by_id(state, THREAD_ID)
+
+    assert DECISION_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
 def test_recorded_verdict_leaves_other_threads_decisions_alone() -> None:
     """Retirement is scoped to the thread whose verdict was just recorded."""
     other_key = _operator_decision_key(OTHER_THREAD_ID)

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -41,6 +41,10 @@ DIRECTIVE = (
     f"For {THREAD_ID}: the off-anchor edit was wrong. Fix the guard at the "
     "reviewer's line and record FIXED; do not re-escalate."
 )
+SECOND_DIRECTIVE = (
+    f"For {THREAD_ID}: ignore my earlier call — the guard belongs on the "
+    "caller side after all; record FIXED there."
+)
 _REPO = RepoRef(owner="dimileeh", name="agent-workspace-fabric")
 
 
@@ -308,6 +312,24 @@ def test_rollback_without_a_retired_decision_adds_nothing() -> None:
     _clear_addressed_state_by_id(state, THREAD_ID)
 
     assert DECISION_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_rollback_keeps_a_newer_operator_ruling_over_the_parked_one() -> None:
+    """A live ruling outranks the parked one a rollback would restore.
+
+    The operator can rule again on a thread that re-parked after answering an
+    earlier ruling. Restoring the parked (older) ruling over that live one would
+    quote superseded guidance in the repair prompt.
+    """
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+    _mark_review_thread_addressed(state, _thread(), "needs_human")
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(SECOND_DIRECTIVE))
+    assert state.threads_addressed_ids[DECISION_KEY] == SECOND_DIRECTIVE
+
+    _clear_addressed_state_by_id(state, THREAD_ID)
+
+    assert state.threads_addressed_ids[DECISION_KEY] == SECOND_DIRECTIVE
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -147,6 +147,31 @@ def test_bounded_directive_keeps_each_named_thread_ruling() -> None:
 
 
 @pytest.mark.unit
+def test_bounded_directive_ignores_prefix_sibling_thread_ids() -> None:
+    """Windowing anchors on the whole thread key, not a longer sibling's prefix.
+
+    ``bb:acme/widgets#12:345`` is a substring of ``bb:acme/widgets#12:3456``, so a
+    plain substring search would window the shorter thread's stored copy on the
+    sibling's mention and quote the sibling's ruling under "do not re-escalate"
+    (PRRT_kwDOSJAM6s6fxier).
+    """
+    sibling_id = "bb:acme/widgets#12:3456"
+    thread_id = "bb:acme/widgets#12:345"
+    state = _parked_state(thread_id, sibling_id)
+    sibling_ruling = f"For {sibling_id}: the reviewer is wrong; record FALSE POSITIVE. " + (
+        "x" * (_OPERATOR_DECISION_MAX_CHARS * 2)
+    )
+    ruling = f"For {thread_id}: rework the guard and record FIXED."
+    directive = f"{sibling_ruling}\n{ruling}"
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(directive))
+
+    stored = state.threads_addressed_ids[_operator_decision_key(thread_id)]
+    assert ruling in stored
+    assert "FALSE POSITIVE" not in stored
+
+
+@pytest.mark.unit
 def test_retirement_leaves_unnamed_threads_untouched() -> None:
     """Only the thread the directive names gains a decision marker."""
     state = _parked_state(THREAD_ID, OTHER_THREAD_ID)

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 import pytest
 
 from awf.common.github_client import RepoRef
-from awf.runtime.feedback_policy import review_thread_body_state_key
+from awf.runtime.feedback_policy import review_thread_body_hash, review_thread_body_state_key
 from awf.runtime.monitor_prompts import address_thread_prompt
 from awf.runtime.monitor_state_keys import _operator_decision_key
 from awf.runtime.pr_monitor import MonitorState, OperatorHint, _mark_review_thread_addressed
@@ -259,6 +259,103 @@ async def test_address_thread_without_state_reads_no_decision(
     )
 
     assert seen == [None]
+
+
+@pytest.mark.unit
+async def test_address_thread_drops_a_decision_the_new_feedback_supersedes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reviewer reply after the ruling supersedes it, so it is not replayed.
+
+    ``_drop_stale_review_thread_addressed_state`` retires an *answered* ruling on
+    fresh feedback, but it skips threads whose verdict still needs attention —
+    exactly the state a live ruling sits in (guide-cleared verdict, or
+    ``agent_failed``). Replaying it there would quote guidance the operator never
+    gave for this conversation while telling the agent not to re-escalate.
+    """
+    seen: list[object] = []
+
+    def _prompt(**kwargs: object) -> str:
+        seen.append(kwargs.get("operator_decision"))
+        return "PROMPT"
+
+    async def _invoke(**_kwargs: object) -> VerdictResult:
+        return VerdictResult(verdict="fix_committed")
+
+    monkeypatch.setattr(comments, "address_thread_prompt", _prompt)
+    runner = SimpleNamespace(
+        _workspace_runtime_context=None,
+        _invoke_cli_for_verdict_result=_invoke,
+    )
+    thread = _thread()
+    state = MonitorState(
+        threads_addressed_ids={
+            DECISION_KEY: DIRECTIVE,
+            review_thread_body_state_key(THREAD_ID): review_thread_body_hash(thread),
+        }
+    )
+
+    await comments._address_thread(
+        runner,
+        workspace_id="ws_939",
+        repo=_REPO,
+        pr_number=939,
+        thread=replace(thread, body_excerpt="new reviewer reply"),
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+    )
+
+    assert seen == [None]
+    # Dropped, not merely skipped: a lingering marker would be parked into the
+    # retired sidecar by the verdict recording and restored by a later rollback.
+    assert DECISION_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+async def test_address_thread_replays_the_decision_for_the_ruled_on_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unchanged conversation is the one the operator ruled on — replay it."""
+    seen: list[object] = []
+
+    def _prompt(**kwargs: object) -> str:
+        seen.append(kwargs.get("operator_decision"))
+        return "PROMPT"
+
+    async def _invoke(**_kwargs: object) -> VerdictResult:
+        return VerdictResult(verdict="fix_committed")
+
+    monkeypatch.setattr(comments, "address_thread_prompt", _prompt)
+    runner = SimpleNamespace(
+        _workspace_runtime_context=None,
+        _invoke_cli_for_verdict_result=_invoke,
+    )
+    thread = _thread()
+    state = MonitorState(
+        threads_addressed_ids={
+            DECISION_KEY: DIRECTIVE,
+            review_thread_body_state_key(THREAD_ID): review_thread_body_hash(thread),
+        }
+    )
+
+    await comments._address_thread(
+        runner,
+        workspace_id="ws_939",
+        repo=_REPO,
+        pr_number=939,
+        thread=thread,
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+        state=state,
+        owned_paths=["src/"],
+        task_tag=None,
+    )
+
+    assert seen == [DIRECTIVE]
+    assert state.threads_addressed_ids[DECISION_KEY] == DIRECTIVE
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -33,7 +33,10 @@ from awf.runtime.pr_monitor_runner.helpers import (
     _clear_addressed_state_by_id,
     _drop_stale_review_thread_addressed_state,
 )
-from awf.runtime.pr_monitor_runner.operator_hint_parsing import _OPERATOR_DECISION_MAX_CHARS
+from awf.runtime.pr_monitor_runner.operator_hint_parsing import (
+    _OPERATOR_DECISION_MAX_CHARS,
+    _operator_decision_marker_text,
+)
 from awf.runtime.pr_monitor_runner.operator_hints import (
     _mark_referenced_needs_human_feedback_answered,
 )
@@ -193,6 +196,65 @@ def test_bounded_directive_ignores_embedding_sibling_thread_ids() -> None:
     stored = state.threads_addressed_ids[DECISION_KEY]
     assert ruling in stored
     assert "FALSE POSITIVE" not in stored
+
+
+@pytest.mark.unit
+def test_bounded_directive_keeps_the_late_repeat_of_the_named_thread() -> None:
+    """An indexed thread id keeps the ruling that repeats it further down.
+
+    A long multi-thread guide typically lists every thread id in an introductory
+    index and then repeats each id beside its actual ruling. Windowing on the
+    first mention alone stores only the index, so the repair prompt would tell
+    the agent an operator already ruled — and not to re-escalate — while quoting
+    no ruling at all (PRRT_kwDOSJAM6s6fx7kx).
+    """
+    state = _parked_state()
+    index_line = f"Rulings below for {THREAD_ID} and {OTHER_THREAD_ID}."
+    ruling = f"For {THREAD_ID}: rework the guard and record FIXED."
+    directive = f"{index_line}\n" + ("x" * (_OPERATOR_DECISION_MAX_CHARS * 2)) + f"\n{ruling}"
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(directive))
+
+    stored = state.threads_addressed_ids[DECISION_KEY]
+    assert ruling in stored
+    assert index_line in stored
+    assert len(stored) <= _OPERATOR_DECISION_MAX_CHARS + 3
+
+
+@pytest.mark.unit
+def test_bounded_directive_merges_neighbouring_mentions_into_one_slice() -> None:
+    """Mentions close enough to share a window are stored as one contiguous slice.
+
+    Splitting the cap per mention must not chop a single ruling that names its
+    thread twice into two elided fragments.
+    """
+    state = _parked_state()
+    ruling = (
+        f"For {THREAD_ID}: rework the guard and record FIXED on {THREAD_ID}; do not re-escalate."
+    )
+    directive = f"{ruling}\n" + ("x" * (_OPERATOR_DECISION_MAX_CHARS * 2))
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(directive))
+
+    stored = state.threads_addressed_ids[DECISION_KEY]
+    assert stored.startswith(ruling)
+    assert stored.count("…") == 1
+    assert stored.endswith("…")
+
+
+@pytest.mark.unit
+def test_bounded_directive_without_an_anchor_keeps_the_head() -> None:
+    """With no thread id to window on, the leading slice is what survives the cap.
+
+    The anchor is read off the pre-redaction text, so an id that redaction rewrote
+    (and the explicit anchorless call) has nothing to position the window on; the
+    head of the ruling is the best available copy.
+    """
+    directive = "Follow the ruling below. " + ("x" * (_OPERATOR_DECISION_MAX_CHARS * 2))
+
+    stored = _operator_decision_marker_text(directive)
+
+    assert stored == directive[:_OPERATOR_DECISION_MAX_CHARS] + "…"
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -125,14 +125,19 @@ def test_retirement_leaves_unnamed_threads_untouched() -> None:
 
 
 @pytest.mark.unit
-def test_non_durable_thread_records_no_decision() -> None:
-    """A thread without a body-hash sidecar is not retired, so nothing is stored."""
+def test_hashless_thread_is_retired_and_records_its_decision() -> None:
+    """A monitor-seeded row without a body-hash sidecar retires with its ruling.
+
+    Outdated hygiene seeds ``needs_human`` with no snapshot, and an unchanged
+    ``needs_human`` never re-enters ``AddressComments`` — skipping these rows
+    would strand the guide at ``NotifyHuman`` (PRRT_kwDOSJAM6s6fw5zx).
+    """
     state = MonitorState(threads_addressed_ids={THREAD_ID: "needs_human"})
 
     _mark_referenced_needs_human_feedback_answered(state, hint=_guide(DIRECTIVE))
 
-    assert state.threads_addressed_ids[THREAD_ID] == "needs_human"
-    assert DECISION_KEY not in state.threads_addressed_ids
+    assert THREAD_ID not in state.threads_addressed_ids
+    assert DECISION_KEY in state.threads_addressed_ids
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -113,6 +113,31 @@ def test_stored_operator_directive_is_bounded() -> None:
 
 
 @pytest.mark.unit
+def test_bounded_directive_keeps_each_named_thread_ruling() -> None:
+    """A capped multi-thread guide stores the slice naming the thread it retires.
+
+    A guide longer than the cap can name a second thread only past the boundary.
+    Storing the leading prefix would tell that thread's agent to follow a ruling
+    the operator gave for a different thread while forbidding re-escalation, so
+    the stored copy is windowed on the thread id (PRRT_kwDOSJAM6s6fxBwP).
+    """
+    state = _parked_state(THREAD_ID, OTHER_THREAD_ID)
+    first_ruling = f"For {THREAD_ID}: rework the guard. " + ("x" * _OPERATOR_DECISION_MAX_CHARS)
+    second_ruling = f"For {OTHER_THREAD_ID}: the reviewer is wrong; record FALSE POSITIVE."
+    directive = f"{first_ruling}\n{second_ruling}"
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(directive))
+
+    first_stored = state.threads_addressed_ids[DECISION_KEY]
+    second_stored = state.threads_addressed_ids[_operator_decision_key(OTHER_THREAD_ID)]
+    assert first_stored.startswith(f"For {THREAD_ID}: rework the guard.")
+    assert second_ruling in second_stored
+    assert second_stored.startswith("…")
+    for stored in (first_stored, second_stored):
+        assert len(stored) <= _OPERATOR_DECISION_MAX_CHARS + 2
+
+
+@pytest.mark.unit
 def test_retirement_leaves_unnamed_threads_untouched() -> None:
     """Only the thread the directive names gains a decision marker."""
     state = _parked_state(THREAD_ID, OTHER_THREAD_ID)

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -1,0 +1,285 @@
+"""Operator decision replay into a re-opened thread's repair prompt (issue #939).
+
+Issue #938 made a guide directive retire a thread's parked ``needs_human`` by
+*clearing* the verdict, so the thread re-enters ``AddressComments``. That alone
+is not enough: the follow-up comment-repair prompt is rebuilt from the reviewer
+thread only, so it carries no trace of the operator's ruling and the agent can
+repeat the rejected fix and re-park. These tests pin the marker that carries the
+decision across that gap — written on retirement, quoted in the thread prompt,
+and dropped once the thread records a real verdict.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from awf.common.github_client import RepoRef
+from awf.runtime.feedback_policy import review_thread_body_state_key
+from awf.runtime.monitor_prompts import address_thread_prompt
+from awf.runtime.monitor_state_keys import _operator_decision_key
+from awf.runtime.pr_monitor import MonitorState, OperatorHint, _mark_review_thread_addressed
+from awf.runtime.pr_monitor_models import ReviewThread
+from awf.runtime.pr_monitor_runner import comments
+from awf.runtime.pr_monitor_runner.comment_verdict import VerdictResult
+from awf.runtime.pr_monitor_runner.operator_hints import (
+    _OPERATOR_DECISION_MAX_CHARS,
+    _mark_referenced_needs_human_feedback_answered,
+)
+
+THREAD_ID = "PRRT_kwDOSJAM6s6fsqcA"
+OTHER_THREAD_ID = "PRRT_kwDOSJAM6s6fsqcB"
+DECISION_KEY = _operator_decision_key(THREAD_ID)
+DIRECTIVE = (
+    f"For {THREAD_ID}: the off-anchor edit was wrong. Fix the guard at the "
+    "reviewer's line and record FIXED; do not re-escalate."
+)
+_REPO = RepoRef(owner="dimileeh", name="agent-workspace-fabric")
+
+
+def _guide(directive: str) -> OperatorHint:
+    return OperatorHint(
+        reason="operator guide",
+        directive=directive,
+        operation_id="op_guide_939",
+        requested_at="2026-09-06T21:00:00+00:00",
+        reason_code="OPERATOR_GUIDE",
+    )
+
+
+def _parked_state(*thread_ids: str) -> MonitorState:
+    addressed: dict[str, str] = {}
+    for thread_id in thread_ids or (THREAD_ID,):
+        addressed[thread_id] = "needs_human"
+        addressed[review_thread_body_state_key(thread_id)] = f"hash-{thread_id}"
+    return MonitorState(threads_addressed_ids=addressed)
+
+
+def _thread(thread_id: str = THREAD_ID) -> ReviewThread:
+    return ReviewThread(
+        thread_id=thread_id,
+        path="src/awf/runtime/pr_monitor_runner/loop.py",
+        line=42,
+        body_excerpt="this guard is on the wrong branch",
+        author="reviewer",
+    )
+
+
+@pytest.mark.unit
+def test_retired_thread_stores_the_operator_directive() -> None:
+    """Clearing a parked thread also records the ruling that cleared it."""
+    state = _parked_state()
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(DIRECTIVE))
+
+    assert THREAD_ID not in state.threads_addressed_ids
+    assert state.threads_addressed_ids[DECISION_KEY] == DIRECTIVE
+
+
+@pytest.mark.unit
+def test_retirement_stores_the_text_actually_shown_to_the_agent() -> None:
+    """A directiveless guide stores the ``acted_text`` reason it presented."""
+    state = _parked_state()
+    reason = f"Approved: keep the current behavior on {THREAD_ID} and resolve it."
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(""), acted_text=reason)
+
+    assert state.threads_addressed_ids[DECISION_KEY] == reason
+
+
+@pytest.mark.unit
+def test_stored_operator_directive_is_bounded() -> None:
+    """An unbounded directive cannot crowd out the reviewer feedback."""
+    state = _parked_state()
+    directive = f"{THREAD_ID} " + ("x" * (_OPERATOR_DECISION_MAX_CHARS * 3))
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(directive))
+
+    stored = state.threads_addressed_ids[DECISION_KEY]
+    assert len(stored) == _OPERATOR_DECISION_MAX_CHARS + 1
+    assert stored.endswith("…")
+    assert stored[:-1] == directive[:_OPERATOR_DECISION_MAX_CHARS]
+
+
+@pytest.mark.unit
+def test_retirement_leaves_unnamed_threads_untouched() -> None:
+    """Only the thread the directive names gains a decision marker."""
+    state = _parked_state(THREAD_ID, OTHER_THREAD_ID)
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(DIRECTIVE))
+
+    assert DECISION_KEY in state.threads_addressed_ids
+    assert _operator_decision_key(OTHER_THREAD_ID) not in state.threads_addressed_ids
+    assert state.threads_addressed_ids[OTHER_THREAD_ID] == "needs_human"
+
+
+@pytest.mark.unit
+def test_non_durable_thread_records_no_decision() -> None:
+    """A thread without a body-hash sidecar is not retired, so nothing is stored."""
+    state = MonitorState(threads_addressed_ids={THREAD_ID: "needs_human"})
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(DIRECTIVE))
+
+    assert state.threads_addressed_ids[THREAD_ID] == "needs_human"
+    assert DECISION_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_retired_review_comment_records_no_thread_decision() -> None:
+    """The comment arm flips to ``false_positive``; it has no repair prompt to feed."""
+    comment_id = "issue:3476977020"
+    state = MonitorState(
+        threads_addressed_ids={
+            comment_id: "needs_human",
+            f"__review_comment_body_hash__:{comment_id}": "comment-hash",
+        }
+    )
+
+    _mark_referenced_needs_human_feedback_answered(
+        state, hint=_guide(f"Resolved out of band: {comment_id} is not actionable.")
+    )
+
+    assert state.threads_addressed_ids[comment_id] == "false_positive"
+    assert _operator_decision_key(comment_id) not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_thread_prompt_quotes_the_operator_decision() -> None:
+    """The re-addressed thread prompt carries the ruling as untrusted evidence."""
+    prompt = address_thread_prompt(
+        pr_number=939,
+        repo_slug=_REPO.slug(),
+        thread=_thread(),
+        operator_decision=DIRECTIVE,
+    )
+
+    assert "Operator decision for this thread:" in prompt
+    assert DIRECTIVE in prompt
+    assert "source_kind: operator_decision" in prompt
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("decision", [None, "", "   "])
+def test_thread_prompt_without_a_decision_is_unchanged(decision: str | None) -> None:
+    """Threads with no operator ruling keep the pre-#939 prompt byte-for-byte."""
+    baseline = address_thread_prompt(pr_number=939, repo_slug=_REPO.slug(), thread=_thread())
+
+    assert (
+        address_thread_prompt(
+            pr_number=939,
+            repo_slug=_REPO.slug(),
+            thread=_thread(),
+            operator_decision=decision,
+        )
+        == baseline
+    )
+    assert "Operator decision for this thread:" not in baseline
+
+
+@pytest.mark.unit
+async def test_address_thread_feeds_the_stored_decision_into_the_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The runner reads the marker for the thread it is addressing, not another."""
+    seen: list[object] = []
+
+    def _prompt(**kwargs: object) -> str:
+        seen.append(kwargs.get("operator_decision"))
+        return "PROMPT"
+
+    async def _invoke(**_kwargs: object) -> VerdictResult:
+        return VerdictResult(verdict="fix_committed")
+
+    monkeypatch.setattr(comments, "address_thread_prompt", _prompt)
+    runner = SimpleNamespace(
+        _workspace_runtime_context=None,
+        _invoke_cli_for_verdict_result=_invoke,
+    )
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+
+    for thread_id in (THREAD_ID, OTHER_THREAD_ID):
+        await comments._address_thread(
+            runner,
+            workspace_id="ws_939",
+            repo=_REPO,
+            pr_number=939,
+            thread=_thread(thread_id),
+            compose_project="proj",
+            compose_file=Path("compose.yml"),
+            state=state,
+            owned_paths=["src/"],
+            task_tag=None,
+        )
+
+    assert seen == [DIRECTIVE, None]
+
+
+@pytest.mark.unit
+async def test_address_thread_without_state_reads_no_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stateless call has no marker store and must not blow up on it."""
+    seen: list[object] = []
+
+    def _prompt(**kwargs: object) -> str:
+        seen.append(kwargs.get("operator_decision"))
+        return "PROMPT"
+
+    async def _invoke(**_kwargs: object) -> VerdictResult:
+        return VerdictResult(verdict="fix_committed")
+
+    monkeypatch.setattr(comments, "address_thread_prompt", _prompt)
+    runner = SimpleNamespace(
+        _workspace_runtime_context=None,
+        _invoke_cli_for_verdict_result=_invoke,
+    )
+
+    await comments._address_thread(
+        runner,
+        workspace_id="ws_939",
+        repo=_REPO,
+        pr_number=939,
+        thread=_thread(),
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+        state=None,
+        owned_paths=["src/"],
+        task_tag=None,
+    )
+
+    assert seen == [None]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("verdict", ["fix_committed", "false_positive", "defer", "needs_human"])
+def test_recorded_verdict_retires_the_operator_decision(verdict: str) -> None:
+    """A real verdict answers the ruling, so the marker must not linger."""
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+
+    _mark_review_thread_addressed(state, _thread(), verdict)
+
+    assert state.threads_addressed_ids[THREAD_ID] == verdict
+    assert DECISION_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_agent_failure_keeps_the_operator_decision() -> None:
+    """``agent_failed`` owes the thread another attempt — keep the ruling in context."""
+    state = MonitorState(threads_addressed_ids={DECISION_KEY: DIRECTIVE})
+
+    _mark_review_thread_addressed(state, _thread(), "agent_failed")
+
+    assert state.threads_addressed_ids[DECISION_KEY] == DIRECTIVE
+
+
+@pytest.mark.unit
+def test_recorded_verdict_leaves_other_threads_decisions_alone() -> None:
+    """Retirement is scoped to the thread whose verdict was just recorded."""
+    other_key = _operator_decision_key(OTHER_THREAD_ID)
+    state = MonitorState(threads_addressed_ids={other_key: DIRECTIVE})
+
+    _mark_review_thread_addressed(state, _thread(), "fix_committed")
+
+    assert state.threads_addressed_ids[other_key] == DIRECTIVE

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -222,6 +222,32 @@ def test_bounded_directive_keeps_the_late_repeat_of_the_named_thread() -> None:
 
 
 @pytest.mark.unit
+def test_bounded_directive_keeps_the_first_mention_past_the_slice_cap() -> None:
+    """An over-cap guide keeps the earliest mention, not only the tail ones.
+
+    Splitting the budget per mention is itself capped, so a guide naming one
+    thread more often than the cap allows has to drop mentions. Dropping from the
+    head alone loses a ruling stated up front and repeated below only as status
+    lines or cross-references, leaving the prompt telling the agent an operator
+    ruled — and not to re-escalate — while quoting none of the ruling
+    (PRRT_kwDOSJAM6s6fyCVT). Both ends are represented instead.
+    """
+    state = _parked_state()
+    ruling = f"For {THREAD_ID}: rework the guard and record FIXED."
+    cross_references = "".join(
+        f"\nStatus update {index}: {THREAD_ID} is tracked. " + ("x" * 300) for index in range(9)
+    )
+    directive = f"{ruling}{cross_references}"
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(directive))
+
+    stored = state.threads_addressed_ids[DECISION_KEY]
+    assert stored.startswith(ruling)
+    assert "Status update 8" in stored
+    assert len(stored) <= _OPERATOR_DECISION_MAX_CHARS + 8
+
+
+@pytest.mark.unit
 def test_bounded_directive_merges_neighbouring_mentions_into_one_slice() -> None:
     """Mentions close enough to share a window are stored as one contiguous slice.
 

--- a/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_decision_replay.py
@@ -29,8 +29,8 @@ from awf.runtime.pr_monitor_runner.helpers import (
     _clear_addressed_state_by_id,
     _drop_stale_review_thread_addressed_state,
 )
+from awf.runtime.pr_monitor_runner.operator_hint_parsing import _OPERATOR_DECISION_MAX_CHARS
 from awf.runtime.pr_monitor_runner.operator_hints import (
-    _OPERATOR_DECISION_MAX_CHARS,
     _mark_referenced_needs_human_feedback_answered,
 )
 

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -60,11 +60,13 @@ from awf.runtime.pr_monitor_runner.lifecycle import (
     _operator_hint_matches,
     _refresh_operator_state_from_workspace,
 )
+from awf.runtime.pr_monitor_runner.operator_hint_parsing import (
+    _operator_hint_feedback_id_candidates,
+)
 from awf.runtime.pr_monitor_runner.operator_hints import (
     _finalize_processed_operator_hint,
     _mark_referenced_needs_human_feedback_answered,
     _operator_hint_block_reason,
-    _operator_hint_feedback_id_candidates,
 )
 from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
 from tests.postgres import postgres_test_engine

--- a/tests/unit/runtime/test_pr_monitor_operator_hints_part_009.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hints_part_009.py
@@ -1,0 +1,260 @@
+"""Operator guide retirement of a ``needs_human`` review THREAD (issue #938).
+
+Review *comments* have no forge thread to resolve, so a guide that names one
+flips it to ``false_positive``. A review *thread* is different: the agent must
+re-read it and record the real verdict, so the guide only clears the parked
+``needs_human`` and lets the thread re-enter ``AddressComments``. These tests
+pin both arms plus the comment path staying byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.runtime.feedback_policy import (
+    review_thread_body_hash,
+    review_thread_body_state_key,
+    thread_enters_address_comments,
+    thread_needs_attention,
+)
+from awf.runtime.monitor_prompts import operator_hint_prompt
+from awf.runtime.pr_monitor import MonitorState, OperatorHint
+from awf.runtime.pr_monitor_models import ReviewThread
+from awf.runtime.pr_monitor_runner.operator_hints import (
+    _finalize_processed_operator_hint,
+    _mark_referenced_needs_human_feedback_answered,
+    _operator_hint_review_thread_id_candidates,
+)
+
+THREAD_ID = "PRRT_kwDOSJAM6s6fsqcA"
+THREAD_HASH_KEY = review_thread_body_state_key(THREAD_ID)
+THREAD_REASON_KEY = f"__needs_human_reason__:{THREAD_ID}"
+REVIEW_COMMENT_ID = "issue:3476977020"
+REVIEW_COMMENT_HASH_KEY = f"__review_comment_body_hash__:{REVIEW_COMMENT_ID}"
+REVIEW_COMMENT_REASON_KEY = f"__needs_human_reason__:{REVIEW_COMMENT_ID}"
+
+
+def _guide(directive: str | None, *, reason: str = "operator guide audit note") -> OperatorHint:
+    return OperatorHint(
+        reason=reason,
+        directive=directive,
+        operation_id="op_guide_thread_938",
+        requested_at="2026-09-06T20:31:00+00:00",
+        reason_code="OPERATOR_GUIDE",
+    )
+
+
+def _parked_thread_state(
+    *,
+    thread_id: str = THREAD_ID,
+    verdict: str = "needs_human",
+    body_hash: str | None = "thread-body-hash",
+) -> MonitorState:
+    addressed = {thread_id: verdict, f"__needs_human_reason__:{thread_id}": "needs a human call"}
+    if body_hash is not None:
+        addressed[review_thread_body_state_key(thread_id)] = body_hash
+    return MonitorState(threads_addressed_ids=addressed)
+
+
+def _review_thread(body: str = "apply the literal ask at the anchor") -> ReviewThread:
+    return ReviewThread(
+        thread_id=THREAD_ID,
+        path="src/awf/runtime/pr_monitor_runner/loop.py",
+        line=42,
+        body_excerpt=body,
+        author="reviewer",
+    )
+
+
+@pytest.mark.unit
+def test_operator_hint_directive_requeues_needs_human_review_thread() -> None:
+    """A directive naming a parked thread clears the verdict (never asserts one)."""
+    state = _parked_thread_state()
+
+    _mark_referenced_needs_human_feedback_answered(
+        state, hint=_guide(f"Accept the fix for {THREAD_ID}; apply the literal ask and resolve.")
+    )
+
+    assert THREAD_ID not in state.threads_addressed_ids
+    assert THREAD_REASON_KEY not in state.threads_addressed_ids
+    assert state.threads_addressed_ids[THREAD_HASH_KEY] == "thread-body-hash"
+
+
+@pytest.mark.unit
+def test_requeued_thread_reenters_address_comments() -> None:
+    """The cleared verdict is what actually un-wedges the thread for ``decide``."""
+    thread = _review_thread()
+    state = _parked_thread_state(body_hash=review_thread_body_hash(thread))
+
+    before = dict(state.threads_addressed_ids)
+    assert thread_needs_attention(before, thread) is False
+    assert thread_enters_address_comments(before, thread) is False
+
+    _mark_referenced_needs_human_feedback_answered(
+        state, hint=_guide(f"Operator decision on {THREAD_ID}: accept and apply.")
+    )
+
+    after = dict(state.threads_addressed_ids)
+    assert thread_needs_attention(after, thread) is True
+    assert thread_enters_address_comments(after, thread) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("body_hash", [None, ""])
+def test_thread_retirement_requires_body_hash_sidecar(body_hash: str | None) -> None:
+    """Only rows carrying durable body-hash evidence are retired."""
+    state = _parked_thread_state(body_hash=body_hash)
+    expected = dict(state.threads_addressed_ids)
+
+    _mark_referenced_needs_human_feedback_answered(
+        state, hint=_guide(f"Accept the fix for {THREAD_ID}.")
+    )
+
+    assert state.threads_addressed_ids == expected
+
+
+@pytest.mark.unit
+def test_thread_retirement_ignores_unknown_thread_id() -> None:
+    """A thread id absent from state creates nothing and changes nothing."""
+    state = _parked_thread_state()
+    expected = dict(state.threads_addressed_ids)
+
+    _mark_referenced_needs_human_feedback_answered(
+        state, hint=_guide("Accept the fix for PRRT_kwDOSJAM6s6UNKNOWN.")
+    )
+
+    assert state.threads_addressed_ids == expected
+    assert "PRRT_kwDOSJAM6s6UNKNOWN" not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("verdict", ["defer", "fix_committed", "false_positive", "agent_failed"])
+def test_thread_retirement_leaves_non_needs_human_verdicts(verdict: str) -> None:
+    """Retirement is scoped to ``needs_human``; other dispositions are untouched."""
+    state = _parked_thread_state(verdict=verdict)
+    expected = dict(state.threads_addressed_ids)
+
+    _mark_referenced_needs_human_feedback_answered(
+        state, hint=_guide(f"Operator decision on {THREAD_ID}: accept and apply.")
+    )
+
+    assert state.threads_addressed_ids == expected
+
+
+@pytest.mark.unit
+def test_thread_retirement_accepts_bitbucket_thread_key_shapes() -> None:
+    """The forge-neutral Bitbucket thread keys retire; ``bbcomment:`` stays a comment."""
+    thread_key = "bb:acme/widgets#12:345"
+    task_key = "bbtask:acme/widgets#12:678"
+    state = MonitorState(
+        threads_addressed_ids={
+            thread_key: "needs_human",
+            review_thread_body_state_key(thread_key): "bb-hash",
+            task_key: "needs_human",
+            review_thread_body_state_key(task_key): "bbtask-hash",
+            "bbcomment:99": "needs_human",
+            "__review_comment_body_hash__:bbcomment:99": "comment-hash",
+        }
+    )
+
+    _mark_referenced_needs_human_feedback_answered(
+        state,
+        hint=_guide(f"Accept {thread_key} and {task_key}; bbcomment:99 is a false positive."),
+    )
+
+    assert thread_key not in state.threads_addressed_ids
+    assert task_key not in state.threads_addressed_ids
+    assert state.threads_addressed_ids[review_thread_body_state_key(thread_key)] == "bb-hash"
+    assert state.threads_addressed_ids[review_thread_body_state_key(task_key)] == "bbtask-hash"
+    assert state.threads_addressed_ids["bbcomment:99"] == "false_positive"
+
+
+@pytest.mark.unit
+def test_comment_retirement_unchanged_when_directive_also_names_a_thread() -> None:
+    """One directive naming both classes routes each to its own arm."""
+    state = MonitorState(
+        threads_addressed_ids={
+            REVIEW_COMMENT_ID: "needs_human",
+            REVIEW_COMMENT_HASH_KEY: "comment-body-hash",
+            REVIEW_COMMENT_REASON_KEY: "review still needs a human",
+            THREAD_ID: "needs_human",
+            THREAD_HASH_KEY: "thread-body-hash",
+            THREAD_REASON_KEY: "needs a human call",
+        }
+    )
+
+    _mark_referenced_needs_human_feedback_answered(
+        state,
+        hint=_guide(f"{REVIEW_COMMENT_ID} is a false positive; accept the fix for {THREAD_ID}."),
+    )
+
+    assert state.threads_addressed_ids[REVIEW_COMMENT_ID] == "false_positive"
+    assert state.threads_addressed_ids[REVIEW_COMMENT_HASH_KEY] == "comment-body-hash"
+    assert REVIEW_COMMENT_REASON_KEY not in state.threads_addressed_ids
+    assert THREAD_ID not in state.threads_addressed_ids
+    assert state.threads_addressed_ids[THREAD_HASH_KEY] == "thread-body-hash"
+    assert THREAD_REASON_KEY not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_thread_retirement_uses_acted_reason_text_for_grant_only_resume() -> None:
+    """Grant-only resumes retire only when the reason was actually acted on."""
+    hint = _guide(None, reason=f"approved protected path; operator accepted {THREAD_ID}")
+
+    acted = _parked_thread_state()
+    _mark_referenced_needs_human_feedback_answered(acted, hint=hint, acted_text=hint.reason)
+    assert THREAD_ID not in acted.threads_addressed_ids
+
+    unacted = _parked_thread_state()
+    expected = dict(unacted.threads_addressed_ids)
+    _mark_referenced_needs_human_feedback_answered(unacted, hint=hint)
+    assert unacted.threads_addressed_ids == expected
+
+
+@pytest.mark.unit
+def test_operator_hint_review_thread_id_candidates_dedupes_and_preserves_order() -> None:
+    """Extraction is order-preserving, deduped, case-sensitive and closed-shape."""
+    text = (
+        f"{THREAD_ID} then bb:acme/widgets#12:345 then {THREAD_ID} again; "
+        "prrt_kwdolower and bb:acme#12:3 are not thread keys."
+    )
+
+    assert _operator_hint_review_thread_id_candidates(text) == (
+        THREAD_ID,
+        "bb:acme/widgets#12:345",
+    )
+
+
+@pytest.mark.unit
+def test_finalize_processed_operator_hint_requeues_needs_human_thread() -> None:
+    """The wiring the runner actually calls retires the thread and still finalizes."""
+    state = _parked_thread_state()
+    state.threads_addressed_ids["__awf_protected_block_preserved_head__"] = "deadbeef"
+    hint = _guide(f"Accept the fix for {THREAD_ID}; apply the literal ask and resolve.")
+
+    _finalize_processed_operator_hint(state, hint=hint)
+
+    assert THREAD_ID not in state.threads_addressed_ids
+    assert THREAD_REASON_KEY not in state.threads_addressed_ids
+    assert state.threads_addressed_ids[THREAD_HASH_KEY] == "thread-body-hash"
+    assert "__awf_protected_block_preserved_head__" not in state.threads_addressed_ids
+    assert state.pending_operator_hint is None
+    assert state.threads_addressed_ids["__awf_operator_hint_processed__:op_guide_thread_938"] == (
+        "processed"
+    )
+
+
+@pytest.mark.unit
+def test_operator_hint_prompt_carries_directive_for_the_hint_cycle() -> None:
+    """Issue #938 requirement 2: the hint cycle's prompt carries the directive."""
+    directive = f"Accept the fix for {THREAD_ID}; apply the literal ask at the anchor."
+
+    prompt = operator_hint_prompt(
+        pr_number=922,
+        repo_slug="dimileeh/aira-web",
+        reason="operator guide audit note",
+        directive=directive,
+        operation_id="op_guide_thread_938",
+    )
+
+    assert directive in prompt

--- a/tests/unit/runtime/test_pr_monitor_operator_hints_part_009.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hints_part_009.py
@@ -18,8 +18,10 @@ from awf.runtime.feedback_policy import (
     thread_needs_attention,
 )
 from awf.runtime.monitor_prompts import operator_hint_prompt
+from awf.runtime.monitor_state_keys import _operator_decision_key
 from awf.runtime.pr_monitor import MonitorState, OperatorHint
 from awf.runtime.pr_monitor_models import ReviewThread
+from awf.runtime.pr_monitor_runner.comments import _operator_decision_for_thread
 from awf.runtime.pr_monitor_runner.operator_hint_parsing import (
     _operator_hint_review_thread_id_candidates,
 )
@@ -103,16 +105,43 @@ def test_requeued_thread_reenters_address_comments() -> None:
 
 @pytest.mark.unit
 @pytest.mark.parametrize("body_hash", [None, ""])
-def test_thread_retirement_requires_body_hash_sidecar(body_hash: str | None) -> None:
-    """Only rows carrying durable body-hash evidence are retired."""
+def test_thread_retirement_covers_hashless_monitor_seeded_verdicts(body_hash: str | None) -> None:
+    """Hashless monitor-seeded ``needs_human`` rows retire too (PRRT_kwDOSJAM6s6fw5zx).
+
+    Outdated-thread hygiene records bare ``needs_human`` verdicts with no
+    body-hash sidecar. Requiring the sidecar here would park those rows forever:
+    an unchanged ``needs_human`` never re-enters ``AddressComments``, so no later
+    path ever holds the live thread to snapshot it, and ``decide`` returns to
+    ``NotifyHuman`` with the guide already marked processed.
+    """
     state = _parked_thread_state(body_hash=body_hash)
-    expected = dict(state.threads_addressed_ids)
 
     _mark_referenced_needs_human_feedback_answered(
         state, hint=_guide(f"Accept the fix for {THREAD_ID}.")
     )
 
-    assert state.threads_addressed_ids == expected
+    assert THREAD_ID not in state.threads_addressed_ids
+    assert THREAD_REASON_KEY not in state.threads_addressed_ids
+    assert state.threads_addressed_ids[_operator_decision_key(THREAD_ID)]
+
+
+@pytest.mark.unit
+def test_hashless_requeued_thread_reenters_address_comments_with_ruling() -> None:
+    """The hashless clear un-wedges the thread AND keeps the ruling quotable."""
+    thread = _review_thread()
+    state = _parked_thread_state(body_hash=None)
+
+    before = dict(state.threads_addressed_ids)
+    assert thread_enters_address_comments(before, thread) is False
+
+    _mark_referenced_needs_human_feedback_answered(
+        state, hint=_guide(f"Operator decision on {THREAD_ID}: accept and apply.")
+    )
+
+    assert thread_enters_address_comments(dict(state.threads_addressed_ids), thread) is True
+    # No recorded hash means the ruling cannot be compared, so it is retained for
+    # the repair prompt rather than dropped as stale.
+    assert _operator_decision_for_thread(state, thread) is not None
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_operator_hints_part_009.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hints_part_009.py
@@ -20,10 +20,12 @@ from awf.runtime.feedback_policy import (
 from awf.runtime.monitor_prompts import operator_hint_prompt
 from awf.runtime.pr_monitor import MonitorState, OperatorHint
 from awf.runtime.pr_monitor_models import ReviewThread
+from awf.runtime.pr_monitor_runner.operator_hint_parsing import (
+    _operator_hint_review_thread_id_candidates,
+)
 from awf.runtime.pr_monitor_runner.operator_hints import (
     _finalize_processed_operator_hint,
     _mark_referenced_needs_human_feedback_answered,
-    _operator_hint_review_thread_id_candidates,
 )
 
 THREAD_ID = "PRRT_kwDOSJAM6s6fsqcA"

--- a/tests/unit/runtime/test_pr_monitor_operator_hints_part_009.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hints_part_009.py
@@ -170,6 +170,36 @@ def test_thread_retirement_accepts_bitbucket_thread_key_shapes() -> None:
 
 
 @pytest.mark.unit
+def test_thread_retirement_accepts_full_adoption_thread_key_grammar() -> None:
+    """Owner/repo segments outside ``[A-Za-z0-9._-]`` still retire (adoption grammar)."""
+    thread_key = "bb:acme/widgets%20legacy#12:345"
+    task_key = "bbtask:acme+co/widgets~fork#12:678"
+    state = MonitorState(
+        threads_addressed_ids={
+            thread_key: "needs_human",
+            review_thread_body_state_key(thread_key): "bb-hash",
+            task_key: "needs_human",
+            review_thread_body_state_key(task_key): "bbtask-hash",
+        }
+    )
+
+    directive = f"Accept {thread_key} and {task_key}."
+
+    assert _operator_hint_review_thread_id_candidates(directive) == (thread_key, task_key)
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=_guide(directive))
+
+    assert thread_key not in state.threads_addressed_ids
+    assert task_key not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_operator_hint_thread_key_extraction_does_not_span_whitespace() -> None:
+    """The broadened owner/repo classes stay token-local, so prose cannot form a key."""
+    assert _operator_hint_review_thread_id_candidates("bb:acme/widgets, see PR #12:345") == ()
+
+
+@pytest.mark.unit
 def test_comment_retirement_unchanged_when_directive_also_names_a_thread() -> None:
     """One directive naming both classes routes each to its own arm."""
     state = MonitorState(

--- a/tests/unit/runtime/test_pr_monitor_outdated_resolution_parts/test_pr_monitor_outdated_resolution_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_outdated_resolution_parts/test_pr_monitor_outdated_resolution_part_002.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.commands import FakeCommandRunner
 from awf.db.repositories import WorkspaceRepository
+from awf.runtime.monitor_state_keys import _operator_decision_key
 from awf.runtime.pr_monitor import (
     AddressComments,
     CheckState,
@@ -766,3 +767,50 @@ async def test_dual_feed_id_not_reconciled_from_comment_keyed_verdict(
     assert cmd.calls == []
     action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
     assert isinstance(action, AddressComments)
+
+
+@pytest.mark.unit
+async def test_live_operator_decision_thread_is_not_reconciled_from_comment_verdict(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(#939 / PRRT_kwDOSJAM6s6fwt3a) The comment-keyed reconcile has the same hazard.
+
+    A guide that answers a parked ``needs_human`` clears the thread verdict and
+    stashes its ruling, so the thread looks unseeded here too. Promoting the
+    comment-path ``fix_committed`` the operator just ruled on would resolve the
+    thread without the requested re-triage; the guide-created requeue owns the
+    next pass instead.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    tid = "PRRT_operator_reconcile"
+    thread = _outdated_thread_with_distinct_comment(tid, comment_id="4688598838")
+    state = MonitorState()
+    state.mark_addressed("4688598838", "fix_committed")
+    state.mark_addressed(_operator_decision_key(tid), "fix the guard at the reviewer's line")
+
+    status = _status_with_outdated(thread)
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=status,
+        state=state,
+    )
+
+    assert gh.attempts == []
+    assert tid not in state.threads_addressed_ids
+    # Seeding is skipped upstream of the evidence grep, so no git read happens.
+    assert cmd.calls == []
+    action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+    assert isinstance(action, AddressComments)
+    assert [t.thread_id for t in action.threads] == [tid]

--- a/tests/unit/runtime/test_pr_monitor_outdated_resolution_parts/test_pr_monitor_outdated_resolution_part_003.py
+++ b/tests/unit/runtime/test_pr_monitor_outdated_resolution_parts/test_pr_monitor_outdated_resolution_part_003.py
@@ -17,8 +17,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.commands import FakeCommandRunner
 from awf.db.repositories import WorkspaceRepository
+from awf.runtime.feedback_policy import review_thread_body_state_key
+from awf.runtime.monitor_state_keys import _operator_decision_key
 from awf.runtime.pr_monitor import (
     _CLOSED_OUTDATED_THREAD_VERDICTS,
+    AddressComments,
     MonitorConfig,
     MonitorState,
     NotifyHuman,
@@ -510,3 +513,64 @@ def test_grep_id_pattern_anchors_numeric_ids_but_not_node_ids() -> None:
     assert re.search(pattern, "fix: address 123") is not None  # id at message end
     assert re.search(pattern, "fix: address review comment issue:12345 — other") is None
     assert re.search(pattern, "fix: address review comment issue:5123 — other") is None
+
+
+@pytest.mark.unit
+async def test_live_operator_decision_thread_is_not_seeded_from_branch_evidence(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(#939 / PRRT_kwDOSJAM6s6fwt3a) A guide-cleared thread awaiting re-triage is
+    exempt from branch-evidence seeding.
+
+    An operator guide that answers a parked ``needs_human`` clears the thread
+    verdict and stashes its ruling under ``__operator_decision__:<thread id>`` so
+    the thread re-enters ``AddressComments`` with the directive quoted. That
+    cleared verdict also makes it look "unseeded" to this pre-decision hygiene
+    step, whose grep still finds the EARLIER ``fix: address <thread id>`` commit
+    on the branch. Seeding from it would re-park the thread at ``needs_human``
+    (a reviewer reply postdates the commit) — straight back to the same human
+    wait with the ruling never read — or, absent such a reply, record
+    ``fix_committed`` and resolve the thread without the requested re-triage.
+    The guide-created requeue owns the next pass instead: no git read, no
+    verdict, ruling intact, ``decide`` → ``AddressComments``.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    tid = "PRRT_kwDOSJAM6s6fwt3a"
+    # The reviewer replied after the earlier fix commit, so unguarded seeding
+    # would restore ``needs_human`` and wedge the guide's requeue.
+    thread = _outdated_thread_with_comment(tid, comment_at=datetime(2026, 6, 11, tzinfo=UTC))
+    # Guide-retired state: no verdict, body snapshot preserved, ruling stashed.
+    state = MonitorState()
+    state.mark_addressed(review_thread_body_state_key(tid), _review_thread_body_hash(thread))
+    state.mark_addressed(_operator_decision_key(tid), "fix the guard at the reviewer's line")
+    # A matching ``fix: address`` commit is on HEAD — it must not be consulted.
+    cmd.queue_result(returncode=0, stdout="2026-06-10T09:00:00+00:00\n")
+
+    status = _status_with_outdated(thread)
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=status,
+        state=state,
+    )
+
+    assert cmd.calls == []
+    assert gh.attempts == []
+    assert tid not in state.threads_addressed_ids
+    assert state.threads_addressed_ids[_operator_decision_key(tid)] == (
+        "fix the guard at the reviewer's line"
+    )
+    action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+    assert isinstance(action, AddressComments)
+    assert [t.thread_id for t in action.threads] == [tid]

--- a/tests/unit/runtime/test_pr_monitor_outdated_resolution_parts/test_pr_monitor_outdated_resolution_part_003.py
+++ b/tests/unit/runtime/test_pr_monitor_outdated_resolution_parts/test_pr_monitor_outdated_resolution_part_003.py
@@ -18,7 +18,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from awf.common.commands import FakeCommandRunner
 from awf.db.repositories import WorkspaceRepository
 from awf.runtime.feedback_policy import review_thread_body_state_key
-from awf.runtime.monitor_state_keys import _operator_decision_key
+from awf.runtime.monitor_state_keys import (
+    _operator_decision_key,
+    _retired_operator_decision_key,
+)
 from awf.runtime.pr_monitor import (
     _CLOSED_OUTDATED_THREAD_VERDICTS,
     AddressComments,
@@ -574,3 +577,54 @@ async def test_live_operator_decision_thread_is_not_seeded_from_branch_evidence(
     action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
     assert isinstance(action, AddressComments)
     assert [t.thread_id for t in action.threads] == [tid]
+
+
+@pytest.mark.unit
+async def test_answered_operator_decision_releases_the_outdated_hygiene_exemption(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(#939 / PRRT_kwDOSJAM6s6fwt3a) The seeding exemption is temporary, not a wedge.
+
+    The exemption above is safe only because it ends: once the re-queued pass
+    records a real verdict, ``_mark_review_thread_addressed`` drops the live
+    ``__operator_decision__`` marker and parks it in the *retired* sidecar. The
+    hygiene guard keys on the LIVE marker alone, so the next poll resolves the
+    outdated thread normally. Were the guard ever widened to the retired key —
+    which survives the verdict precisely so a rollback can restore it — a guided
+    thread would be skipped by hygiene forever and the merge gate would hold at
+    ``NotifyHuman`` on an invisible conversation, the exact #484 wedge seeding
+    exists to prevent.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    tid = "PRRT_operator_answered"
+    thread = _outdated_thread(tid)
+    state = MonitorState()
+    state.mark_addressed(_operator_decision_key(tid), "fix the guard at the reviewer's line")
+    # The re-queued pass ran and answered the ruling.
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+
+    assert _operator_decision_key(tid) not in state.threads_addressed_ids
+    assert state.threads_addressed_ids[_retired_operator_decision_key(tid)] == (
+        "fix the guard at the reviewer's line"
+    )
+
+    status = _status_with_outdated(thread)
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=status,
+        state=state,
+    )
+
+    assert gh.resolved == [tid]

--- a/tests/unit/runtime/test_pr_monitor_task_tag_threading.py
+++ b/tests/unit/runtime/test_pr_monitor_task_tag_threading.py
@@ -34,7 +34,12 @@ from awf.runtime.pr_monitor import (
     ReviewComment,
     ReviewThread,
 )
-from awf.runtime.pr_monitor_runner import ci_ops, comments, operator_hints
+from awf.runtime.pr_monitor_runner import (
+    ci_ops,
+    comments,
+    operator_hint_retirement,
+    operator_hints,
+)
 from awf.runtime.pr_monitor_runner import remote_ops as pr_remote_ops
 from awf.runtime.pr_monitor_runner import remote_repair as pr_remote_repair
 from awf.runtime.pr_monitor_runner.comments import VerdictResult
@@ -943,7 +948,12 @@ async def test_run_operator_hint_cycle_resolves_once_and_threads_to_sink(
         return "PROMPT"
 
     monkeypatch.setattr(operator_hints, "operator_hint_prompt", _operator_hint_prompt)
-    monkeypatch.setattr(operator_hints, "mark_operator_hint_processed", lambda _state: None)
+    # ``_finalize_processed_operator_hint`` (and the marker call it makes) now lives in
+    # the sibling ``operator_hint_retirement`` module, so the stub must target the
+    # binding that module resolves.
+    monkeypatch.setattr(
+        operator_hint_retirement, "mark_operator_hint_processed", lambda _state: None
+    )
 
     self = SimpleNamespace(
         _worktrees_root=tmp_path,

--- a/tests/unit/service/test_pr_monitor_adoption_parts/test_pr_monitor_adoption_part_011.py
+++ b/tests/unit/service/test_pr_monitor_adoption_parts/test_pr_monitor_adoption_part_011.py
@@ -16,6 +16,8 @@ from awf.db.enums import WorkspaceStatus
 from awf.db.models import Operation, Workspace, WorkspaceEvent
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
+from awf.runtime.monitor_prompts import address_thread_prompt
+from awf.runtime.monitor_state_keys import _operator_decision_key
 from awf.runtime.operator_hints import OPERATOR_HINT_STATE_KEY, operator_hint_from_threads
 from awf.runtime.pr_monitor import (
     AddressOperatorHint,
@@ -27,7 +29,7 @@ from awf.runtime.pr_monitor import (
     PRStatus,
     decide,
 )
-from awf.runtime.pr_monitor_models import ReviewComment
+from awf.runtime.pr_monitor_models import ReviewComment, ReviewThread
 from awf.service.pr_monitor_adoption import PullRequestMonitorAdoptionService
 from awf.service.pr_monitor_adoption_helpers import PR_ADOPTION_REQUESTED_EVENT_TYPE
 from awf.service.pr_monitor_adoption_seed import (
@@ -40,6 +42,12 @@ from tests.postgres import postgres_test_engine
 REPO_SLUG = "dimileeh/aira-infra"
 PR_NUMBER = 229
 
+# A thread whose ``needs_human`` an operator guide retired: the guide clears the
+# verdict and stashes its ruling, so the thread is owed an answer when the
+# predecessor goes terminal.
+_UNPARKED_THREAD_ID = "PRRT_kwDOSJAM6s6fvFdY"
+_OPERATOR_DECISION = "take the anchored fix, not the rename"
+
 # The aira-infra PR #229 shape: verdicts the predecessor already dispositioned,
 # their evidence markers, plus run-local bookkeeping that must stay behind.
 _SEEDABLE_PREDECESSOR_STATE: dict[str, str] = {
@@ -51,6 +59,12 @@ _SEEDABLE_PREDECESSOR_STATE: dict[str, str] = {
     "issue:5549805026": "defer",
     "__review_comment_body_hash__:5120013294": "a" * 64,
     "__deferred_issue_filed__:PRRT_kwDOSJAM6s6fNhZo:abc123": f"{REPO_SLUG}#42",
+    # A thread an operator guide un-parked (issues #938/#939): its verdict was
+    # cleared, so it crosses as a body hash with no verdict and the successor
+    # re-queues it. The ruling has to cross with it or the re-queued thread is
+    # re-prompted with the reviewer text the agent already escalated on.
+    f"__review_thread_body_hash__:{_UNPARKED_THREAD_ID}": "b" * 64,
+    f"__operator_decision__:{_UNPARKED_THREAD_ID}": _OPERATOR_DECISION,
 }
 _NEVER_COPIED_PREDECESSOR_STATE: dict[str, str] = {
     "__awf_protected_block_preserved_head__": "d" * 40,
@@ -237,6 +251,50 @@ class TestPullRequestMonitorAdoptionSeedingPart011:
         assert await _monitor_state(factory, fresh_id) == expected
         events = await _events(factory, fresh_id, PR_ADOPTION_SEEDED_EVENT_TYPE)
         assert (events[0].payload or {})["copied_keys"] == sorted(expected)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("head_sha", ["a" * 40, "f" * 40])
+    async def test_re_queued_thread_inherits_its_operator_decision_into_the_prompt(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        head_sha: str,
+    ) -> None:
+        """A thread the operator un-parked crosses re-adoption with its ruling.
+
+        The guide clears the thread's ``needs_human`` and stashes the directive,
+        so the thread reaches the successor as a body hash with no verdict and is
+        re-queued into ``AddressComments``. If the ruling stayed behind, the
+        successor would rebuild the repair prompt from the reviewer text alone
+        (``operator_decision=None``) and the agent could repeat the rejected
+        approach and re-park on the same question — the loop issue #939 exists to
+        break. The ruling disposes of the *feedback*, never suppresses it nor
+        unblocks the merge gate, so it crosses a moved head too.
+        """
+        previous_id = await _adopt(factory)
+        await _fail_with_monitor_state(factory, previous_id, _SEEDABLE_PREDECESSOR_STATE)
+
+        fresh_id = await _adopt(factory, head_sha=head_sha)
+
+        state = await _monitor_state(factory, fresh_id)
+        assert _UNPARKED_THREAD_ID not in state
+        assert state[f"__review_thread_body_hash__:{_UNPARKED_THREAD_ID}"] == "b" * 64
+        assert state[_operator_decision_key(_UNPARKED_THREAD_ID)] == _OPERATOR_DECISION
+
+        thread = ReviewThread(
+            thread_id=_UNPARKED_THREAD_ID,
+            path="src/awf/service/pr_monitor_adoption_seed.py",
+            line=120,
+            body_excerpt="rename the marker helper",
+            author="chatgpt-codex-connector",
+        )
+        prompt = address_thread_prompt(
+            pr_number=PR_NUMBER,
+            repo_slug=REPO_SLUG,
+            thread=thread,
+            operator_decision=state.get(_operator_decision_key(thread.thread_id)),
+        )
+
+        assert _OPERATOR_DECISION in prompt
 
     @pytest.mark.unit
     async def test_first_adoption_seeds_nothing_and_emits_no_seeded_event(

--- a/tests/unit/service/test_pr_monitor_adoption_seed.py
+++ b/tests/unit/service/test_pr_monitor_adoption_seed.py
@@ -1,10 +1,11 @@
 """Allowlist policy for seeding a re-adopted PR monitor from its predecessor.
 
 Issue #911: only thread/review-comment verdicts, review-thread and
-review-comment body hashes, and deferred-issue markers may cross the
+review-comment body hashes, deferred-issue markers, and the per-thread operator
+decision that un-parked a re-queued thread (issues #938/#939) may cross the
 supersede boundary. Everything else -- protected-block state, awaiting-check
-timestamps, operator-hint bookkeeping, merge-block/workflow-scope markers --
-must stay behind so the fresh monitor re-derives it from the live PR.
+timestamps, operator-hint cycle bookkeeping, merge-block/workflow-scope markers
+-- must stay behind so the fresh monitor re-derives it from the live PR.
 """
 
 from __future__ import annotations
@@ -48,6 +49,11 @@ _COPIED_CASES: list[tuple[str, str]] = [
     ("__review_thread_body_hash__:bb:acme/widgets#12:99", "c" * 64),
     # Deferred-issue marker.
     ("__deferred_issue_filed__:PRRT_kwDOSJAM6s6fNhZo:abc123", "dimileeh/aira-infra#42"),
+    # Operator decision that un-parked a thread whose verdict was cleared
+    # (issues #938/#939): the thread crosses the boundary owed an answer, so the
+    # ruling has to cross with it or the successor re-prompts without it.
+    ("__operator_decision__:PRRT_kwDOSJAM6s6fNhZo", "take the anchored fix, not the rename"),
+    ("__operator_decision__:bb:acme/widgets#12:99", "ship the guard, skip the refactor"),
 ]
 
 # ``fix_committed`` asserts the fix is in the branch and ``false_positive`` asserts
@@ -162,10 +168,34 @@ def test_non_string_values_are_dropped(value: Any) -> None:
         "__review_comment_body_hash__:",
         "__review_thread_body_hash__:",
         "__deferred_issue_filed__:",
+        "__operator_decision__:",
     ],
 )
 def test_prefix_only_marker_keys_are_dropped(key: str) -> None:
     assert seedable_monitor_state({key: "a" * 64}) == {}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("head_continuity", [True, False])
+def test_operator_decision_crosses_with_the_thread_it_re_queues(head_continuity: bool) -> None:
+    """A re-queued thread keeps the ruling that un-parked it (issues #938/#939).
+
+    The guide clears the thread's ``needs_human`` verdict and stashes the
+    directive, so the thread crosses re-adoption as a *body hash with no
+    verdict*: the successor re-queues it into ``AddressComments``. Dropping the
+    ruling here would hand the agent the same reviewer text it already escalated
+    on, letting it repeat the rejected approach and re-park -- the loop #939
+    exists to break. The ruling disposes of the *feedback*, never suppresses it
+    or unblocks the merge gate, and reaches the agent only as quoted untrusted
+    evidence, so it crosses on a moved head too.
+    """
+    thread_id = "PRRT_kwDOSJAM6s6fNhZo"
+    previous = {
+        f"__review_thread_body_hash__:{thread_id}": "b" * 64,
+        f"__operator_decision__:{thread_id}": "take the anchored fix, not the rename",
+    }
+
+    assert seedable_monitor_state(previous, head_continuity=head_continuity) == previous
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_pr_monitor_adoption_seed.py
+++ b/tests/unit/service/test_pr_monitor_adoption_seed.py
@@ -201,24 +201,52 @@ def test_operator_decision_crosses_with_the_thread_it_re_queues(head_continuity:
 
 @pytest.mark.unit
 @pytest.mark.parametrize("verdict", ["fix_committed", "false_positive"])
-def test_parked_ruling_is_un_parked_when_its_verdict_does_not_cross(verdict: str) -> None:
-    """Dropping a head-dependent verdict re-opens the thread, so its ruling revives.
+def test_parked_ruling_does_not_revive_on_a_moved_head(verdict: str) -> None:
+    """A moved head drops the parked ruling with the verdict it produced.
 
     ``_mark_review_thread_addressed`` parks the operator ruling once a verdict
-    answers it. A moved head drops that verdict here and the successor re-queues
-    the unchanged thread into ``AddressComments`` -- with the ruling still parked
-    (or dropped) the agent would see only the reviewer text it already escalated
-    on and could repeat the rejected approach and re-park (issue #939).
+    answers it, so a parked ruling has already been consumed once -- and on a
+    moved head the verdict it produced is exactly the head-dependent one this
+    boundary drops as no longer provably true of the branch. Reviving it as a
+    live directive would tell the successor's agent to follow that ruling and not
+    re-escalate, recreating the discarded verdict against code a force-push may
+    have removed, and neither verdict blocks the merge gate
+    (PRRT_kwDOSJAM6s6fyCVP). It is dropped outright rather than left parked, so
+    the successor's own next rollback cannot revive it against the new head
+    either.
+    """
+    thread_id = "PRRT_kwDOSJAM6s6fNhZo"
+    previous = {
+        thread_id: verdict,
+        f"__review_thread_body_hash__:{thread_id}": "b" * 64,
+        f"__operator_decision_retired__:{thread_id}": "take the anchored fix, not the rename",
+    }
+
+    assert seedable_monitor_state(previous, head_continuity=False) == {
+        f"__review_thread_body_hash__:{thread_id}": "b" * 64,
+    }
+
+
+@pytest.mark.unit
+def test_parked_ruling_is_un_parked_on_a_stable_head_when_its_verdict_does_not_cross() -> None:
+    """Losing a verdict re-opens the thread, so its ruling revives with it.
+
+    With the head unchanged the ruling still describes the branch, so a verdict
+    that does not cross (here a value outside the seedable vocabulary) is the
+    same rollback ``_clear_addressed_state_by_id`` handles: the successor
+    re-queues the unchanged thread into ``AddressComments`` and must carry the
+    ruling, or the agent sees only the reviewer text it already escalated on and
+    can repeat the rejected approach and re-park (issue #939).
     """
     thread_id = "PRRT_kwDOSJAM6s6fNhZo"
     decision = "take the anchored fix, not the rename"
     previous = {
-        thread_id: verdict,
+        thread_id: "superseded_by_a_future_verdict",
         f"__review_thread_body_hash__:{thread_id}": "b" * 64,
         f"__operator_decision_retired__:{thread_id}": decision,
     }
 
-    assert seedable_monitor_state(previous, head_continuity=False) == {
+    assert seedable_monitor_state(previous, head_continuity=True) == {
         f"__operator_decision__:{thread_id}": decision,
         f"__review_thread_body_hash__:{thread_id}": "b" * 64,
     }
@@ -244,21 +272,30 @@ def test_parked_ruling_stays_parked_alongside_the_verdict_it_answered(verdict: s
 
 
 @pytest.mark.unit
-def test_live_ruling_supersedes_the_parked_copy_it_replaced() -> None:
-    """A re-issued ruling is the operator's latest word; the parked copy is stale."""
+@pytest.mark.parametrize("head_continuity", [True, False])
+def test_live_ruling_supersedes_the_parked_copy_it_replaced(head_continuity: bool) -> None:
+    """A re-issued ruling is the operator's latest word; the parked copy is stale.
+
+    The parked copy is dropped either way: on a stable head because the live
+    ruling supersedes it, on a moved head because a consumed ruling does not
+    cross at all.
+    """
     thread_id = "PRRT_kwDOSJAM6s6fNhZo"
     live = "ship the guard, skip the refactor"
     previous = {
-        "5120013294": "fix_committed",
+        "5120013294": "false_positive",
         f"__review_thread_body_hash__:{thread_id}": "b" * 64,
         f"__operator_decision__:{thread_id}": live,
         f"__operator_decision_retired__:{thread_id}": "take the anchored fix, not the rename",
     }
-
-    assert seedable_monitor_state(previous, head_continuity=False) == {
+    expected = {
         f"__operator_decision__:{thread_id}": live,
         f"__review_thread_body_hash__:{thread_id}": "b" * 64,
     }
+    if head_continuity:
+        expected["5120013294"] = "false_positive"
+
+    assert seedable_monitor_state(previous, head_continuity=head_continuity) == expected
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_pr_monitor_adoption_seed.py
+++ b/tests/unit/service/test_pr_monitor_adoption_seed.py
@@ -169,6 +169,7 @@ def test_non_string_values_are_dropped(value: Any) -> None:
         "__review_thread_body_hash__:",
         "__deferred_issue_filed__:",
         "__operator_decision__:",
+        "__operator_decision_retired__:",
     ],
 )
 def test_prefix_only_marker_keys_are_dropped(key: str) -> None:
@@ -196,6 +197,68 @@ def test_operator_decision_crosses_with_the_thread_it_re_queues(head_continuity:
     }
 
     assert seedable_monitor_state(previous, head_continuity=head_continuity) == previous
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("verdict", ["fix_committed", "false_positive"])
+def test_parked_ruling_is_un_parked_when_its_verdict_does_not_cross(verdict: str) -> None:
+    """Dropping a head-dependent verdict re-opens the thread, so its ruling revives.
+
+    ``_mark_review_thread_addressed`` parks the operator ruling once a verdict
+    answers it. A moved head drops that verdict here and the successor re-queues
+    the unchanged thread into ``AddressComments`` -- with the ruling still parked
+    (or dropped) the agent would see only the reviewer text it already escalated
+    on and could repeat the rejected approach and re-park (issue #939).
+    """
+    thread_id = "PRRT_kwDOSJAM6s6fNhZo"
+    decision = "take the anchored fix, not the rename"
+    previous = {
+        thread_id: verdict,
+        f"__review_thread_body_hash__:{thread_id}": "b" * 64,
+        f"__operator_decision_retired__:{thread_id}": decision,
+    }
+
+    assert seedable_monitor_state(previous, head_continuity=False) == {
+        f"__operator_decision__:{thread_id}": decision,
+        f"__review_thread_body_hash__:{thread_id}": "b" * 64,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("verdict", ["fix_committed", "false_positive"])
+def test_parked_ruling_stays_parked_alongside_the_verdict_it_answered(verdict: str) -> None:
+    """With the verdict inherited the thread is not re-queued, so the ruling waits.
+
+    It crosses parked rather than live so a later rollback of that still
+    unconfirmed verdict on the successor (``_clear_addressed_state_by_id``)
+    restores it with the thread instead of re-opening the thread without it.
+    """
+    thread_id = "PRRT_kwDOSJAM6s6fNhZo"
+    previous = {
+        thread_id: verdict,
+        f"__review_thread_body_hash__:{thread_id}": "b" * 64,
+        f"__operator_decision_retired__:{thread_id}": "take the anchored fix, not the rename",
+    }
+
+    assert seedable_monitor_state(previous, head_continuity=True) == previous
+
+
+@pytest.mark.unit
+def test_live_ruling_supersedes_the_parked_copy_it_replaced() -> None:
+    """A re-issued ruling is the operator's latest word; the parked copy is stale."""
+    thread_id = "PRRT_kwDOSJAM6s6fNhZo"
+    live = "ship the guard, skip the refactor"
+    previous = {
+        "5120013294": "fix_committed",
+        f"__review_thread_body_hash__:{thread_id}": "b" * 64,
+        f"__operator_decision__:{thread_id}": live,
+        f"__operator_decision_retired__:{thread_id}": "take the anchored fix, not the rename",
+    }
+
+    assert seedable_monitor_state(previous, head_continuity=False) == {
+        f"__operator_decision__:{thread_id}": live,
+        f"__review_thread_body_hash__:{thread_id}": "b" * 64,
+    }
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_b5becb722c63467592f512fb` (agent: `claude_code`, model: `claude-opus-5`, effort: `high`).


### Task
Fix GitHub issue #938 (read it first: gh issue view 938). Narrow scope in src/awf/runtime/pr_monitor_runner/operator_hints.py (and a sibling module if the file nears 1500 lines): _mark_referenced_needs_human_feedback_answered only retires review-COMMENT ids that carry a __review_comment_body_hash__ sidecar; a review THREAD id (PRRT_... or the forge-neutral thread key shapes accepted by adoption seeding in src/awf/service/pr_monitor_adoption_seed.py) named in a guide directive must retire that thread's recorded needs_human too, gated on its __review_thread_body_hash__:<id> sidecar, by clearing the verdict so the thread re-enters AddressComments with the directive in context - do NOT flip it to false_positive; the agent records the real verdict. Keep review-comment behaviour unchanged. Strict TDD: failing tests first (ls the operator-hint test files and add a NEW part file, never overwrite): directive naming a needs_human thread -> re-queued; unknown id -> no change; comment-id path unchanged. Coverage gate 99 percent line+branch; catch specific exceptions; preserve reason codes. Run ruff check, ruff format --check, mypy and 'pytest tests -q -n 20' before pushing. Keep each agent run short: focused tests, commit, always end with the AWF-VERDICT line; put review-fix hunks in the reviewed file at the reviewed line; never cite your own commit in a FALSE POSITIVE or DEFER. Reference 'Closes #938' in the PR body.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR monitor merge-gating, operator-guide retirement, comment-repair prompts, and adoption seeding—state bugs could wedge merges or mis-quote operator intent—but behavior is heavily specified and covered by new tests.
> 
> **Overview**
> **Operator guides that name a parked `needs_human` review thread** now *clear* the thread verdict (not `false_positive`) so it re-enters `AddressComments`, while review-comment retirement stays on the body-hash–gated `false_positive` path (#938).
> 
> **Issue #939** adds durable monitor markers (`__operator_decision__`, `__operator_decision_at__`, `__operator_decision_retired__`) so the stashed guide text is quoted in `address_thread_prompt` / `_address_thread`, with redaction, length caps, and anchor-aware windowing for multi-thread directives. Rulings retire when the agent records a real verdict (kept through `agent_failed`), restore on verdict rollback, and drop when reviewer feedback or timestamps show the conversation moved on.
> 
> **Outdated-thread hygiene** skips branch-evidence and comment reconcile seeding while a live operator decision is pending, so hygiene cannot re-park or auto-resolve threads the guide just un-wedged.
> 
> **PR re-adoption** copies the new marker classes (and issue-time bindings) and can un-park retired rulings when head continuity holds and the answering verdict did not cross; moved heads drop consumed parked rulings to avoid replaying stale merge-gate dispositions.
> 
> **Refactor:** parsing and retirement logic move from `operator_hints.py` into `operator_hint_parsing.py` and `operator_hint_retirement.py` for the line-cap maintainability gate, with broad unit/integration coverage and doc updates in `PR_MONITOR_ADOPTION.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a07008f34c10f90d434c860cf194a58d70c3ed39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->