### PR TITLE
Fix #942: make the nested-git-probe residue tests deterministic under load

### DIFF
--- a/src/awf/node/git_manager_ownership.py
+++ b/src/awf/node/git_manager_ownership.py
@@ -863,6 +863,7 @@ def _copy_opened_regular_file_to_path(
     budget_seconds: float = _OBJECT_STORE_LEAF_COPY_BUDGET_SECONDS,
     validate_git_loose_object: bool = False,
     enum_budget: _ObjectStoreEnumBudget | None = None,
+    preserve_source_times: bool = False,
 ) -> bool:
     """Stream a size/deadline-bounded private copy from an opened regular file.
 
@@ -874,7 +875,10 @@ def _copy_opened_regular_file_to_path(
     exhausts its compressed-byte / wall-time budget before parsing a size
     (PRRT_kwDOSJAM6s6ewp-Z). When ``enum_budget`` is set, charge the opened
     descriptor's ``fstat`` size against the shared aggregate so a post-pathname
-    grow cannot bypass the walk cap (PRRT_kwDOSJAM6s6fDL6r). Returns ``False``
+    grow cannot bypass the walk cap (PRRT_kwDOSJAM6s6fDL6r). When
+    ``preserve_source_times`` is set, stamp the copy with the source inode's
+    atime/mtime — index files must keep them or Git's racily-clean re-check is
+    disabled (issue #942, see ``_symlink_git_dir_child_via_fd``). Returns ``False``
     on type/size/stability failures.
     """
     try:
@@ -945,6 +949,12 @@ def _copy_opened_regular_file_to_path(
             and copied == st.st_size
         ):
             return False
+        if preserve_source_times:
+            # Stamp through the destination descriptor, never the pathname.
+            try:
+                os.utime(out_fd, ns=(st.st_atime_ns, st.st_mtime_ns))
+            except OSError:
+                return False
         succeeded = True
         return True
     finally:
@@ -963,6 +973,7 @@ def _symlink_git_dir_child_via_fd(
     expect_directory: bool | None = None,
     validate_git_loose_object: bool = False,
     enum_budget: _ObjectStoreEnumBudget | None = None,
+    preserve_source_times: bool = False,
 ) -> bool:
     """Materialize ``dest`` from the opened inode of ``name`` under ``dir_fd``.
 
@@ -975,6 +986,15 @@ def _symlink_git_dir_child_via_fd(
     (PRRT_kwDOSJAM6s6eteRs). Pass ``enum_budget`` so leaf copies charge the
     opened inode size against the shared object-store walk cap
     (PRRT_kwDOSJAM6s6fDL6r).
+
+    Pass ``preserve_source_times`` for index files. Git decides whether a cached
+    entry is *racily clean* — and therefore must be content-compared instead of
+    trusted from stat — by comparing the entry's cached mtime against the mtime of
+    the index file itself, in whole seconds (Git is built without ``USE_NSEC``). A
+    copy stamped with the staging time pushes the index timestamp past every cached
+    entry, so a same-size overwrite made in the same second as the index-recorded
+    mtime becomes invisible to snapshot-scoped ``diff-files`` and nested residue
+    silently loses its unstaged component (issue #942).
 
     Callers must keep every appended ``held_fds`` entry (directory pins only)
     open until staging is discarded, then close them.
@@ -1023,6 +1043,7 @@ def _symlink_git_dir_child_via_fd(
             dest,
             validate_git_loose_object=validate_git_loose_object,
             enum_budget=enum_budget,
+            preserve_source_times=preserve_source_times,
         ):
             return False
     finally:
@@ -1262,7 +1283,12 @@ def _symlink_split_index_backing_files_via_fd(
     ):  # pragma: no cover - oid.hex() always matches
         return True
     return _symlink_git_dir_child_via_fd(
-        dir_fd, name, staging / name, held_fds, expect_directory=False
+        dir_fd,
+        name,
+        staging / name,
+        held_fds,
+        expect_directory=False,
+        preserve_source_times=True,
     )
 
 

--- a/src/awf/node/git_manager_ownership_store.py
+++ b/src/awf/node/git_manager_ownership_store.py
@@ -815,12 +815,16 @@ def untrusted_nested_probe_config_snapshot_git_dir(
             return
         # Git rejects a git-dir whose HEAD is a symlink ("not a git repository").
         (staging / "HEAD").write_bytes(head_text.encode("utf-8", errors="surrogateescape"))
+        # Keep the live index mtime: Git's racily-clean re-check keys off it, and a
+        # staging-time stamp makes same-size same-second overwrites invisible to
+        # snapshot-scoped ``diff-files`` (issue #942).
         if not _own()._symlink_git_dir_child_via_fd(
             primary_fd,
             "index",
             staging / "index",
             metadata_leaf_fds,
             expect_directory=False,
+            preserve_source_times=True,
         ):
             yield None
             return

--- a/tests/unit/control/test_worker_parts/test_worker_part_057.py
+++ b/tests/unit/control/test_worker_parts/test_worker_part_057.py
@@ -1273,6 +1273,12 @@ class TestRunOnceStaleActiveExecutionRecoveryPart002HostedAdoption:
             ),
         )
 
-        await worker.run_once()
+        # ``run_once`` only *dispatches* the monitor resume as a background task;
+        # ``resume_pr_monitor`` runs several DB round-trips later inside that task.
+        # Assert the dispatch decision from the return value, then drain the task
+        # before inspecting the executor — reading ``resume_calls`` straight after
+        # ``run_once`` races the still-pending task and intermittently sees ``[]``.
+        assert await worker.run_once() == 1
+        await worker.wait_for_execution_tasks()
 
         assert executor.resume_calls == [workspace_id]

--- a/tests/unit/control/test_worker_parts/test_worker_part_057.py
+++ b/tests/unit/control/test_worker_parts/test_worker_part_057.py
@@ -1273,12 +1273,6 @@ class TestRunOnceStaleActiveExecutionRecoveryPart002HostedAdoption:
             ),
         )
 
-        # ``run_once`` only *dispatches* the monitor resume as a background task;
-        # ``resume_pr_monitor`` runs several DB round-trips later inside that task.
-        # Assert the dispatch decision from the return value, then drain the task
-        # before inspecting the executor — reading ``resume_calls`` straight after
-        # ``run_once`` races the still-pending task and intermittently sees ``[]``.
-        assert await worker.run_once() == 1
-        await worker.wait_for_execution_tasks()
+        await worker.run_once()
 
         assert executor.resume_calls == [workspace_id]

--- a/tests/unit/node/test_git_manager_ownership_edges.py
+++ b/tests/unit/node/test_git_manager_ownership_edges.py
@@ -14,6 +14,10 @@ import awf.node.git_manager as git_manager
 import awf.node.git_manager_ownership as git_manager_ownership
 from awf.node.git_manager import GitManager
 
+# Fixed mtime stamp (2023-11-14T22:13:20Z) for worktree writes whose visibility to
+# stat-only ``git diff-files`` must not depend on when the test happened to run.
+_STAMP_EPOCH_NS = 1_700_000_000_000_000_000
+
 
 @pytest.mark.unit
 def test_chown_tree_skips_symlink_targets_using_lchown(
@@ -329,19 +333,34 @@ def test_untrusted_nested_git_config_args_override_core_symlinks_false(
     )
     link.unlink()
     link.write_bytes(b"target")
-    # Settle the index's cached stat data for the replaced entry. Without this the
-    # poisoned baseline only stays blind while the whole setup happens to fit inside
-    # one filesystem timestamp second: once the replacement lands in a later second,
-    # ``diff-files`` reports the path on the mtime difference alone and the "Git hides
-    # this" premise fails for a reason that has nothing to do with core.symlinks
-    # (issue #942). Refreshing under the poisoned config is what a real repository
-    # would already have done, and it leaves the entry mode untouched.
-    subprocess.run(
+    # Pin the replacement to a fixed mtime well before the index write, then settle the
+    # index's cached stat data for the entry. Both steps are needed for the "Git hides
+    # this" premise to hold by construction rather than by luck (issue #942):
+    #
+    # * Without the refresh the entry keeps the mtime Git recorded for the symlink, so
+    #   the baseline only stays blind while the whole setup fits inside one filesystem
+    #   timestamp second (Git is built without ``USE_NSEC``). Once the replacement lands
+    #   in a later second, ``diff-files`` reports the path on the mtime difference alone
+    #   — the flake, reported as ``assert 'link' == ''``.
+    # * Without the pin the refreshed mtime is "now", which is also the second the index
+    #   is written in, so the entry is *racily clean* and blindness rests on Git's
+    #   content re-check instead of on plain stat equality. A past stamp puts the entry
+    #   outside the racy window, leaving one deterministic code path.
+    #
+    # Refreshing under the poisoned config is what a real repository would already have
+    # done, and it leaves the entry mode untouched.
+    os.utime(link, ns=(_STAMP_EPOCH_NS, _STAMP_EPOCH_NS))
+    refreshed = subprocess.run(
         ["git", "update-index", "--refresh"],
         cwd=nested,
         check=False,
         capture_output=True,
+        text=True,
     )
+    # Exit 0 means no entry was left needing update, i.e. the cached stat data now
+    # matches the pinned replacement. A silent refresh failure would otherwise surface
+    # later as an unexplained baseline difference.
+    assert refreshed.returncode == 0, refreshed.stdout + refreshed.stderr
 
     poisoned = subprocess.run(
         ["git", "diff-files", "--name-only"],
@@ -351,7 +370,7 @@ def test_untrusted_nested_git_config_args_override_core_symlinks_false(
         text=True,
     )
     # Variant A recipe: local core.symlinks=false hides this typechange on Git 2.39.5+.
-    assert poisoned.stdout.strip() == ""
+    assert poisoned.stdout.strip() == "", refreshed.stdout + refreshed.stderr
 
     sanitized = subprocess.run(
         [

--- a/tests/unit/node/test_git_manager_ownership_edges.py
+++ b/tests/unit/node/test_git_manager_ownership_edges.py
@@ -329,6 +329,19 @@ def test_untrusted_nested_git_config_args_override_core_symlinks_false(
     )
     link.unlink()
     link.write_bytes(b"target")
+    # Settle the index's cached stat data for the replaced entry. Without this the
+    # poisoned baseline only stays blind while the whole setup happens to fit inside
+    # one filesystem timestamp second: once the replacement lands in a later second,
+    # ``diff-files`` reports the path on the mtime difference alone and the "Git hides
+    # this" premise fails for a reason that has nothing to do with core.symlinks
+    # (issue #942). Refreshing under the poisoned config is what a real repository
+    # would already have done, and it leaves the entry mode untouched.
+    subprocess.run(
+        ["git", "update-index", "--refresh"],
+        cwd=nested,
+        check=False,
+        capture_output=True,
+    )
 
     poisoned = subprocess.run(
         ["git", "diff-files", "--name-only"],

--- a/tests/unit/node/test_git_manager_ownership_edges_part_004.py
+++ b/tests/unit/node/test_git_manager_ownership_edges_part_004.py
@@ -785,3 +785,117 @@ def test_snapshot_git_dir_info_exclude_fail_closed_edges(tmp_path: Path) -> None
     assert snap is not None
     assert snap.get(git_manager_ownership._INFO_EXCLUDE_NAME) == "# keep\n"
     assert "config" in snap
+
+
+def _init_committed_repo_around_existing_file(root: Path, *, email: str) -> None:
+    """Commit ``tracked.txt`` without disturbing the stamped mtime it already carries."""
+    subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", email], cwd=root, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=root, check=True, capture_output=True
+    )
+    subprocess.run(["git", "add", "tracked.txt"], cwd=root, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=root, check=True, capture_output=True)
+
+
+@pytest.mark.unit
+def test_untrusted_nested_probe_config_snapshot_preserves_index_mtime(
+    tmp_path: Path,
+) -> None:
+    """Issue #942: the snapshot ``index`` must keep the live index file's mtime.
+
+    Git decides whether a tracked entry is *racily clean* by comparing the entry's
+    cached mtime against the mtime of the index file itself; when the entry is not
+    older than the index, ``diff-files`` re-reads the file and compares content
+    instead of trusting stat. Git is built without ``USE_NSEC``, so that comparison
+    is whole-second. Copying the index into the private snapshot git-dir with a
+    fresh mtime moves the index timestamp past every cached entry mtime, disabling
+    the content re-check: a same-size overwrite performed in the same second as the
+    index-recorded mtime then becomes invisible to a snapshot-scoped ``diff-files``
+    once the probe runs a second later, and nested residue silently loses its
+    unstaged component. Preserve the source mtime so the snapshot reproduces the
+    live git-dir's verdict.
+    """
+    nested = tmp_path / "nested"
+    _init_marked_nested_repo(nested, email="mtime@example.com", blob="tracked\n")
+    git_dir = nested / ".git"
+    subprocess.run(
+        ["git", "update-index", "--split-index"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+    )
+    shared = sorted(git_dir.glob("sharedindex.*"))
+    assert shared, "expected git to materialize a sharedindex.* backing file"
+
+    live_index_mtime_ns = (git_dir / "index").stat().st_mtime_ns
+    live_shared_mtime_ns = {path.name: path.stat().st_mtime_ns for path in shared}
+
+    with git_manager.untrusted_nested_probe_config_snapshot_git_dir(nested) as shadow:
+        assert shadow is not None
+        assert (shadow / "index").stat().st_mtime_ns == live_index_mtime_ns
+        for name, mtime_ns in live_shared_mtime_ns.items():
+            assert (shadow / name).stat().st_mtime_ns == mtime_ns
+
+
+@pytest.mark.unit
+def test_snapshot_scoped_diff_files_matches_live_git_dir_for_racily_clean_entry(
+    tmp_path: Path,
+) -> None:
+    """Issue #942: snapshot-scoped ``diff-files`` must agree with the live git-dir.
+
+    The racily-clean state is built deterministically instead of racing the clock:
+    the tracked file is overwritten with same-size content and then stamped — along
+    with the live index — into one fixed past second, so the entry's cached mtime,
+    the worktree mtime and the index mtime all coincide and git *must* fall back to
+    a content comparison. ``core.trustctime=false`` neutralizes the one stat field
+    ``os.utime`` cannot restore (a content write always bumps ctime); every other
+    field matches by construction, so the racily-clean re-check is the only thing
+    that can still report the path. The live git-dir reports it; before the fix the
+    snapshot's freshly-stamped index copy reported nothing.
+    """
+    nested = tmp_path / "racy"
+    nested.mkdir()
+    tracked = nested / "tracked.txt"
+    tracked.write_text("tracked\n", encoding="utf-8")
+    # A fixed past second, so the snapshot's copy timestamp is always a *later*
+    # second than the cached entry mtime — the exact state the bug went blind on.
+    stamp_ns = 1_700_000_000_000_000_000
+    os.utime(tracked, ns=(stamp_ns, stamp_ns))
+    _init_committed_repo_around_existing_file(nested, email="racy@example.com")
+    git_dir = nested / ".git"
+
+    tracked.write_text("mutated\n", encoding="utf-8")
+    assert tracked.stat().st_size == len("tracked\n"), "mutation must be same-size"
+    os.utime(tracked, ns=(stamp_ns, stamp_ns))
+    os.utime(git_dir / "index", ns=(stamp_ns, stamp_ns))
+
+    def _changed_paths(probe_git_dir: Path) -> str:
+        return subprocess.run(
+            [
+                "git",
+                "-c",
+                "core.trustctime=false",
+                "-c",
+                "core.checkStat=default",
+                "--git-dir",
+                str(probe_git_dir),
+                "--work-tree",
+                str(nested),
+                "diff-files",
+                "--name-only",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+    live = _changed_paths(git_dir)
+    assert live.split() == ["tracked.txt"], (
+        f"precondition: live git-dir must report it, got {live!r}"
+    )
+    with git_manager.untrusted_nested_probe_config_snapshot_git_dir(nested) as shadow:
+        assert shadow is not None
+        assert _changed_paths(shadow) == live

--- a/tests/unit/node/test_git_manager_ownership_object_store_budget.py
+++ b/tests/unit/node/test_git_manager_ownership_object_store_budget.py
@@ -692,3 +692,53 @@ def test_copy_opened_regular_file_fails_closed_when_lseek_after_peek_fails(
         assert not dest.exists()
     finally:
         os.close(fd)
+
+
+@pytest.mark.unit
+def test_copy_opened_regular_file_preserve_times_stamps_and_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``preserve_source_times`` copies the source mtime and fails closed on utime errors.
+
+    Index copies must keep the source mtime or Git's racily-clean re-check is
+    disabled for the snapshot git-dir (issue #942).
+    """
+    src = tmp_path / "leaf"
+    src.write_bytes(b"payload")
+    stamp_ns = 1_700_000_000_000_000_000
+    os.utime(src, ns=(stamp_ns, stamp_ns))
+
+    dest = tmp_path / "stamped"
+    fd = os.open(src, os.O_RDONLY)
+    try:
+        assert (
+            git_manager_ownership._copy_opened_regular_file_to_path(
+                fd, dest, preserve_source_times=True
+            )
+            is True
+        )
+    finally:
+        os.close(fd)
+    assert dest.stat().st_mtime_ns == stamp_ns
+
+    real_utime = os.utime
+
+    def _utime_fails(path: object, *args: object, **kwargs: object) -> None:
+        if isinstance(path, int):
+            raise OSError("utime failed")
+        real_utime(path, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(os, "utime", _utime_fails)
+    failing = tmp_path / "unstamped"
+    fd = os.open(src, os.O_RDONLY)
+    try:
+        assert (
+            git_manager_ownership._copy_opened_regular_file_to_path(
+                fd, failing, preserve_source_times=True
+            )
+            is False
+        )
+    finally:
+        os.close(fd)
+    assert not failing.exists()

--- a/tests/unit/runtime/test_comment_verdict_coverage_edges_parts/test_comment_verdict_coverage_edges_part_004.py
+++ b/tests/unit/runtime/test_comment_verdict_coverage_edges_parts/test_comment_verdict_coverage_edges_part_004.py
@@ -21,6 +21,23 @@ from tests.unit.runtime.test_comment_verdict_coverage_edges_parts._helpers impor
 
 _git_env = git_env_without_object_lookup_overrides
 
+# Fixed base far in the past; never "now", so stamps never depend on when a test runs.
+_STAMP_EPOCH_NS = 1_700_000_000_000_000_000
+
+
+def _write_stamped(path: Path, text: str, *, tick: int) -> None:
+    """Write ``text`` and pin a deterministic, per-step distinct mtime.
+
+    Nested probes list unstaged edits with stat-only ``git diff-files``. Git compares
+    index-cached stat data in whole seconds, so a same-size overwrite landing in the
+    second the index recorded is only caught by the racily-clean content re-check.
+    Giving every write an explicit tick makes the recorded and on-disk stat differ by
+    construction, so detection never depends on how fast the test ran (issue #942).
+    """
+    path.write_text(text, encoding="utf-8")
+    stamp = _STAMP_EPOCH_NS + tick * 1_000_000_000
+    os.utime(path, ns=(stamp, stamp))
+
 
 @pytest.mark.unit
 def test_nested_git_probe_pins_to_git_reported_worktree_root(
@@ -623,12 +640,17 @@ def test_open_worktree_directory_path_pins_multi_component_inside_outer(
 
 
 @pytest.mark.unit
-@pytest.mark.timeout(2)
 def test_nested_git_probe_retains_opened_worktree_across_path_swap(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PRRT_kwDOSJAM6s6eY3eE: redirected core.worktree must stay fd-pinned across probes."""
+    """PRRT_kwDOSJAM6s6eY3eE: redirected core.worktree must stay fd-pinned across probes.
+
+    Carries no per-test ``timeout`` marker: this test runs three nested probes, each
+    forking several ``git`` processes, so a two-second budget measured latency rather
+    than a hang under ``pytest -n 20`` (issue #942). The repo-wide 30 s timeout still
+    bounds a genuine hang, and matches the production nested-probe budget.
+    """
     worktree = tmp_path / "ws_redirected_worktree_fd"
     worktree.mkdir()
     init_git_worktree(worktree)
@@ -651,7 +673,7 @@ def test_nested_git_probe_retains_opened_worktree_across_path_swap(
         capture_output=True,
     )
     tracked = redirected_root / "f"
-    tracked.write_text("tracked\n", encoding="utf-8")
+    _write_stamped(tracked, "tracked\n", tick=0)
     git_dir = nested_root / ".git"
     subprocess.run(
         [
@@ -687,7 +709,9 @@ def test_nested_git_probe_retains_opened_worktree_across_path_swap(
         capture_output=True,
     )
 
-    tracked.write_text("mutated\n", encoding="utf-8")
+    # Distinct length as well as distinct bytes and mtime: the unstaged edit is then
+    # visible to ``diff-files`` on size alone, independent of any stat timing.
+    _write_stamped(tracked, "mutated-content\n", tick=1)
     before = comment_verdict_residue._git_nested_worktree_commit(
         worktree_path=worktree,
         path=nested_name,
@@ -697,7 +721,12 @@ def test_nested_git_probe_retains_opened_worktree_across_path_swap(
 
     decoy_root = worktree / "decoy_baseline"
     shutil.copytree(redirected_root, decoy_root)
-    (decoy_root / "f").write_text("tracked\n", encoding="utf-8")
+    # ``copytree`` uses ``copy2``, so the decoy would otherwise inherit the real
+    # tree's mtimes verbatim; give it its own tick.
+    _write_stamped(decoy_root / "f", "tracked\n", tick=2)
+    real_ino = redirected_root.stat().st_ino
+    decoy_ino = decoy_root.stat().st_ino
+    assert real_ino != decoy_ino
     # Measure what a pathname-following probe would hash if it saw the decoy.
     backup_for_decoy = worktree / "actual.decoy_measure"
     redirected_root.rename(backup_for_decoy)
@@ -713,15 +742,24 @@ def test_nested_git_probe_retains_opened_worktree_across_path_swap(
     assert decoy_fp != before
 
     real_pinned_probe = comment_verdict_residue._pinned_nested_git_probe
-    swap_done = False
+    # Record what the pinned probe actually saw instead of a bare "did it run" flag,
+    # so the swap is sequenced by an observation rather than by hoping the rename
+    # lands first, and a CI failure is self-diagnosing (issue #942).
+    pin_observations: list[tuple[str, str, int, str]] = []
 
     @contextlib.contextmanager
     def _swap_redirected_worktree_on_pin(git_dir_path: Path, worktree_path: Path) -> Iterator[None]:
-        nonlocal swap_done
         backup = worktree / "actual.real"
         redirected_root.rename(backup)
         decoy_root.rename(redirected_root)
-        swap_done = True
+        pin_observations.append(
+            (
+                str(git_dir_path),
+                str(worktree_path),
+                redirected_root.stat().st_ino,
+                (redirected_root / "f").read_text(encoding="utf-8"),
+            )
+        )
         try:
             with real_pinned_probe(git_dir_path, worktree_path):
                 yield
@@ -741,18 +779,26 @@ def test_nested_git_probe_retains_opened_worktree_across_path_swap(
         git_env=_git_env(),
     )
 
-    assert swap_done
-    assert after == before
-    assert after != decoy_fp
+    assert len(pin_observations) == 1, pin_observations
+    # The swap was already in place when the pinned probe ran: the redirected
+    # pathname resolved to the decoy inode holding the index-matching bytes.
+    assert pin_observations[0][2] == decoy_ino, pin_observations
+    assert pin_observations[0][3] == "tracked\n", pin_observations
+    assert after is not None, pin_observations
+    assert after == before, pin_observations
+    assert after != decoy_fp, pin_observations
 
 
 @pytest.mark.unit
-@pytest.mark.timeout(2)
 def test_nested_worktree_fd_pin_does_not_reenter_by_pathname_mid_hash(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PRRT_kwDOSJAM6s6eajOa: pinned worktree fd must not be a pathname-only oracle."""
+    """PRRT_kwDOSJAM6s6eajOa: pinned worktree fd must not be a pathname-only oracle.
+
+    Carries no per-test ``timeout`` marker for the same reason as
+    ``test_nested_git_probe_retains_opened_worktree_across_path_swap`` (issue #942).
+    """
     worktree = tmp_path / "ws_worktree_fd_no_reenter"
     worktree.mkdir()
     init_git_worktree(worktree)
@@ -775,7 +821,7 @@ def test_nested_worktree_fd_pin_does_not_reenter_by_pathname_mid_hash(
         capture_output=True,
     )
     tracked = redirected_root / "f"
-    tracked.write_text("tracked\n", encoding="utf-8")
+    _write_stamped(tracked, "tracked\n", tick=0)
     git_dir = nested_root / ".git"
     subprocess.run(
         [
@@ -811,8 +857,10 @@ def test_nested_worktree_fd_pin_does_not_reenter_by_pathname_mid_hash(
         capture_output=True,
     )
 
-    tracked.write_text("mutated\n", encoding="utf-8")
-    (redirected_root / "u").write_text("untracked-real\n", encoding="utf-8")
+    # Distinct length as well as distinct bytes and mtime, so ``diff-files`` reports
+    # the unstaged edit on size alone rather than on stat timing.
+    _write_stamped(tracked, "mutated-content\n", tick=1)
+    _write_stamped(redirected_root / "u", "untracked-real\n", tick=2)
     before = comment_verdict_residue._git_nested_worktree_commit(
         worktree_path=worktree,
         path=nested_name,
@@ -822,8 +870,10 @@ def test_nested_worktree_fd_pin_does_not_reenter_by_pathname_mid_hash(
 
     decoy_root = worktree / "decoy_mid_hash"
     shutil.copytree(redirected_root, decoy_root)
-    (decoy_root / "f").write_text("tracked\n", encoding="utf-8")
-    (decoy_root / "u").write_text("untracked-decoy\n", encoding="utf-8")
+    # ``copytree`` uses ``copy2``; re-stamp every decoy leaf with its own tick so the
+    # decoy's stat data can never coincide with the real tree's.
+    _write_stamped(decoy_root / "f", "tracked\n", tick=3)
+    _write_stamped(decoy_root / "u", "untracked-decoy-bytes\n", tick=4)
 
     # Pathname-only oracle baseline: hashing after a full path replacement.
     backup_for_decoy = worktree / "actual.decoy_measure"
@@ -841,7 +891,11 @@ def test_nested_worktree_fd_pin_does_not_reenter_by_pathname_mid_hash(
 
     real_open = comment_verdict_residue._open_worktree_regular_file_under_root
     swap_done = False
-    seen_proc_worktree = False
+    # Record every leaf open (root, leaf, whether it came through the pinned fd)
+    # instead of a bare bool, so the swap is sequenced by an explicit marker and the
+    # assertions describe what the probe read (issue #942).
+    opens: list[tuple[str, str, bool]] = []
+    swap_at: list[int] = []
 
     @contextlib.contextmanager
     def _swap_redirected_worktree_on_byte_open(
@@ -850,12 +904,12 @@ def test_nested_worktree_fd_pin_does_not_reenter_by_pathname_mid_hash(
         *,
         root_dir_fd: int | None = None,
     ) -> Iterator[object]:
-        nonlocal swap_done, seen_proc_worktree
+        nonlocal swap_done
         root_s = str(root)
-        if "/proc/self/fd/" in root_s or root_dir_fd is not None:
-            seen_proc_worktree = True
         leaf = Path(path).name
+        opens.append((root_s, leaf, "/proc/self/fd/" in root_s or root_dir_fd is not None))
         if not swap_done and leaf in {"f", "u"}:
+            swap_at.append(len(opens) - 1)
             backup = worktree / "actual.real"
             redirected_root.rename(backup)
             decoy_root.rename(redirected_root)
@@ -882,10 +936,19 @@ def test_nested_worktree_fd_pin_does_not_reenter_by_pathname_mid_hash(
         git_env=_git_env(),
     )
 
-    assert swap_done
-    assert seen_proc_worktree
-    assert after == before
-    assert after != decoy_fp
+    leaves = [leaf for _, leaf, _ in opens]
+    # Both leaves were actually opened, so an empty untracked listing cannot silently
+    # skip the swap; the swap is then sequenced onto the first of them by index rather
+    # than by a bare "it happened" flag.
+    assert {"f", "u"} <= set(leaves), opens
+    assert swap_done, opens
+    first_leaf_open = next(i for i, leaf in enumerate(leaves) if leaf in {"f", "u"})
+    assert swap_at == [first_leaf_open], (swap_at, opens)
+    # Byte reads entered through the retained descriptor, not a mutable pathname.
+    assert any(pinned for _, _, pinned in opens), opens
+    assert after is not None, opens
+    assert after == before, opens
+    assert after != decoy_fp, opens
 
 
 @pytest.mark.unit
@@ -1265,7 +1328,8 @@ def test_nested_git_probe_discovers_inner_repo_while_outer_pin_active(
         check=True,
         capture_output=True,
     )
-    (inner_root / "inner.txt").write_text("v1\n", encoding="utf-8")
+    inner_file = inner_root / "inner.txt"
+    _write_stamped(inner_file, "v1\n", tick=0)
     subprocess.run(["git", "add", "inner.txt"], cwd=inner_root, check=True, capture_output=True)
     subprocess.run(
         ["git", "commit", "-m", "inner init"],
@@ -1274,18 +1338,25 @@ def test_nested_git_probe_discovers_inner_repo_while_outer_pin_active(
         capture_output=True,
     )
 
+    committed_bytes = inner_file.read_bytes()
     before = comment_verdict_residue._git_nested_worktree_commit(
         worktree_path=worktree,
         path=vendor_name,
         git_env=_git_env(),
     )
-    (inner_root / "inner.txt").write_text("v2\n", encoding="utf-8")
+    # Distinct length, bytes and mtime, so the inner edit is visible to the probe
+    # regardless of how long the probes took (issue #942).
+    _write_stamped(inner_file, "v2-mutated\n", tick=1)
+    mutated_bytes = inner_file.read_bytes()
     after = comment_verdict_residue._git_nested_worktree_commit(
         worktree_path=worktree,
         path=vendor_name,
         git_env=_git_env(),
     )
 
+    # Assert the observed input first: distinguishes "the test never mutated" from
+    # "the probe did not see the mutation".
+    assert committed_bytes != mutated_bytes
     assert before is not None
     assert after is not None
     assert before != after
@@ -1307,7 +1378,9 @@ def test_nested_gitfile_inside_outer_git_dir_detects_inner_mutations(
         path=outer_name,
         git_env=_git_env(),
     )
-    (inner_root / "inner.txt").write_text("v2\n", encoding="utf-8")
+    # Distinct length and mtime: same-size same-second overwrites are only visible to
+    # stat-only ``diff-files`` through the racily-clean re-check (issue #942).
+    _write_stamped(inner_root / "inner.txt", "v2-mutated\n", tick=1)
     after = comment_verdict_residue._git_nested_worktree_commit(
         worktree_path=worktree,
         path=outer_name,
@@ -1386,7 +1459,10 @@ def test_digest_nested_git_directory_uses_pinned_fd_not_readlink_pathname(
     decoy = tmp_path / "wt_nested_dir_decoy"
     decoy.mkdir()
     init_git_worktree_with_embedded_repo(decoy)
-    (decoy / nested_name / "inner.txt").write_text("decoy\n", encoding="utf-8")
+    # Distinct length and mtime from the committed ``inner\n``: the two repos can share
+    # a commit SHA when both ``git commit`` calls land in one second, so the decoy's
+    # unstaged edit is the only thing separating the digests (issue #942).
+    _write_stamped(decoy / nested_name / "inner.txt", "decoy-bytes\n", tick=1)
 
     decoy_digest = comment_verdict_residue._digest_worktree_entry_bytes(
         worktree_path=decoy,


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_a22487e96ded48d7b0dacbb2` (agent: `claude_code`, model: `claude-opus-5`, effort: `high`).


### Task
Fix GitHub issue #942 (read it first: gh issue view 942). Three tests in tests/unit/runtime/test_comment_verdict_coverage_edges_parts/test_comment_verdict_coverage_edges_part_004.py flake under CI and 'pytest -n 20' load and pass alone: test_nested_git_probe_retains_opened_worktree_across_path_swap, test_nested_worktree_fd_pin_does_not_reenter_by_pathname_mid_hash, test_nested_git_probe_discovers_inner_repo_while_outer_pin_active. Root-cause the nondeterminism (most likely wall-clock ordering of filesystem mutations within one timestamp tick, or fd re-open timing) and make the tests deterministic WITHOUT sleeps: force distinct mtimes/inodes explicitly (os.utime), sequence the swap/pin steps with explicit markers, and assert on observed inputs rather than elapsed time. Do not change the behaviour under test in comment_verdict_residue* unless a genuine production race is found - if so, fix it minimally with its own regression test and say so in the PR body. Prove stability: run the file 20 times under 'pytest -n 20 -p no:randomly' (or a loop) before pushing. Coverage gate 99 percent line+branch; ruff check, ruff format --check, mypy and 'pytest tests -q -n 20' before pushing. Keep each agent run short: focused tests, commit, always end with the AWF-VERDICT line; for review items put the fix hunk in the reviewed file at the reviewed line and never cite your own commit in a FALSE POSITIVE or DEFER. Reference 'Closes #942' in the PR body.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes nested-git probe snapshot semantics for index timestamps (security-sensitive residue detection); behavior is narrowly scoped to index/sharedindex copies with fail-closed utime errors.
> 
> **Overview**
> **Fixes nested residue blind spots and stabilizes flaky nested-probe tests under parallel CI.**
> 
> Nested probe git-dir snapshots copy `index` (and split-index `sharedindex.*`) into a private staging tree. Those copies now optionally keep the source inode’s atime/mtime via `preserve_source_times` on `_copy_opened_regular_file_to_path` / `_symlink_git_dir_child_via_fd`, with `os.utime` on the destination fd. Without that, a staging-time index mtime disables Git’s racily-clean content re-check, so same-size worktree overwrites in the same second as the cached entry could disappear from snapshot-scoped `diff-files` while the live git-dir still reported them.
> 
> Tests pin deterministic mtimes (`os.utime`, `_write_stamped`), tighten swap/pin sequencing assertions, drop overly tight 2s per-test timeouts on heavy nested-probe cases, and add regressions for index mtime preservation and live vs snapshot `diff-files` agreement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cdf3038eb48c1d766dd9fdf3ef1a761f5b16845. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->