### PR TITLE
fix(deps): bump browserslist to >=4.28.7 (GHSA-73wf-gq98-2v4g)

### DIFF
--- a/apps/console/package-lock.json
+++ b/apps/console/package-lock.json
@@ -2611,9 +2611,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.10.44",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz",
+      "integrity": "sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2649,9 +2649,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2669,10 +2669,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2743,9 +2743,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3001,9 +3001,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.376",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
-      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
     },
@@ -5306,9 +5306,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_3a6951badf554676bf764cc1` (agent: `codex`, model: `gpt-5.6-sol`, effort: `xhigh`).


### Task
Resolve Dependabot alert #65 on dimileeh/agent-workspace-fabric: browserslist <=4.28.6 is vulnerable to GHSA-73wf-gq98-2v4g (high, CVSS 7.5) - uncaught crash / prototype write via untrusted browserslist-stats.json custom stats in normalizeStats. First patched version is 4.28.7 (published on npm).

Context I already verified, do not redo it:
- browserslist is a TRANSITIVE dev-scope dependency of apps/console. It is NOT in apps/console/package.json dependencies or devDependencies.
- Its parents in apps/console/package-lock.json are @babel/helper-compilation-targets (dependencies: browserslist ^4.24.0) and update-browserslist-db (peerDependencies: >= 4.21.0). Both ranges already accept 4.28.7, so NO parent package needs bumping.
- Both origin/main and origin/development currently pin browserslist 4.28.2.
- No browserslist-stats.json exists in the repo, so the vulnerable code path is not reachable from our build. This is a hygiene/defence-in-depth bump, not an active exploit.

Task: update apps/console/package-lock.json so every browserslist entry resolves to >= 4.28.7. This should be a LOCKFILE-ONLY change. Prefer the minimal, targeted command, e.g.:
  npm --prefix apps/console install browserslist@^4.28.7 --package-lock-only
or an equivalent that leaves package.json untouched.

Hard requirements:
- Do NOT add browserslist to apps/console/package.json. It must stay transitive.
- Do NOT bump any other package. Verify the final diff touches ONLY apps/console/package-lock.json, and that the only version changes in it are browserslist (and, if npm insists, its own direct sub-deps such as caniuse-lite/node-releases - if anything else moves, state exactly what and why in the PR description).
- Confirm the console still builds and lints: npm --prefix apps/console ci, then npm --prefix apps/console run lint, run typecheck, run build.
- Base branch is development. Do not target main.
- Follow AGENTS.md. This is a dependency bump with no behaviour change, so no new unit tests are expected; if you believe a test is warranted, explain why in the PR description rather than inventing one.
- Report in the PR description: the before/after browserslist versions, the exact command used, and confirmation that package.json is unchanged.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only lockfile bump with no runtime or auth/data-path changes; vulnerability was not reachable from this repo’s build.
> 
> **Overview**
> **Lockfile-only** update in `apps/console/package-lock.json` so transitive dev dependency **`browserslist`** resolves from **4.28.2** to **4.28.7**, addressing **GHSA-73wf-gq98-2v4g** (crash / prototype pollution via untrusted `browserslist-stats.json` in `normalizeStats`). **`package.json` is unchanged**—`browserslist` is not added as a direct dependency.
> 
> npm also refreshed **`browserslist`**’s pinned sub-dependencies in the lockfile: **`baseline-browser-mapping`**, **`caniuse-lite`**, **`electron-to-chromium`**, and **`node-releases`**. No application source or build config changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be5944c29de6765bd5dfd93ab3237bd634ddbf90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->