### PR TITLE
chore(runtime): bump pinned agent CLIs (codex, claude, opencode, grok, cursor, ccusage) + ollama-bridge socat

### DIFF
--- a/docker/agent-runtime.Dockerfile
+++ b/docker/agent-runtime.Dockerfile
@@ -145,16 +145,16 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
 #
 # npm-backed CLIs are pinned to a version. Bump via PR so we can verify the
 # output format hasn't drifted in the adapters.
-ARG CODEX_VERSION=0.147.0
+ARG CODEX_VERSION=0.153.4
 # 2.1.226+ is required for Claude Opus 5 (the default model in defaults.py);
 # older CLIs reject `--model claude-opus-5`. Keep this >= the default model's
 # minimum supported CLI.
-ARG CLAUDE_CODE_VERSION=2.1.226
-ARG OPENCODE_VERSION=1.17.18
-ARG GROK_VERSION=0.2.94
-ARG CURSOR_VERSION=2026.07.20-8cc9c0b
-ARG CURSOR_X64_SHA256=6e9f17247ffeb5f8f7e2246b4bcd6bb26cb2d5a9f9a4b0012c9a80d868ed25b4
-ARG CURSOR_ARM64_SHA256=2986152b283c70a666b015035b2e99a96d13afd2660a587b8639417cfdd147fb
+ARG CLAUDE_CODE_VERSION=2.1.263
+ARG OPENCODE_VERSION=1.18.29
+ARG GROK_VERSION=1.0.13
+ARG CURSOR_VERSION=2026.09.02-c22c1a3
+ARG CURSOR_X64_SHA256=b73b59854762535c0fc20d7ccc51c3b5a356a851491088d60a362be48750f53c
+ARG CURSOR_ARM64_SHA256=fb7bc635be6172ebcf68f907fd9217e3614da51916455c6d7fdb66690997884c
 # Antigravity CLI (agy). Pinned by GitHub release asset + sha256 per arch.
 # Operator must verify the arm64 sha before merge; CI validates linux/amd64 only.
 ARG ANTIGRAVITY_VERSION=1.1.13
@@ -162,7 +162,7 @@ ARG ANTIGRAVITY_AMD64_SHA256=edc7c32b5ab4fc2e4da03381fee83ed566dea6b56b56f9329cd
 ARG ANTIGRAVITY_ARM64_SHA256=a9fdd2a386770c27dbf784436bd4de70d4d4901c832d5ec6abf27758d5c370f8
 # Usage collector. Pinned (not fetched via runtime npx/bunx) so AWF's
 # per-workspace usage sampler reads local provider usage files offline.
-ARG CCUSAGE_VERSION=20.0.3
+ARG CCUSAGE_VERSION=20.0.20
 
 # Install a pinned Cursor CLI release only after verifying its architecture-
 # specific checksum. The official convenience installer is mutable.

--- a/docker/compose/local-service.yml
+++ b/docker/compose/local-service.yml
@@ -315,7 +315,7 @@ services:
   ollama-bridge:
     profiles:
       - ollama-bridge
-    image: alpine/socat:1.8.0.3
+    image: alpine/socat:1.8.1.3
     network_mode: host
     command:
       - "TCP-LISTEN:${AWF_OLLAMA_BRIDGE_LISTEN_PORT:-11434},bind=${AWF_OLLAMA_BRIDGE_BIND_ADDRESS:-172.17.0.1},fork,reuseaddr"

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -527,7 +527,7 @@ class _CcusageSampleContext(UsageSampleContext):
         await asyncio.shield(self._pending_write)
 
     async def _run_ccusage(self) -> tuple[NormalizedUsage | None, str | None, str | None]:
-        # Expected ccusage CLI contract (pinned at 20.0.3 in
+        # Expected ccusage CLI contract (pinned at 20.0.20 in
         # docker/agent-runtime.Dockerfile): ``ccusage <source> daily --json --offline
         # --config <neutral>``, where ``<source>`` is a positional provider
         # sub-command ("claude" / "codex" / "gemini" / "opencode"; see
@@ -540,7 +540,7 @@ class _CcusageSampleContext(UsageSampleContext):
         # this invocation degrade to REASON_COMMAND_FAILED, so re-verify the argument
         # order and flags whenever the Dockerfile pin is bumped. ``--offline`` is
         # ccusage's global ``-O`` option and is accepted by every source subcommand,
-        # including ``opencode``, at the pinned 20.0.3 (verified: ``ccusage opencode
+        # including ``opencode``, at the pinned 20.0.20 (verified: ``ccusage opencode
         # daily --help`` lists ``-O, --offline`` and the full invocation exits 0), so
         # it does not degrade opencode runs even though the docs page omits it.
         invocation = build_tracked_compose_exec(

--- a/tests/integration/test_local_service_compose.py
+++ b/tests/integration/test_local_service_compose.py
@@ -464,7 +464,7 @@ def test_local_service_compose_declares_control_plane_stack() -> None:
 
     bridge = services["ollama-bridge"]
     assert bridge["profiles"] == ["ollama-bridge"]
-    assert bridge["image"] == "alpine/socat:1.8.0.3"
+    assert bridge["image"] == "alpine/socat:1.8.1.3"
     assert bridge["network_mode"] == "host"
     assert bridge["command"] == [
         "TCP-LISTEN:${AWF_OLLAMA_BRIDGE_LISTEN_PORT:-11434},bind=${AWF_OLLAMA_BRIDGE_BIND_ADDRESS:-172.17.0.1},fork,reuseaddr",

--- a/tests/unit/test_agent_runtime_dockerfile.py
+++ b/tests/unit/test_agent_runtime_dockerfile.py
@@ -87,13 +87,13 @@ def test_agent_runtime_installs_pinned_docker_buildx_plugin() -> None:
 def test_agent_runtime_verifies_pinned_cursor_release_before_extracting() -> None:
     dockerfile = _agent_runtime_dockerfile()
 
-    assert "ARG CURSOR_VERSION=2026.07.20-8cc9c0b" in dockerfile
+    assert "ARG CURSOR_VERSION=2026.09.02-c22c1a3" in dockerfile
     assert (
-        "ARG CURSOR_X64_SHA256=6e9f17247ffeb5f8f7e2246b4bcd6bb26cb2d5a9f9a4b0012c9a80d868ed25b4"
+        "ARG CURSOR_X64_SHA256=b73b59854762535c0fc20d7ccc51c3b5a356a851491088d60a362be48750f53c"
         in dockerfile
     )
     assert (
-        "ARG CURSOR_ARM64_SHA256=2986152b283c70a666b015035b2e99a96d13afd2660a587b8639417cfdd147fb"
+        "ARG CURSOR_ARM64_SHA256=fb7bc635be6172ebcf68f907fd9217e3614da51916455c6d7fdb66690997884c"
         in dockerfile
     )
     assert "https://cursor.com/install" not in dockerfile
@@ -124,11 +124,11 @@ def test_agent_runtime_installs_all_supported_coding_clis() -> None:
     """Verify agent runtime installs all supported coding clis."""
     dockerfile = _agent_runtime_dockerfile()
 
-    assert "ARG CODEX_VERSION=0.147.0" in dockerfile
-    assert "ARG CLAUDE_CODE_VERSION=2.1.226" in dockerfile
-    assert "ARG OPENCODE_VERSION=1.17.18" in dockerfile
-    assert "ARG CURSOR_VERSION=2026.07.20-8cc9c0b" in dockerfile
-    assert "ARG GROK_VERSION=0.2.94" in dockerfile
+    assert "ARG CODEX_VERSION=0.153.4" in dockerfile
+    assert "ARG CLAUDE_CODE_VERSION=2.1.263" in dockerfile
+    assert "ARG OPENCODE_VERSION=1.18.29" in dockerfile
+    assert "ARG CURSOR_VERSION=2026.09.02-c22c1a3" in dockerfile
+    assert "ARG GROK_VERSION=1.0.13" in dockerfile
     assert "ARG ANTIGRAVITY_VERSION=1.1.13" in dockerfile
     assert (
         "ARG ANTIGRAVITY_AMD64_SHA256=edc7c32b5ab4fc2e4da03381fee83ed566dea6b56b56f9329cd13cd77947a1d9"
@@ -165,7 +165,7 @@ def test_agent_runtime_installs_all_supported_coding_clis() -> None:
     assert "cursor-agent --version || true" in dockerfile
     assert dockerfile.index(
         'ln -sf "$(readlink -f "$(command -v node)")" /usr/local/bin/node'
-    ) < dockerfile.index("ARG CURSOR_VERSION=2026.07.20-8cc9c0b")
+    ) < dockerfile.index("ARG CURSOR_VERSION=2026.09.02-c22c1a3")
     assert "npm install -g cursor-agent" not in dockerfile
     assert "@xai-official/grok@${GROK_VERSION}" in dockerfile
     assert "https://x.ai/cli/install.sh" not in dockerfile


### PR DESCRIPTION
## Summary
Bumps the agent CLI pins in `docker/agent-runtime.Dockerfile` (and the matching asserts in `tests/unit/test_agent_runtime_dockerfile.py`) to the latest published releases:

| CLI | from | to |
|---|---|---|
| `@openai/codex` | 0.147.0 | 0.153.4 |
| `@anthropic-ai/claude-code` | 2.1.226 | 2.1.263 |
| `opencode-ai` | 1.17.18 | 1.18.29 |
| `@xai-official/grok` | 0.2.94 | 1.0.13 |
| Cursor agent CLI | 2026.07.20-8cc9c0b | 2026.09.02-c22c1a3 (new x64 + arm64 sha256 pins) |
| `ccusage` | 20.0.3 | 20.0.20 |
| Antigravity `agy` | 1.1.13 | **unchanged** (see below) |

Also refreshes the ccusage contract comment in `usage_collection.py` (20.0.3 → 20.0.20).

## Why agy is held at 1.1.13
agy 1.1.27 changed its API-key-mode contract: none of the three slugs in `ANTIGRAVITY_API_KEY_MODE_MODELS` are recognized any more (it now offers Gemini 3.8/3.7/3.6 Flash and Gemini 3.1 Pro) and `--effort` is mandatory, which the adapter deliberately never emits. Bumping the pin without an adapter change would fail every Antigravity run at model selection. That migration is tracked in a separate issue so it gets a TDD adapter change.

## Verification
- `docker build -f docker/agent-runtime.Dockerfile` succeeds on the new pins (arm64 host); all sha256 pins match the downloaded assets. In-image: `codex-cli 0.153.4`, `2.1.263 (Claude Code)`, `opencode 1.18.29`, `grok 1.0.13`, `agy 1.1.13`, `ccusage 20.0.20`, `cursor-agent 2026.09.02-c22c1a3`.
- Grok 1.0.13 still accepts every flag the adapter passes (`--always-approve`, `--no-auto-update`, `-m <model>`) and the `agent stdio` ACP subcommand.
- ccusage 20.0.20: `claude|codex|opencode|gemini daily --help` all still list `--json`, `-O, --offline`, `--config` (a new `grok` source exists; wiring it up is a follow-up).
- `pytest tests/unit/test_agent_runtime_dockerfile.py tests/unit/adapters/test_antigravity_docker_smoke.py` green; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015v4aeG8uqCvsJD5rKdV3T9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every workspace agent container via rebuilt runtime images and multiple coding CLIs; adapter contracts were manually verified but CLI output/format drift could still break runs until images are rebuilt and rolled out.
> 
> **Overview**
> Updates **pinned tooling versions** in the agent-runtime image and local compose stack, with matching test and documentation comments—no adapter or runtime logic changes beyond reflecting the new `ccusage` pin.
> 
> **Agent runtime (`docker/agent-runtime.Dockerfile`):** bumps Codex (0.153.4), Claude Code (2.1.263), OpenCode (1.18.29), Grok (1.0.13), Cursor agent CLI (2026.09.02-c22c1a3 with new x64/arm64 SHA256), and `ccusage` (20.0.20). Unit tests in `test_agent_runtime_dockerfile.py` assert the new pins.
> 
> **Usage collection:** comments in `usage_collection.py` now document the `ccusage` 20.0.20 CLI contract (same invocation flags as before).
> 
> **Local service:** `ollama-bridge` image moves from `alpine/socat:1.8.0.3` to `1.8.1.3`; integration compose test updated accordingly.
> 
> Antigravity (`agy`) is **not** bumped in this PR (separate adapter work needed for newer API-key/model contract).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bd3844f92e8473f0bbc93356815d0afe1f94ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->