### PR TITLE
fix(deps): bump baseline-browser-mapping to >=2.11.0 (GHSA-w5vr-8v7q-w6rv)

### DIFF
--- a/apps/console/package-lock.json
+++ b/apps/console/package-lock.json
@@ -2611,9 +2611,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.44",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz",
-      "integrity": "sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==",
+      "version": "2.11.22",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.22.tgz",
+      "integrity": "sha512-pWc4w51fBFd7mav43/zKRC+RI6f4yfzQoVlfvE8dECePyfkn1bzLp01Fj0QACcyCZyFhiEMyD2qScfKRWgWibA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_d0e16dd255fd4300a89ef628` (agent: `codex`, model: `gpt-5.6-sol`, effort: `xhigh`).


### Task
Fix Dependabot alert #66 (medium, GHSA-w5vr-8v7q-w6rv): "baseline-browser-mapping process termination on invalid input causes denial of service". Vulnerable range >=2.0.0 <2.11.0; first patched version 2.11.0.

CONTEXT — why this is a workspace and not a Dependabot merge. Dependabot PR #959 exists for this bump but CANNOT land: it is a `npm_and_yarn` SECURITY PR, so Dependabot files it against the DEFAULT branch (`main`) and resets `baseRefName` back to `main` on every rebase/recreate, undoing any retarget. It was retargeted to `development` twice and reverted to `main` both times, and it conflicts with `development` because `development` is already ahead (browserslist 4.28.7 vs 4.28.2 on main). So the fix must be made directly on `development`. Do NOT try to reuse, cherry-pick from, or reference PR #959's branch.

CURRENT STATE on `development` (verified in apps/console/package-lock.json):
  baseline-browser-mapping = 2.10.44   <-- VULNERABLE, needs >= 2.11.0
  browserslist             = 4.28.7    <-- already fine

TASK — lockfile-only change:
`baseline-browser-mapping` is a TRANSITIVE dependency. It is pulled in by `browserslist` (browserslist declares `baseline-browser-mapping: ^2.10.12`). It is NOT declared in apps/console/package.json and MUST NOT be added there.

Do this:
1. `npm --prefix apps/console update baseline-browser-mapping`
   (if that alone does not reach >= 2.11.0, `npm --prefix apps/console update browserslist` as well, since a newer browserslist widens the range — browserslist 4.28.9 requires baseline-browser-mapping ^2.11.20.)
2. Confirm every `node_modules/baseline-browser-mapping` entry in apps/console/package-lock.json is at >= 2.11.0.

HARD CONSTRAINTS:
- The diff MUST be confined to `apps/console/package-lock.json`. Do NOT modify apps/console/package.json. Do NOT promote baseline-browser-mapping into dependencies or devDependencies — it is transitive and must stay transitive.
- Do NOT add overrides/resolutions entries. Let the resolver produce the version naturally.
- Keep the change minimal: only the browserslist/baseline-browser-mapping transitive cluster should move. Do not run a broad `npm update` that churns unrelated packages.
- Do not touch any other lockfile, workflow, or source file.

VERIFY before opening the PR:
- `npm --prefix apps/console ci` succeeds (proves the lockfile is internally consistent).
- `npm --prefix apps/console run build` succeeds.
- `npm --prefix apps/console run lint` and `npm --prefix apps/console run typecheck` succeed.
- Print the resulting baseline-browser-mapping version(s) in the PR description and state explicitly that package.json is unchanged (`git diff --name-only` should list only apps/console/package-lock.json).

Target branch is `development`. This is a dependency-only change, so no new tests are required; state that reasoning in the PR description rather than inventing tests for a lockfile bump.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only transitive dependency security patch with no runtime code or direct dependency manifest changes.
> 
> **Overview**
> Addresses Dependabot alert **GHSA-w5vr-8v7q-w6rv** by updating the transitive **`baseline-browser-mapping`** lockfile entry in `apps/console/package-lock.json` from **2.10.44** to **2.11.22** (patched at ≥2.11.0). No changes to `package.json`; the package remains a transitive dependency pulled in via **`browserslist`**.
> 
> This is a lockfile-only resolver bump to close the “process termination on invalid input” denial-of-service issue, with no application source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ecafe30ef50806f97d3702f49fbadf6fa853112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->