### PR TITLE
Fix #952: same-package evidence on the correction attempt

### DIFF
--- a/src/awf/runtime/pr_monitor_runner/comment_verdict.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_verdict.py
@@ -42,6 +42,9 @@ from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
     correction_unscoped_fix_outcome as correction_unscoped_fix_outcome,
 )
 from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
+    package_level_item_fix_evidence as package_level_item_fix_evidence,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
     path_level_item_fix_evidence as path_level_item_fix_evidence,
 )
 from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
@@ -889,6 +892,38 @@ async def _run_item_verdict_protocol(
                     # check above was already path-level. Inside the commit-sink
                     # ``try`` so it shares the rollback / reason-code handlers.
                     logical_fix_evidence = await path_level_item_fix_evidence(
+                        runner,
+                        worktree_path=worktree_path,
+                        item_start_head=item_start_head,
+                        item_path=item_path,
+                        state=state,
+                        dirty_changes_committed=dirty_changes_committed,
+                    )
+                if (
+                    not logical_fix_evidence
+                    and protocol_attempt == 1
+                    and item_path is not None
+                    and (item_line is None or item_line > 0)
+                ):
+                    # Package-level evidence on the correction (#952). Both
+                    # checks above have failed, so the item's own commit range
+                    # changes neither the anchored line nor the reviewed file.
+                    # Accept it when it changes any file in the reviewed file's
+                    # *package* (the bundle-scope rule: same parent directory,
+                    # or descendant paths). That is the normal shape of a
+                    # callee-anchored review — "honour the ownership result in
+                    # that caller" is anchored on the callee and fixed in the
+                    # caller — and of a line-limit split that moved the reviewed
+                    # code into a sibling module, which makes every correct fix
+                    # off-path by construction. Eight escalations on 2026-09-07
+                    # (PRs #922, #934, #939) were exactly those shapes. Same
+                    # guards as above: correction attempt only, the item's own
+                    # ``item_start_head``..HEAD range, contentful + descendant,
+                    # and the ``item_line <= 0`` unmappable-anchor sentinel
+                    # stays fail-closed. Cross-package commits keep escalating.
+                    # Inside the commit-sink ``try`` so it shares the rollback /
+                    # reason-code handlers.
+                    logical_fix_evidence = await package_level_item_fix_evidence(
                         runner,
                         worktree_path=worktree_path,
                         item_start_head=item_start_head,

--- a/src/awf/runtime/pr_monitor_runner/comment_verdict_correction.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_verdict_correction.py
@@ -3,7 +3,7 @@
 Kept separate so ``comment_verdict`` stays under the first-party line budget;
 re-exported from ``comment_verdict`` for callers and tests.
 
-Three policies live here, all scoped to the correction retry — the attempt that
+Four policies live here, all scoped to the correction retry — the attempt that
 runs only after AWF told the agent, explicitly, why attempt 0 was rejected.
 
 * **Path-level evidence on the correction** — attempt 0 keeps the strict
@@ -16,6 +16,22 @@ runs only after AWF told the agent, explicitly, why attempt 0 was rejected.
   unnecessary escalation #925 set out to remove. This is never the first gate,
   and the range is the item's own, so the commit cannot be a stale, foreign, or
   pre-existing change. Restores the PR #926 D1 behaviour on top of #928.
+* **Package-level evidence on the correction** (#952) — after the line-anchored
+  and the path-level checks have both failed, the same item-own range is
+  accepted when it changes any file in the reviewed file's *package* (the
+  bundle-scope rule: same parent directory, or descendant paths). A
+  same-package change is the normal shape of a callee-anchored review ("honour
+  the ownership result in that caller" is anchored on the callee and fixed in
+  the caller), and of a line-limit split that moved the reviewed code into a
+  sibling module — where every correct fix is off-path by construction. Eight
+  escalations on 2026-09-07 (PRs #922, #934, #939) were exactly those shapes,
+  each costing an operator decision for a fix that was correct. The widening
+  changes the *radius* of the existing "an unrelated edit could satisfy the
+  gate" risk, not its kind: the strict rule already accepts an unrelated edit
+  to the reviewed file itself. Attempt 0 stays strict, cross-package commits
+  keep escalating with the commit preserved, and the unmappable-anchor sentinel
+  stays fail-closed. A request to remove this acceptance (PR #929 /
+  issue:5558086911) is answered DEFER — it is an explicit operator decision.
 * **No rollback on a self-citing non-fix** — the correction prompt puts the
   item's own attempt-0 commit at HEAD, so an agent can answer ``FALSE POSITIVE:
   already addressed by commit <its own sha>``. Accepting that as a non-fix and
@@ -239,6 +255,94 @@ async def path_level_item_fix_evidence(
     )
 
 
+async def package_level_item_fix_evidence(
+    runner: PullRequestMonitorRunner,
+    *,
+    worktree_path: Path,
+    item_start_head: str | None,
+    item_path: str | None,
+    state: MonitorState | None,
+    dirty_changes_committed: bool,
+) -> bool:
+    """Accept a same-package change as correction-attempt FIXED evidence (#952).
+
+    The last of the three correction-attempt evidence checks: same
+    ``item_start_head``..HEAD range and the same contentful-descendant
+    requirement as the line-anchored and path-level gates, only the scope
+    predicate widened from "the reviewed line" to "the reviewed file's package"
+    — the existing bundle-scope rule ``_commit_range_in_item_scope`` /
+    ``_changed_path_in_item_scope`` (same parent directory, or descendant
+    paths), which also covers a module extracted out of the reviewed file.
+
+    Why this is safe, and why it is needed (issue #952): the correction attempt
+    only runs after AWF told the agent its FIXED lacked evidence and the agent
+    re-affirmed FIXED; the range is the item's *own*, so the commit cannot be
+    stale or foreign; and a same-package change is the normal shape of a
+    callee-anchored review — "honour the ownership result in that caller" is
+    anchored on the callee but fixed in the caller, and a line-limit split moves
+    reviewed code into a sibling module so that every correct fix is off-path by
+    construction. Eight escalations on 2026-09-07 (PRs #922, #934, #939) were
+    correct fixes of exactly those two shapes, each costing an operator
+    decision. The widening changes the *radius* of the existing "an unrelated
+    edit could satisfy the gate" risk, not its kind: the strict rule already
+    accepts an unrelated edit to the reviewed file itself. Attempt 0 stays
+    strict so a no-op FIXED still earns its correction round, cross-package
+    commits keep escalating to ``needs_human`` with the commit preserved, and
+    the unmappable-anchor sentinel stays fail-closed. If a reviewer asks for
+    this acceptance to be removed again (PR #929 / issue:5558086911), the answer
+    is DEFER: it is an explicit operator decision recorded in issue #952.
+
+    ``dirty_changes_committed`` is accepted for signature parity with the other
+    two evidence helpers and deliberately never consulted: the earlier checks
+    already produced the degraded dirty-sink fallback, so the widest gate must
+    never be the one that invents evidence for a lightweight or mocked runner.
+    """
+    del dirty_changes_committed
+
+    if item_start_head is None or item_path is None or not worktree_path.exists():
+        return False
+
+    descends = getattr(runner, "_head_descends_from", None)
+    trees_differ = getattr(runner, "_commit_trees_differ", None)
+    in_item_scope = getattr(runner, "_commit_range_in_item_scope", None)
+    if not (callable(descends) and callable(trees_differ) and callable(in_item_scope)):
+        return False
+
+    candidate_heads: list[str] = []
+    end_head = await runner._rev_parse_head(worktree_path)
+    if end_head:
+        candidate_heads.append(end_head)
+    if state is not None and state.hosted_terminal_head_advanced:
+        hosted_head = (state.last_push_sha or "").strip()
+        if hosted_head and hosted_head not in candidate_heads:
+            candidate_heads.append(hosted_head)
+
+    for candidate in candidate_heads:
+        if candidate.lower() == item_start_head.lower():
+            continue
+        if not await descends(
+            worktree_path=worktree_path,
+            ancestor=item_start_head,
+            descendant=candidate,
+        ):
+            continue
+        if not await trees_differ(
+            worktree_path=worktree_path,
+            left=item_start_head,
+            right=candidate,
+        ):
+            continue
+        if not await in_item_scope(
+            worktree_path=worktree_path,
+            left=item_start_head,
+            right=candidate,
+            item_path=item_path,
+        ):
+            continue
+        return True
+    return False
+
+
 def correction_self_citation_outcome(
     *,
     workspace_id: str,
@@ -252,7 +356,11 @@ def correction_self_citation_outcome(
     ``has_path_evidence`` is the caller's item-scoped FIXED evidence: the
     line-anchored check, **or** — because this only ever runs on the correction
     attempt — the path-level re-check of the item's own commit range
-    (``path_level_item_fix_evidence``). An explicit corrected ``needs_human``
+    (``path_level_item_fix_evidence``), **or** the package-level re-check of
+    that same range (``package_level_item_fix_evidence``, #952). The guard reads
+    whatever the correction accepted as evidence, so a sibling-module fix the
+    agent then points at as "already addressed" resolves the thread instead of
+    escalating. An explicit corrected ``needs_human``
     always stays ``needs_human``: no evidence converts a requested human gate
     into a resolvable ``fix_committed`` (issue:5558086911). For
     ``false_positive`` / ``defer``, item-scoped evidence means the item is what
@@ -354,8 +462,10 @@ def correction_unscoped_fix_outcome(
     touches none of the reviewed paths, so AWF cannot accept FIXED. The
     same-file off-anchor case no longer reaches here: on the correction attempt
     ``path_level_item_fix_evidence`` accepts a commit that changes the reviewed
-    file, so what is left is a commit in the wrong file (or, with an unmappable
-    anchor, one AWF cannot place at all — that stays fail-closed). The protocol
+    file, and ``package_level_item_fix_evidence`` accepts one that changes a
+    file in the reviewed file's package (#952). What is left is a commit in
+    another package entirely (or, with an unmappable anchor, one AWF cannot
+    place at all — that stays fail-closed). The protocol
     used to roll that commit back and terminate with ``AGENT_FIXED_WITHOUT_EVIDENCE``,
     which failed the whole monitor — the shape that killed ws_46bc0f45 on PR
     #922 after a protocol-violation correction, where attempt 1's off-anchor

--- a/tests/unit/runtime/_verdict_retry_fixtures.py
+++ b/tests/unit/runtime/_verdict_retry_fixtures.py
@@ -28,7 +28,11 @@ class _VerdictRunner(SimpleNamespace):
         stranded_status_raises: bool = False,
         path_touched: bool = True,
         line_touched: bool = True,
-        in_item_scope: bool = True,
+        # "Is the item's commit range inside the reviewed file's package?" —
+        # the #952 correction-attempt widening. Defaults to False so the many
+        # ``path_touched=False`` correction tests keep narrating what they mean:
+        # the commit landed in another package entirely.
+        in_item_scope: bool = False,
         provider_error_action: BaseException | None = None,
         provider_recovery_suppress_attempts: frozenset[int] | None = None,
         reset_fails: bool = False,

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_005.py
@@ -498,11 +498,20 @@ async def test_protocol_retry_non_fix_verdict_rollback_failure_is_terminal(
 
 
 @pytest.mark.unit
-async def test_fixed_rejected_when_only_same_directory_sibling_changed(
+async def test_same_directory_sibling_fix_accepted_on_the_correction(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PRRT_kwDOSJAM6s6bdFvk: sibling-file edits must not satisfy inline FIXED."""
+    """#952 supersedes PRRT_kwDOSJAM6s6bdFvk on the correction attempt only.
+
+    Attempt 0 still rejects the sibling-file edit (the correction prompt is
+    issued), so a no-op FIXED keeps earning its correction round. Once the agent
+    has been told its FIXED carried no item-scoped evidence and re-affirms it,
+    a contentful commit in the item's own range that changes a file in the
+    reviewed file's package is accepted: that is the normal shape of a
+    callee-anchored review, and escalating it cost eight operator decisions on
+    2026-09-07.
+    """
     reviewed_path = "src/awf/reviewed.py"
     worktree = tmp_path / "ws_protocol"
     worktree.mkdir()
@@ -521,6 +530,7 @@ async def test_fixed_rejected_when_only_same_directory_sibling_changed(
         heads_after_attempt=["b" * 40, "b" * 40],
         dirty_after_attempt=[True, True],
         path_touched=False,
+        in_item_scope=True,
     )
     thread = ReviewThread(
         thread_id="thread_cross_file",
@@ -540,12 +550,12 @@ async def test_fixed_rejected_when_only_same_directory_sibling_changed(
         operation_start_head="a" * 40,
     )
 
-    # The contentful commit misses the anchored path, so FIXED is still not
-    # accepted — but the correction attempt now preserves the commit and
-    # escalates instead of terminating the monitor (#925 follow-up).
-    assert verdict == "needs_human"
+    # Attempt 0 was still corrected, and the re-affirmed FIXED is kept rather
+    # than rolled back or escalated (#952).
+    assert verdict == "fix_committed"
     assert runner.reset_targets == []
     assert len(runner.prompts) == 2
+    assert "no new item-scoped Git change" in runner.prompts[1]
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_026.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_026.py
@@ -1,0 +1,532 @@
+"""Same-package FIXED evidence on the correction attempt (issue #952).
+
+Eight `needs_human` escalations on 2026-09-07 (PRs #922, #934, #939) were
+correct fixes that landed in a *sibling* of the reviewed file: either the
+reviewer anchored on the callee while asking for the fix in the caller
+(``lifecycle.py:640`` → ``merge_loop.py``), or a line-limit split had moved the
+reviewed code into a new module (``comment_verdict.py:555`` →
+``comment_verdict_entrypoint.py``), which makes any correct fix "off-path" by
+construction.
+
+On the **correction attempt only**, after the line-anchored and the path-level
+checks both fail, the item's own commit range now counts as FIXED evidence when
+it changes any file in the reviewed file's package — the existing bundle-scope
+rule (same parent directory, or descendant paths). Attempt 0 stays strict,
+cross-package commits keep escalating with the commit preserved, and the
+unmappable-anchor sentinel stays fail-closed.
+
+The runner here models the real package rule rather than a boolean: it carries
+the paths its commit changed and delegates ``_commit_range_in_item_scope`` to
+the production ``_changed_path_in_item_scope``, so "sibling", "extracted
+module" and "other package" are genuinely different inputs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import structlog
+
+from awf.common.github_client import RepoRef
+from awf.runtime.pr_monitor import MonitorState, ReviewThread
+from awf.runtime.pr_monitor_runner import comment_verdict, comments, pre_push_validation
+from awf.runtime.pr_monitor_runner import pre_push_validation_fix_pass_ancestry as ancestry
+from awf.runtime.pr_monitor_runner.comment_verdict import (
+    AGENT_FIXED_WITHOUT_EVIDENCE,
+    AGENT_NON_FIX_CITES_OWN_COMMIT,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
+    package_level_item_fix_evidence,
+)
+from awf.runtime.pr_monitor_runner.comments import _address_thread
+from tests.unit.runtime._verdict_retry_fixtures import _VerdictRunner
+
+pytest_plugins = ["tests.unit.runtime._verdict_retry_fixtures"]
+
+_ITEM_START_HEAD = "a" * 40
+_ATTEMPT0_HEAD = "b" * 40
+_HOSTED_HEAD = "c" * 40
+_NO_VERDICT_LINE = "Rewired the caller; the sweep is still running."
+
+_MONITOR_PACKAGE = "src/awf/runtime/pr_monitor_runner"
+_REVIEWED_LIFECYCLE = f"{_MONITOR_PACKAGE}/lifecycle.py"
+_SIBLING_MERGE_LOOP = f"{_MONITOR_PACKAGE}/merge_loop.py"
+_REVIEWED_VERDICT = f"{_MONITOR_PACKAGE}/comment_verdict.py"
+_EXTRACTED_ENTRYPOINT = f"{_MONITOR_PACKAGE}/comment_verdict_entrypoint.py"
+_REVIEWED_ADAPTER = "src/awf/adapters/codex.py"
+_OTHER_PACKAGE = "src/awf/control/worker/manager.py"
+_DOCS_ONLY = "docs/CONCEPTS.md"
+
+
+class _PackageScopeRunner(_VerdictRunner):
+    """A ``_VerdictRunner`` whose commit range changed ``changed_paths``.
+
+    ``_commit_range_in_item_scope`` delegates to the production
+    ``_changed_path_in_item_scope`` so the same-package rule under test is the
+    real one, not a stub that answers the question it is meant to ask.
+    """
+
+    def __init__(self, *, changed_paths: list[str], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.changed_paths = list(changed_paths)
+
+    async def _commit_range_in_item_scope(
+        self,
+        *,
+        worktree_path: Path,
+        left: str,
+        right: str,
+        item_path: str,
+    ) -> bool:
+        del worktree_path, left, right
+        return any(
+            pre_push_validation._changed_path_in_item_scope(
+                item_path=item_path,
+                changed_path=changed,
+            )
+            for changed in self.changed_paths
+        )
+
+
+@pytest.fixture(autouse=True)
+def _no_owned_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _empty_owned_paths(_runner: object, _workspace_id: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(comments, "_owned_paths_for_prompt", _empty_owned_paths)
+
+
+def _thread(thread_id: str, path: str, line: int = 640) -> ReviewThread:
+    return ReviewThread(
+        thread_id=thread_id,
+        path=path,
+        line=line,
+        body_excerpt="honor the ownership result in that caller",
+    )
+
+
+async def _address(
+    runner: _VerdictRunner,
+    thread: ReviewThread,
+    state: MonitorState | None = None,
+) -> str:
+    return await _address_thread(
+        runner,  # type: ignore[arg-type]
+        workspace_id="ws_protocol",
+        repo=RepoRef(owner="o", name="r"),
+        pr_number=1,
+        thread=thread,
+        compose_project="awf_ws_protocol",
+        compose_file=Path("compose.yml"),
+        state=state,
+        operation_start_head=_ITEM_START_HEAD,
+    )
+
+
+@pytest.mark.unit
+async def test_same_package_sibling_fix_accepted_on_the_correction(tmp_path: Path) -> None:
+    """Shape 1 of #952: the reviewer anchors on the callee, the fix lands in the caller.
+
+    ``lifecycle.py:640`` says "honor the ownership result in that caller"; the
+    fix is in ``merge_loop.py``, same package. Attempt 0 is still rejected (the
+    correction prompt is issued), and the re-affirmed FIXED is accepted rather
+    than costing an operator decision.
+    """
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _PackageScopeRunner(
+        changed_paths=[_SIBLING_MERGE_LOOP],
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: honored the ownership result in the caller",
+            "AWF-VERDICT: FIXED: the caller is where the fix belongs",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, True],
+        path_touched=False,
+    )
+
+    verdict = await _address(runner, _thread("thread_callee_anchor", _REVIEWED_LIFECYCLE))
+
+    assert verdict == "fix_committed"
+    assert runner.reset_targets == []
+    assert len(runner.prompts) == 2
+    assert "no new item-scoped Git change" in runner.prompts[1]
+
+
+@pytest.mark.unit
+async def test_extracted_module_fix_accepted_on_the_correction(tmp_path: Path) -> None:
+    """Shape 2 of #952: a line-limit split moved the reviewed code out of the file.
+
+    The thread is anchored on ``comment_verdict.py`` but the code it points at
+    now lives in ``comment_verdict_entrypoint.py``, extracted on the same
+    branch, so every correct fix is off-path by construction.
+    """
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _PackageScopeRunner(
+        changed_paths=[_EXTRACTED_ENTRYPOINT],
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: the reviewed block moved to the entrypoint module",
+            "AWF-VERDICT: FIXED: the split moved this code, the fix is there",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, True],
+        path_touched=False,
+    )
+
+    verdict = await _address(runner, _thread("thread_split_moved", _REVIEWED_VERDICT, line=555))
+
+    assert verdict == "fix_committed"
+    assert runner.reset_targets == []
+    assert len(runner.prompts) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("changed_path", [_OTHER_PACKAGE, _DOCS_ONLY])
+async def test_cross_package_correction_fix_still_escalates(
+    tmp_path: Path,
+    changed_path: str,
+) -> None:
+    """A commit in another package keeps today's outcome: escalate, keep the commit."""
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _PackageScopeRunner(
+        changed_paths=[changed_path],
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: changed something elsewhere",
+            "AWF-VERDICT: FIXED: still elsewhere",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, True],
+        path_touched=False,
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        verdict = await _address(runner, _thread("thread_cross_package", _REVIEWED_ADAPTER))
+
+    assert verdict == "needs_human"
+    assert runner.reset_targets == []
+    assert len(runner.prompts) == 2
+    escalations = [
+        entry
+        for entry in captured
+        if entry.get("event") == "monitor.agent_verdict_correction_fixed_outside_item_scope"
+    ]
+    assert len(escalations) == 1
+    assert escalations[0]["reason_code"] == AGENT_FIXED_WITHOUT_EVIDENCE
+
+
+@pytest.mark.unit
+async def test_attempt_zero_with_only_a_sibling_change_is_still_corrected(
+    tmp_path: Path,
+) -> None:
+    """Attempt 0 stays strict, so a same-package FIXED still earns its correction round."""
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _PackageScopeRunner(
+        changed_paths=[_SIBLING_MERGE_LOOP],
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: fixed it in the caller",
+            "AWF-VERDICT: NEEDS_HUMAN: the ownership contract needs an operator call",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=False,
+    )
+
+    verdict = await _address(runner, _thread("thread_attempt_zero_strict", _REVIEWED_LIFECYCLE))
+
+    assert verdict == "needs_human"
+    assert len(runner.prompts) == 2
+    assert "no new item-scoped Git change" in runner.prompts[1]
+
+
+@pytest.mark.unit
+async def test_self_citing_false_positive_with_same_package_evidence_returns_fixed(
+    tmp_path: Path,
+) -> None:
+    """The #925 D2 self-citation guard reads the same widened evidence (#952)."""
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _PackageScopeRunner(
+        changed_paths=[_SIBLING_MERGE_LOOP],
+        worktrees_root=tmp_path,
+        outputs=[
+            _NO_VERDICT_LINE,
+            f"AWF-VERDICT: FALSE POSITIVE: already addressed by commit {_ATTEMPT0_HEAD}",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=False,
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        verdict = await _address(runner, _thread("thread_self_cite_sibling", _REVIEWED_LIFECYCLE))
+
+    assert verdict == "fix_committed"
+    assert runner.reset_targets == []
+    self_citation = [
+        entry
+        for entry in captured
+        if entry.get("event") == "monitor.agent_verdict_correction_cites_own_commit"
+    ]
+    assert len(self_citation) == 1
+    assert self_citation[0]["reason_code"] == AGENT_NON_FIX_CITES_OWN_COMMIT
+    assert self_citation[0]["has_path_evidence"] is True
+
+
+@pytest.mark.unit
+async def test_self_citing_needs_human_with_same_package_evidence_stays_needs_human(
+    tmp_path: Path,
+) -> None:
+    """Widened evidence must not convert a requested human gate (issue:5558086911)."""
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _PackageScopeRunner(
+        changed_paths=[_SIBLING_MERGE_LOOP],
+        worktrees_root=tmp_path,
+        outputs=[
+            _NO_VERDICT_LINE,
+            f"AWF-VERDICT: NEEDS_HUMAN: addressed by {_ATTEMPT0_HEAD[:12]}, policy call needed",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=False,
+    )
+
+    verdict = await _address(runner, _thread("thread_self_cite_human", _REVIEWED_LIFECYCLE))
+
+    assert verdict == "needs_human"
+    assert runner.reset_targets == []
+
+
+@pytest.mark.unit
+async def test_unmappable_anchor_stays_fail_closed_with_same_package_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``item_line <= 0`` sentinel outranks the widening (PRRT_kwDOSJAM6s6dFLGV)."""
+    (tmp_path / "ws_protocol").mkdir()
+
+    async def _no_line(*_args: object, **_kwargs: object) -> int | None:
+        return None
+
+    async def _same_path(*_args: object, **kwargs: object) -> str | None:
+        return str(kwargs["path"])
+
+    monkeypatch.setattr(ancestry, "_map_review_line_through_commits", _no_line)
+    monkeypatch.setattr(ancestry, "_map_review_path_through_commits", _same_path)
+
+    runner = _PackageScopeRunner(
+        changed_paths=[_SIBLING_MERGE_LOOP],
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: fixed it in the caller",
+            "AWF-VERDICT: FIXED: still the caller",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=False,
+    )
+
+    result = await comment_verdict._invoke_cli_for_verdict_result(
+        runner,  # type: ignore[arg-type]
+        workspace_id="ws_protocol",
+        prompt="ORIGINAL REVIEW PROMPT",
+        commit_message="fix: review item",
+        compose_project="awf_ws_protocol",
+        compose_file=Path("compose.yml"),
+        operation_start_head=_ITEM_START_HEAD,
+        evidence_item_path=_REVIEWED_LIFECYCLE,
+        evidence_item_line=640,
+        evidence_anchor_head=_HOSTED_HEAD,
+    )
+
+    assert result.verdict == "needs_human"
+    assert runner.reset_targets == []
+    assert len(runner.prompts) == 2
+
+
+class _ScopeProbeRunner(SimpleNamespace):
+    """Minimal runner exposing only the Git seams the widened probe needs."""
+
+    def __init__(
+        self,
+        *,
+        head: str | None,
+        non_descendants: frozenset[str] = frozenset(),
+        identical_trees: frozenset[str] = frozenset(),
+        in_scope_heads: frozenset[str] = frozenset(),
+    ) -> None:
+        super().__init__()
+        self.head = head
+        self.non_descendants = non_descendants
+        self.identical_trees = identical_trees
+        self.in_scope_heads = in_scope_heads
+        self.scope_calls: list[str] = []
+
+    async def _rev_parse_head(self, _worktree_path: Path) -> str | None:
+        return self.head
+
+    async def _head_descends_from(
+        self,
+        *,
+        worktree_path: Path,
+        ancestor: str,
+        descendant: str,
+    ) -> bool:
+        del worktree_path, ancestor
+        return descendant not in self.non_descendants
+
+    async def _commit_trees_differ(
+        self,
+        *,
+        worktree_path: Path,
+        left: str,
+        right: str,
+    ) -> bool:
+        del worktree_path, left
+        return right not in self.identical_trees
+
+    async def _commit_range_in_item_scope(
+        self,
+        *,
+        worktree_path: Path,
+        left: str,
+        right: str,
+        item_path: str,
+    ) -> bool:
+        del worktree_path, left, item_path
+        self.scope_calls.append(right)
+        return right in self.in_scope_heads
+
+
+async def _package_evidence(
+    runner: object,
+    *,
+    worktree_path: Path,
+    item_start_head: str | None = _ITEM_START_HEAD,
+    item_path: str | None = _REVIEWED_LIFECYCLE,
+    state: MonitorState | None = None,
+    dirty_changes_committed: bool = True,
+) -> bool:
+    return await package_level_item_fix_evidence(
+        runner,  # type: ignore[arg-type]
+        worktree_path=worktree_path,
+        item_start_head=item_start_head,
+        item_path=item_path,
+        state=state,
+        dirty_changes_committed=dirty_changes_committed,
+    )
+
+
+@pytest.mark.unit
+async def test_package_evidence_requires_an_item_start_head_and_a_path(tmp_path: Path) -> None:
+    """Without the item's own baseline or a reviewed path there is nothing to widen."""
+    worktree = tmp_path / "ws_protocol"
+    worktree.mkdir()
+    runner = _ScopeProbeRunner(head=_ATTEMPT0_HEAD, in_scope_heads=frozenset({_ATTEMPT0_HEAD}))
+
+    assert not await _package_evidence(runner, worktree_path=worktree, item_start_head=None)
+    assert not await _package_evidence(runner, worktree_path=worktree, item_path=None)
+    assert runner.scope_calls == []
+
+
+@pytest.mark.unit
+async def test_package_evidence_requires_an_existing_worktree(tmp_path: Path) -> None:
+    """A missing worktree cannot be probed; the widening never invents evidence."""
+    runner = _ScopeProbeRunner(head=_ATTEMPT0_HEAD, in_scope_heads=frozenset({_ATTEMPT0_HEAD}))
+
+    assert not await _package_evidence(runner, worktree_path=tmp_path / "gone")
+    assert runner.scope_calls == []
+
+
+@pytest.mark.unit
+async def test_package_evidence_false_for_a_runner_without_the_git_seams(tmp_path: Path) -> None:
+    """Lightweight runners get ``False``, not the dirty-sink fallback of the earlier gates."""
+    worktree = tmp_path / "ws_protocol"
+    worktree.mkdir()
+
+    async def _head(_worktree_path: Path) -> str | None:
+        return _ATTEMPT0_HEAD
+
+    async def _true(**_kwargs: object) -> bool:
+        return True
+
+    bare = SimpleNamespace(_rev_parse_head=_head)
+    no_scope = SimpleNamespace(
+        _rev_parse_head=_head,
+        _head_descends_from=_true,
+        _commit_trees_differ=_true,
+    )
+
+    assert not await _package_evidence(bare, worktree_path=worktree)
+    assert not await _package_evidence(no_scope, worktree_path=worktree)
+
+
+@pytest.mark.unit
+async def test_package_evidence_skips_candidates_that_are_not_forward_changes(
+    tmp_path: Path,
+) -> None:
+    """The item's own start, a non-descendant, and an identical tree are all skipped."""
+    worktree = tmp_path / "ws_protocol"
+    worktree.mkdir()
+
+    unmoved = _ScopeProbeRunner(head=_ITEM_START_HEAD, in_scope_heads=frozenset({_ITEM_START_HEAD}))
+    assert not await _package_evidence(unmoved, worktree_path=worktree)
+    assert unmoved.scope_calls == []
+
+    unreadable = _ScopeProbeRunner(head=None)
+    assert not await _package_evidence(unreadable, worktree_path=worktree)
+    assert unreadable.scope_calls == []
+
+    forked = _ScopeProbeRunner(
+        head=_ATTEMPT0_HEAD,
+        non_descendants=frozenset({_ATTEMPT0_HEAD}),
+        in_scope_heads=frozenset({_ATTEMPT0_HEAD}),
+    )
+    assert not await _package_evidence(forked, worktree_path=worktree)
+    assert forked.scope_calls == []
+
+    empty = _ScopeProbeRunner(
+        head=_ATTEMPT0_HEAD,
+        identical_trees=frozenset({_ATTEMPT0_HEAD}),
+        in_scope_heads=frozenset({_ATTEMPT0_HEAD}),
+    )
+    assert not await _package_evidence(empty, worktree_path=worktree)
+    assert empty.scope_calls == []
+
+    out_of_scope = _ScopeProbeRunner(head=_ATTEMPT0_HEAD)
+    assert not await _package_evidence(out_of_scope, worktree_path=worktree)
+    assert out_of_scope.scope_calls == [_ATTEMPT0_HEAD]
+
+
+@pytest.mark.unit
+async def test_package_evidence_accepts_the_hosted_candidate_head(tmp_path: Path) -> None:
+    """A hosted adapter's pushed head is a candidate too, exactly as in the strict gate."""
+    worktree = tmp_path / "ws_protocol"
+    worktree.mkdir()
+    runner = _ScopeProbeRunner(head=_ITEM_START_HEAD, in_scope_heads=frozenset({_HOSTED_HEAD}))
+    state = MonitorState()
+    state.hosted_terminal_head_advanced = True
+    state.last_push_sha = _HOSTED_HEAD
+
+    assert await _package_evidence(runner, worktree_path=worktree, state=state)
+    assert runner.scope_calls == [_HOSTED_HEAD]
+
+    # An advanced-but-unrecorded push adds no candidate, and a hosted head equal
+    # to the worktree HEAD is not probed twice.
+    blank = _ScopeProbeRunner(head=_ITEM_START_HEAD, in_scope_heads=frozenset({_HOSTED_HEAD}))
+    blank_state = MonitorState()
+    blank_state.hosted_terminal_head_advanced = True
+    blank_state.last_push_sha = None
+    assert not await _package_evidence(blank, worktree_path=worktree, state=blank_state)
+    assert blank.scope_calls == []
+
+    duplicate = _ScopeProbeRunner(head=_HOSTED_HEAD, in_scope_heads=frozenset({_HOSTED_HEAD}))
+    duplicate_state = MonitorState()
+    duplicate_state.hosted_terminal_head_advanced = True
+    duplicate_state.last_push_sha = _HOSTED_HEAD
+    assert await _package_evidence(duplicate, worktree_path=worktree, state=duplicate_state)
+    assert duplicate.scope_calls == [_HOSTED_HEAD]


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_7f6c3d9bf2274c86b4e8de73` (agent: `claude_code`, model: `claude-opus-5`, effort: `high`).


### Task
Fix GitHub issue #952 (read it first: gh issue view 952). Narrow scope: src/awf/runtime/pr_monitor_runner/comment_verdict_correction.py (and comment_verdict.py only where the correction-attempt evidence and the self-citation guard are wired). On the correction attempt only, after the line-anchored and path-level evidence checks fail, accept the item's own commit range (item_start_head..HEAD, contentful, descendant) as FIXED evidence when it changes any file in the reviewed file's package, using the existing bundle-scope helper _commit_range_in_item_scope / _changed_path_in_item_scope (same parent directory or descendant paths). Cross-package changes keep the current needs_human outcome with the commit preserved; attempt 0 stays strict; the self-citation guard uses the same widened evidence. Document the rationale from the issue in the docstrings. Strict TDD: failing tests first. Put ALL new tests in a NEW file under tests/unit/runtime/test_pr_monitor_verdict_retry_parts/ (ls the directory first, pick the next part number, never overwrite or append to an existing part); update test_pr_monitor_verdict_retry_part_005.py's same-directory-sibling test to the new disposition. Coverage gate 99 percent line+branch; files under 1500 lines; catch specific exceptions; preserve reason codes. Run ruff check, ruff format --check, mypy and 'pytest tests -q -n 20' before pushing. Keep each agent run short: focused tests, commit, always end with the AWF-VERDICT line; for review items put the fix hunk in the reviewed file at the reviewed line and never cite your own commit in a FALSE POSITIVE or DEFER; if a reviewer asks to remove the same-package acceptance, answer DEFER citing the operator decision in issue #952. Reference 'Closes #952' in the PR body.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automated PR review verdict acceptance for merge-gating automation, but only on the second protocol attempt with the same item-owned commit range and existing scope helpers.
> 
> **Overview**
> On the **correction attempt only**, after line-anchored and path-level FIXED checks both fail, the PR monitor now treats the item’s own `item_start_head`..HEAD commit range as evidence when it **changes any file in the reviewed file’s package** (existing bundle-scope: same parent directory or descendant paths). Attempt 0 stays strict; cross-package fixes still escalate to `needs_human` with the commit preserved; unmappable anchors remain fail-closed.
> 
> Adds `package_level_item_fix_evidence` in `comment_verdict_correction.py`, wires it into `comment_verdict.py` after path-level evidence, and extends the self-citation / unscoped-fix dispositions so package-level acceptance counts as item-scoped evidence. Test fixtures default `in_item_scope` to false for clearer “wrong package” scenarios; part 005’s sibling-file case now expects `fix_committed` on correction; part 026 adds regression coverage for callee-anchored fixes, extracted modules, cross-package escalation, and probe edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4925f7d97ce32510c69933c6fb2a14eb7a021242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->