### PR TITLE
fix(console): show confirmed fleet counts under partial coverage

### DIFF
--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -797,6 +797,14 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     ) {
       return null;
     }
+    if (
+      stage.started_at == null &&
+      (stage.ended_at != null ||
+        stage.duration_seconds != null ||
+        (stage.status !== "pending" && stage.status !== "terminal_skipped"))
+    ) {
+      return null;
+    }
     if (stage.started_at != null && startedMs != null) {
       entered.push({ stage, startedAt: stage.started_at, startedMs, endedMs });
     }

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -68,6 +68,7 @@ import {
 formatRecoveryBadge
 } from "@/lib/recovery-format";
 import type {
+ConsoleDashboardCountEvidence,
 WorkspaceOverview
 } from "@/lib/types";
 import {
@@ -258,12 +259,14 @@ export function FleetHealthStrip({
   lastSuccessAt,
   coverageStatus,
   coverageNotes,
+  countEvidence,
 }: {
   kpis: FleetKpi[];
   error?: string | null;
   lastSuccessAt?: string | null;
   coverageStatus?: "complete" | "partial" | "unknown" | null;
   coverageNotes?: readonly string[] | null;
+  countEvidence?: ConsoleDashboardCountEvidence | null;
 }) {
   const anyStale = kpis.some((kpi) => kpi.stale);
   // HTTP 200 can still be incomplete. Do not treat partial/unknown as a request
@@ -271,6 +274,7 @@ export function FleetHealthStrip({
   // look fully current either.
   const coverageNotice = formatDashboardCoverageNotice(
     coverageStatus ? { status: coverageStatus, notes: coverageNotes ?? [] } : null,
+    countEvidence,
   );
   return (
     <div className="border-b border-line bg-canvas px-4 py-3" aria-label="Fleet health">

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -838,18 +838,18 @@ const WorkspaceCard = memo(function WorkspaceCard({
                     </span>
                     <div
                       className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-slate-500"
-                      data-testid={`workspace-card-timing-${item.workspace_id}`}
+                      data-testid={`workspace-timing-${item.workspace_id}`}
                     >
                       <span>Created {formatDateTime(item.created_at)}</span>
                       {terminal ? (
                         <>
-                          <span data-testid={`workspace-card-finished-${item.workspace_id}`}>
+                          <span data-testid={`workspace-finished-${item.workspace_id}`}>
                             Finished{" "}
                             {terminalTiming?.finishedAt
                               ? formatDateTime(terminalTiming.finishedAt)
                               : "not recorded"}
                           </span>
-                          <span data-testid={`workspace-card-duration-${item.workspace_id}`}>
+                          <span data-testid={`workspace-duration-${item.workspace_id}`}>
                             Duration{" "}
                             {recordedDurationLabel(terminalTiming?.durationSeconds) ?? "not recorded"}
                           </span>

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -39,7 +39,11 @@ useRef,
 useState
 } from "react";
 
-import { formatAgentLabel,formatAgentTitle } from "@/lib/agent-format";
+import {
+formatAgentLabel,
+formatAgentTitle,
+resolveWorkflowFinishedAt
+} from "@/lib/agent-format";
 import {
   displayedTaskKey,
   MAX_FULLSCREEN_LOG_WORKSPACES,
@@ -59,6 +63,7 @@ compactDuration,
 compactId,
 formatDateTime,
 lifecycleStages,
+recordedDurationLabel,
 relativeTime,
 toneClass,
 type StatusTone
@@ -741,6 +746,154 @@ type WorkspaceCardProps = {
   onCopy: (event: SyntheticEvent<HTMLElement>, workspaceId: string) => void;
 };
 
+const TERMINAL_WORKSPACE_CARD_STATUSES = new Set<WorkspaceOverview["status"]>([
+  "completed",
+  "failed",
+  "cancelled",
+  "destroyed",
+]);
+
+type WorkflowCardTiming = {
+  finishedAt: string | null;
+  durationLabel: string | null;
+};
+
+type TimedLifecycleStage = {
+  stage: WorkspaceOverview["lifecycle"][number];
+  startedAt: string;
+  startedMs: number;
+  endedMs: number | null;
+};
+
+function recordedMilliseconds(value: string | null | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const milliseconds = Date.parse(value);
+  return Number.isFinite(milliseconds) ? milliseconds : null;
+}
+
+function recordedDurationSeconds(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function lifecycleWorkflowTiming(item: WorkspaceOverview): {
+  finishedAt: string;
+  finishedMs: number;
+  durationSeconds: number | null;
+} | null {
+  // Lifecycle summaries collapse repeated visits to a stage. Once a retry or
+  // reverse transition exists, they cannot identify the current workflow end.
+  if (item.recovery != null) {
+    return null;
+  }
+  const entered: TimedLifecycleStage[] = [];
+  for (const stage of item.lifecycle) {
+    const startedMs = recordedMilliseconds(stage.started_at);
+    const endedMs = recordedMilliseconds(stage.ended_at);
+    if (
+      (stage.started_at != null && startedMs == null) ||
+      (stage.ended_at != null && endedMs == null)
+    ) {
+      return null;
+    }
+    if (stage.started_at != null && startedMs != null) {
+      entered.push({ stage, startedAt: stage.started_at, startedMs, endedMs });
+    }
+  }
+  const latestEntered = entered.reduce<TimedLifecycleStage | null>(
+    (latest, entry) => (latest == null || entry.startedMs > latest.startedMs ? entry : latest),
+    null,
+  );
+  if (latestEntered == null) {
+    return null;
+  }
+
+  let finishedAt = latestEntered.stage.ended_at;
+  let finishedMs = latestEntered.endedMs;
+  if (latestEntered.stage.stage === "completed") {
+    const previousEndMs = entered.reduce<number | null>(
+      (latest, entry) =>
+        entry.stage.stage !== "completed" &&
+        entry.endedMs != null &&
+        (latest == null || entry.endedMs > latest)
+          ? entry.endedMs
+          : latest,
+      null,
+    );
+    // The completed stage starts at workflow end but may itself end much later
+    // during cleanup. Require the preceding lifecycle boundary to corroborate
+    // that start so a collapsed retry history cannot invent a fresh finish.
+    if (previousEndMs !== latestEntered.startedMs) {
+      return null;
+    }
+    finishedAt = latestEntered.startedAt;
+    finishedMs = latestEntered.startedMs;
+  }
+  if (finishedAt == null || finishedMs == null) {
+    return null;
+  }
+
+  const durationStages = entered
+    .filter(
+      (entry) =>
+        entry.stage.stage !== "completed" &&
+        entry.startedMs <= finishedMs,
+    )
+    .sort((left, right) => left.startedMs - right.startedMs);
+  let durationSeconds = 0;
+  let previousEndMs: number | null = null;
+  for (const entry of durationStages) {
+    const stageDuration = recordedDurationSeconds(entry.stage.duration_seconds);
+    if (
+      entry.endedMs == null ||
+      entry.endedMs > finishedMs ||
+      stageDuration == null ||
+      (previousEndMs != null && previousEndMs !== entry.startedMs)
+    ) {
+      return { finishedAt, finishedMs, durationSeconds: null };
+    }
+    durationSeconds += stageDuration;
+    previousEndMs = entry.endedMs;
+  }
+  if (previousEndMs !== finishedMs) {
+    return { finishedAt, finishedMs, durationSeconds: null };
+  }
+  return { finishedAt, finishedMs, durationSeconds };
+}
+
+function workflowCardTiming(item: WorkspaceOverview): WorkflowCardTiming {
+  const resolvedFinishedAt = resolveWorkflowFinishedAt(item);
+  const explicitFinishedMs = recordedMilliseconds(resolvedFinishedAt);
+  if (resolvedFinishedAt != null && explicitFinishedMs == null) {
+    return { finishedAt: null, durationLabel: null };
+  }
+
+  const lifecycleTiming = lifecycleWorkflowTiming(item);
+  const finishedAt = resolvedFinishedAt ?? lifecycleTiming?.finishedAt ?? null;
+  const finishedMs = explicitFinishedMs ?? lifecycleTiming?.finishedMs ?? null;
+  if (finishedAt == null || finishedMs == null) {
+    return { finishedAt: null, durationLabel: null };
+  }
+
+  const explicitDurationPresent = item.duration_seconds != null;
+  const explicitDuration = recordedDurationSeconds(item.duration_seconds);
+  let durationSeconds: number | null = null;
+  if (explicitDurationPresent) {
+    const fallbackFinishedMs = recordedMilliseconds(item.finished_at);
+    const durationMatchesFinish =
+      item.finished_at == null || fallbackFinishedMs === finishedMs;
+    durationSeconds = explicitDuration != null && durationMatchesFinish ? explicitDuration : null;
+  } else if (lifecycleTiming?.finishedMs === finishedMs) {
+    durationSeconds = lifecycleTiming.durationSeconds;
+  }
+
+  return {
+    finishedAt,
+    durationLabel: recordedDurationLabel(durationSeconds),
+  };
+}
+
 const WorkspaceCard = memo(function WorkspaceCard({
   item,
   selected,
@@ -761,6 +914,8 @@ const WorkspaceCard = memo(function WorkspaceCard({
     ? attentionAgeSeconds(attentionSince(item))
     : null;
   const taskKey = displayedTaskKey(item);
+  const terminal = TERMINAL_WORKSPACE_CARD_STATUSES.has(item.status);
+  const terminalTiming = terminal ? workflowCardTiming(item) : null;
   return (
     <div
       data-testid={`workspace-card-${item.workspace_id}`}
@@ -822,14 +977,31 @@ const WorkspaceCard = memo(function WorkspaceCard({
                         </span>
                       ) : null}
                     </span>
-                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-slate-500">
-                      <span>created {formatDateTime(item.created_at)}</span>
-                      <span>updated {formatDateTime(item.updated_at)}</span>
-                      {item.last_activity_at ? (
+                    <div
+                      className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-slate-500"
+                      data-testid={`workspace-card-timing-${item.workspace_id}`}
+                    >
+                      <span>Created {formatDateTime(item.created_at)}</span>
+                      {terminal ? (
+                        <>
+                          <span data-testid={`workspace-card-finished-${item.workspace_id}`}>
+                            Finished{" "}
+                            {terminalTiming?.finishedAt
+                              ? formatDateTime(terminalTiming.finishedAt)
+                              : "not recorded"}
+                          </span>
+                          <span data-testid={`workspace-card-duration-${item.workspace_id}`}>
+                            Duration {terminalTiming?.durationLabel ?? "not recorded"}
+                          </span>
+                        </>
+                      ) : (
                         <span data-testid={`workspace-last-activity-${item.workspace_id}`}>
-                          activity {formatDateTime(item.last_activity_at)}
+                          Last activity{" "}
+                          {item.last_activity_at
+                            ? formatDateTime(item.last_activity_at)
+                            : "not recorded"}
                         </span>
-                      ) : null}
+                      )}
                     </div>
                     <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-600">
                       <Bot size={13} aria-hidden className="shrink-0" />

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -42,7 +42,7 @@ useState
 import {
 formatAgentLabel,
 formatAgentTitle,
-resolveWorkflowFinishedAt
+resolveWorkflowTiming
 } from "@/lib/agent-format";
 import {
   displayedTaskKey,
@@ -753,155 +753,6 @@ const TERMINAL_WORKSPACE_CARD_STATUSES = new Set<WorkspaceOverview["status"]>([
   "destroyed",
 ]);
 
-type WorkflowCardTiming = {
-  finishedAt: string | null;
-  durationLabel: string | null;
-};
-
-type TimedLifecycleStage = {
-  stage: WorkspaceOverview["lifecycle"][number];
-  startedAt: string;
-  startedMs: number;
-  endedMs: number | null;
-};
-
-function recordedMilliseconds(value: string | null | undefined): number | null {
-  if (!value) {
-    return null;
-  }
-  const milliseconds = Date.parse(value);
-  return Number.isFinite(milliseconds) ? milliseconds : null;
-}
-
-function recordedDurationSeconds(value: number | null | undefined): number | null {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
-}
-
-function lifecycleWorkflowTiming(item: WorkspaceOverview): {
-  finishedAt: string;
-  finishedMs: number;
-  durationSeconds: number | null;
-} | null {
-  // Lifecycle summaries collapse repeated visits to a stage. Once a retry or
-  // reverse transition exists, they cannot identify the current workflow end.
-  if (item.recovery != null) {
-    return null;
-  }
-  const entered: TimedLifecycleStage[] = [];
-  for (const stage of item.lifecycle) {
-    const startedMs = recordedMilliseconds(stage.started_at);
-    const endedMs = recordedMilliseconds(stage.ended_at);
-    if (
-      (stage.started_at != null && startedMs == null) ||
-      (stage.ended_at != null && endedMs == null)
-    ) {
-      return null;
-    }
-    if (
-      stage.started_at == null &&
-      (stage.ended_at != null ||
-        stage.duration_seconds != null ||
-        (stage.status !== "pending" && stage.status !== "terminal_skipped"))
-    ) {
-      return null;
-    }
-    if (stage.started_at != null && startedMs != null) {
-      entered.push({ stage, startedAt: stage.started_at, startedMs, endedMs });
-    }
-  }
-  const latestEntered = entered.reduce<TimedLifecycleStage | null>(
-    (latest, entry) => (latest == null || entry.startedMs > latest.startedMs ? entry : latest),
-    null,
-  );
-  if (latestEntered == null) {
-    return null;
-  }
-
-  let finishedAt = latestEntered.stage.ended_at;
-  let finishedMs = latestEntered.endedMs;
-  if (latestEntered.stage.stage === "completed") {
-    const previousEndMs = entered.reduce<number | null>(
-      (latest, entry) =>
-        entry.stage.stage !== "completed" &&
-        entry.endedMs != null &&
-        (latest == null || entry.endedMs > latest)
-          ? entry.endedMs
-          : latest,
-      null,
-    );
-    // The completed stage starts at workflow end but may itself end much later
-    // during cleanup. Require the preceding lifecycle boundary to corroborate
-    // that start so a collapsed retry history cannot invent a fresh finish.
-    if (previousEndMs !== latestEntered.startedMs) {
-      return null;
-    }
-    finishedAt = latestEntered.startedAt;
-    finishedMs = latestEntered.startedMs;
-  }
-  if (finishedAt == null || finishedMs == null) {
-    return null;
-  }
-
-  const durationStages = entered
-    .filter(
-      (entry) =>
-        entry.stage.stage !== "completed" &&
-        entry.startedMs <= finishedMs,
-    )
-    .sort((left, right) => left.startedMs - right.startedMs);
-  let durationSeconds = 0;
-  let previousEndMs: number | null = null;
-  for (const entry of durationStages) {
-    const stageDuration = recordedDurationSeconds(entry.stage.duration_seconds);
-    if (
-      entry.endedMs == null ||
-      entry.endedMs > finishedMs ||
-      stageDuration == null ||
-      (previousEndMs != null && previousEndMs !== entry.startedMs)
-    ) {
-      return { finishedAt, finishedMs, durationSeconds: null };
-    }
-    durationSeconds += stageDuration;
-    previousEndMs = entry.endedMs;
-  }
-  if (previousEndMs !== finishedMs) {
-    return { finishedAt, finishedMs, durationSeconds: null };
-  }
-  return { finishedAt, finishedMs, durationSeconds };
-}
-
-function workflowCardTiming(item: WorkspaceOverview): WorkflowCardTiming {
-  const resolvedFinishedAt = resolveWorkflowFinishedAt(item);
-  const explicitFinishedMs = recordedMilliseconds(resolvedFinishedAt);
-  if (resolvedFinishedAt != null && explicitFinishedMs == null) {
-    return { finishedAt: null, durationLabel: null };
-  }
-
-  const lifecycleTiming = lifecycleWorkflowTiming(item);
-  const finishedAt = resolvedFinishedAt ?? lifecycleTiming?.finishedAt ?? null;
-  const finishedMs = explicitFinishedMs ?? lifecycleTiming?.finishedMs ?? null;
-  if (finishedAt == null || finishedMs == null) {
-    return { finishedAt: null, durationLabel: null };
-  }
-
-  const explicitDurationPresent = item.duration_seconds != null;
-  const explicitDuration = recordedDurationSeconds(item.duration_seconds);
-  let durationSeconds: number | null = null;
-  if (explicitDurationPresent) {
-    const fallbackFinishedMs = recordedMilliseconds(item.finished_at);
-    const durationMatchesFinish =
-      item.finished_at == null || fallbackFinishedMs === finishedMs;
-    durationSeconds = explicitDuration != null && durationMatchesFinish ? explicitDuration : null;
-  } else if (lifecycleTiming?.finishedMs === finishedMs) {
-    durationSeconds = lifecycleTiming.durationSeconds;
-  }
-
-  return {
-    finishedAt,
-    durationLabel: recordedDurationLabel(durationSeconds),
-  };
-}
-
 const WorkspaceCard = memo(function WorkspaceCard({
   item,
   selected,
@@ -923,7 +774,7 @@ const WorkspaceCard = memo(function WorkspaceCard({
     : null;
   const taskKey = displayedTaskKey(item);
   const terminal = TERMINAL_WORKSPACE_CARD_STATUSES.has(item.status);
-  const terminalTiming = terminal ? workflowCardTiming(item) : null;
+  const terminalTiming = terminal ? resolveWorkflowTiming(item) : null;
   return (
     <div
       data-testid={`workspace-card-${item.workspace_id}`}
@@ -999,7 +850,8 @@ const WorkspaceCard = memo(function WorkspaceCard({
                               : "not recorded"}
                           </span>
                           <span data-testid={`workspace-card-duration-${item.workspace_id}`}>
-                            Duration {terminalTiming?.durationLabel ?? "not recorded"}
+                            Duration{" "}
+                            {recordedDurationLabel(terminalTiming?.durationSeconds) ?? "not recorded"}
                           </span>
                         </>
                       ) : (

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -575,7 +575,7 @@ export function WorkspaceSummary({
         </div>
       }
     >
-      <div className="grid min-w-0 gap-4">
+      <div className="grid min-w-0 grid-cols-1 gap-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
             <h2 className="truncate text-lg font-semibold">{overview.title}</h2>

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -29,6 +29,7 @@ formatRequestedEffort,
 formatRequestedModel,
 mergeWorkspacePresentationFields,
 resolveWorkflowFinishedAt,
+resolveWorkflowTiming,
 } from "@/lib/agent-format";
 import { displayedTaskKey } from "@/lib/console-dashboard-derived";
 import {
@@ -115,9 +116,10 @@ export function TaskDetailsModal({
 }) {
   const labelId = `task-details-label-${workspace.workspace_id}`;
   const titleId = `task-details-title-${workspace.workspace_id}`;
-  const workflowFinishedAt = resolveWorkflowFinishedAt(workspace);
+  const workflowTiming = resolveWorkflowTiming(workspace);
+  const workflowFinishedAt = workflowTiming.finishedAt;
   const finishedAt = distinctFinishedAt(workspace);
-  const recordedDuration = recordedDurationLabel(workspace.duration_seconds);
+  const recordedDuration = recordedDurationLabel(workflowTiming.durationSeconds);
   const taskKey = displayedTaskKey(workspace);
 
   useIsomorphicLayoutEffect(() => {

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -1182,6 +1182,9 @@ export function ConsoleDashboard() {
           coverageNotes={
             fleetSummaryAvailable ? (dashboardSummary?.coverage.notes ?? null) : null
           }
+          countEvidence={
+            fleetSummaryAvailable ? (dashboardSummary?.count_evidence ?? null) : null
+          }
         />
       ) : null}
       <SectionNav

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -197,6 +197,171 @@ export function distinctFinishedAt(workspace: WorkflowTimingFields): string | nu
   return finishedAt;
 }
 
+const TERMINAL_WORKFLOW_STATUSES = new Set<WorkspaceOverview["status"]>([
+  "completed",
+  "failed",
+  "cancelled",
+  "destroyed",
+]);
+
+export type ResolvedWorkflowTiming = {
+  finishedAt: string | null;
+  durationSeconds: number | null;
+};
+
+type TimedLifecycleStage = {
+  stage: WorkspaceOverview["lifecycle"][number];
+  startedAt: string;
+  startedMs: number;
+  endedMs: number | null;
+};
+
+function recordedMilliseconds(value: string | null | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const milliseconds = Date.parse(value);
+  return Number.isFinite(milliseconds) ? milliseconds : null;
+}
+
+function recordedDurationSeconds(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function lifecycleWorkflowTiming(item: WorkspaceOverview): {
+  finishedAt: string;
+  finishedMs: number;
+  durationSeconds: number | null;
+} | null {
+  // Lifecycle summaries collapse repeated visits to a stage. Once a retry or
+  // reverse transition exists, they cannot identify the current workflow end.
+  if (item.recovery != null) {
+    return null;
+  }
+  const entered: TimedLifecycleStage[] = [];
+  for (const stage of item.lifecycle) {
+    const startedMs = recordedMilliseconds(stage.started_at);
+    const endedMs = recordedMilliseconds(stage.ended_at);
+    if (
+      (stage.started_at != null && startedMs == null) ||
+      (stage.ended_at != null && endedMs == null)
+    ) {
+      return null;
+    }
+    if (
+      stage.started_at == null &&
+      (stage.ended_at != null ||
+        stage.duration_seconds != null ||
+        (stage.status !== "pending" && stage.status !== "terminal_skipped"))
+    ) {
+      return null;
+    }
+    if (stage.started_at != null && startedMs != null) {
+      entered.push({ stage, startedAt: stage.started_at, startedMs, endedMs });
+    }
+  }
+  const latestEntered = entered.reduce<TimedLifecycleStage | null>(
+    (latest, entry) => (latest == null || entry.startedMs > latest.startedMs ? entry : latest),
+    null,
+  );
+  if (latestEntered == null) {
+    return null;
+  }
+
+  let finishedAt = latestEntered.stage.ended_at;
+  let finishedMs = latestEntered.endedMs;
+  if (latestEntered.stage.stage === "completed") {
+    const previousEndMs = entered.reduce<number | null>(
+      (latest, entry) =>
+        entry.stage.stage !== "completed" &&
+        entry.endedMs != null &&
+        (latest == null || entry.endedMs > latest)
+          ? entry.endedMs
+          : latest,
+      null,
+    );
+    // The completed stage starts at workflow end but may itself end much later
+    // during cleanup. Require the preceding lifecycle boundary to corroborate
+    // that start so a collapsed retry history cannot invent a fresh finish.
+    if (previousEndMs !== latestEntered.startedMs) {
+      return null;
+    }
+    finishedAt = latestEntered.startedAt;
+    finishedMs = latestEntered.startedMs;
+  }
+  if (finishedAt == null || finishedMs == null) {
+    return null;
+  }
+
+  const durationStages = entered
+    .filter(
+      (entry) =>
+        entry.stage.stage !== "completed" &&
+        entry.startedMs <= finishedMs,
+    )
+    .sort((left, right) => left.startedMs - right.startedMs);
+  let durationSeconds = 0;
+  let previousEndMs: number | null = null;
+  for (const entry of durationStages) {
+    const stageDuration = recordedDurationSeconds(entry.stage.duration_seconds);
+    if (
+      entry.endedMs == null ||
+      entry.endedMs > finishedMs ||
+      stageDuration == null ||
+      (previousEndMs != null && previousEndMs !== entry.startedMs)
+    ) {
+      return { finishedAt, finishedMs, durationSeconds: null };
+    }
+    durationSeconds += stageDuration;
+    previousEndMs = entry.endedMs;
+  }
+  if (previousEndMs !== finishedMs) {
+    return { finishedAt, finishedMs, durationSeconds: null };
+  }
+  return { finishedAt, finishedMs, durationSeconds };
+}
+
+/**
+ * Resolve the workflow timing displayed by console surfaces. Terminal local
+ * overviews may derive timing from one complete lifecycle interval; active
+ * workspaces retain their explicit timing fields and never infer a finish.
+ */
+export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflowTiming {
+  const resolvedFinishedAt = resolveWorkflowFinishedAt(item);
+  if (!TERMINAL_WORKFLOW_STATUSES.has(item.status)) {
+    return {
+      finishedAt: resolvedFinishedAt,
+      durationSeconds: item.duration_seconds ?? null,
+    };
+  }
+
+  const explicitFinishedMs = recordedMilliseconds(resolvedFinishedAt);
+  if (resolvedFinishedAt != null && explicitFinishedMs == null) {
+    return { finishedAt: null, durationSeconds: null };
+  }
+
+  const lifecycleTiming = lifecycleWorkflowTiming(item);
+  const finishedAt = resolvedFinishedAt ?? lifecycleTiming?.finishedAt ?? null;
+  const finishedMs = explicitFinishedMs ?? lifecycleTiming?.finishedMs ?? null;
+  if (finishedAt == null || finishedMs == null) {
+    return { finishedAt: null, durationSeconds: null };
+  }
+
+  const explicitDurationPresent = item.duration_seconds != null;
+  const explicitDuration = recordedDurationSeconds(item.duration_seconds);
+  let durationSeconds: number | null = null;
+  if (explicitDurationPresent) {
+    const fallbackFinishedMs = recordedMilliseconds(item.finished_at);
+    const durationMatchesFinish =
+      item.finished_at == null || fallbackFinishedMs === finishedMs;
+    durationSeconds = explicitDuration != null && durationMatchesFinish ? explicitDuration : null;
+  } else if (lifecycleTiming?.finishedMs === finishedMs) {
+    durationSeconds = lifecycleTiming.durationSeconds;
+  }
+
+  return { finishedAt, durationSeconds };
+}
+
 type PresentationModelFields = RequestedModelWorkspace & ConfirmedModelWorkspace;
 
 /**

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -117,13 +117,18 @@ test("workspace summary does not embed effort in the Agent fact", () => {
   assert.doesNotMatch(summarySource, /formatAgentLabel\(/);
 });
 
-test("task details modal shows duration when duration_seconds is recorded", () => {
+test("task details modal uses resolved workflow timing", () => {
   const modalSource = extractFunctionSource("TaskDetailsModal");
 
   assert.match(
     modalSource,
-    /recordedDurationLabel\(workspace\.duration_seconds\)/,
-    "Expected TaskDetailsModal to read duration_seconds from the hosted overview",
+    /resolveWorkflowTiming\(workspace\)/,
+    "Expected TaskDetailsModal to share the card workflow timing resolver",
+  );
+  assert.match(
+    modalSource,
+    /recordedDurationLabel\(workflowTiming\.durationSeconds\)/,
+    "Expected TaskDetailsModal to format resolved explicit or lifecycle duration",
   );
   assert.match(
     modalSource,

--- a/apps/console/lib/console-dashboard-summary.test.mjs
+++ b/apps/console/lib/console-dashboard-summary.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  fleetKpisFromDashboardSummary,
   formatDashboardCoverageNotice,
   parseDashboardSummary,
 } from "./console-dashboard-summary.ts";
@@ -16,6 +17,30 @@ const fixture = JSON.parse(
 
 function validSummary(overrides = {}) {
   return structuredClone({ ...fixture, ...overrides });
+}
+
+const countKeys = Object.keys(fixture.counts);
+
+function zeroConfirmedCounts() {
+  return Object.fromEntries(countKeys.map((key) => [key, 0]));
+}
+
+function summaryWithCountEvidence({
+  total = 29,
+  known = 24,
+  unknown = 5,
+  confirmed = {},
+} = {}) {
+  return validSummary({
+    coverage: { status: "partial", notes: ["workflow_status_incomplete"] },
+    counts: Object.fromEntries(countKeys.map((key) => [key, null])),
+    count_evidence: {
+      total_workspaces: total,
+      status_known_workspaces: known,
+      status_unknown_workspaces: unknown,
+      confirmed_counts: { ...zeroConfirmedCounts(), ...confirmed },
+    },
+  });
 }
 
 for (const level of [null, "window", "coverage", "counts", "overlap"]) {
@@ -164,6 +189,223 @@ test("formatDashboardCoverageNotice surfaces partial and unknown notes", () => {
   assert.equal(formatDashboardCoverageNotice({ status: "complete", notes: [] }), null);
   assert.equal(formatDashboardCoverageNotice(null), null);
   assert.equal(formatDashboardCoverageNotice(undefined), null);
+});
+
+test("parseDashboardSummary accepts absent, null, and valid count evidence", () => {
+  const legacy = parseDashboardSummary(validSummary());
+  assert.ok(legacy);
+  assert.equal("count_evidence" in legacy, false);
+
+  const explicitNull = parseDashboardSummary(validSummary({ count_evidence: null }));
+  assert.ok(explicitNull);
+  assert.equal(explicitNull.count_evidence, null);
+
+  const allZero = parseDashboardSummary(summaryWithCountEvidence());
+  assert.ok(allZero);
+  assert.equal(allZero.count_evidence.total_workspaces, 29);
+  assert.equal(allZero.count_evidence.status_known_workspaces, 24);
+  assert.equal(allZero.count_evidence.status_unknown_workspaces, 5);
+  assert.equal(allZero.count_evidence.confirmed_counts.active, 0);
+
+  const oneRunning = parseDashboardSummary(
+    summaryWithCountEvidence({
+      total: 30,
+      known: 25,
+      unknown: 5,
+      confirmed: { active: 1, executing: 1 },
+    }),
+  );
+  assert.ok(oneRunning);
+  assert.equal(oneRunning.counts.active, null);
+  assert.equal(oneRunning.count_evidence.confirmed_counts.active, 1);
+  assert.equal(oneRunning.count_evidence.confirmed_counts.executing, 1);
+});
+
+test("parseDashboardSummary rejects malformed count evidence objects", () => {
+  for (const level of ["count_evidence", "confirmed_counts"]) {
+    const payload = summaryWithCountEvidence();
+    const target = level === "count_evidence"
+      ? payload.count_evidence
+      : payload.count_evidence.confirmed_counts;
+    target.unpublished_field = 0;
+    assert.equal(parseDashboardSummary(payload), null, `unknown key at ${level}`);
+  }
+
+  for (const [level, key] of [
+    ["count_evidence", "total_workspaces"],
+    ["count_evidence", "status_known_workspaces"],
+    ["count_evidence", "status_unknown_workspaces"],
+    ["count_evidence", "confirmed_counts"],
+    ...countKeys.map((key) => ["confirmed_counts", key]),
+  ]) {
+    const payload = summaryWithCountEvidence();
+    const target = level === "count_evidence"
+      ? payload.count_evidence
+      : payload.count_evidence.confirmed_counts;
+    delete target[key];
+    assert.equal(parseDashboardSummary(payload), null, `missing ${level}.${key}`);
+  }
+});
+
+test("parseDashboardSummary rejects non-strict count evidence integers", () => {
+  for (const path of [
+    ["total_workspaces"],
+    ["status_known_workspaces"],
+    ["status_unknown_workspaces"],
+    ["confirmed_counts", "active"],
+  ]) {
+    for (const invalid of ["1", true, -1, 1.5]) {
+      const payload = summaryWithCountEvidence();
+      const target = path.length === 1
+        ? payload.count_evidence
+        : payload.count_evidence.confirmed_counts;
+      target[path.at(-1)] = invalid;
+      assert.equal(parseDashboardSummary(payload), null, `${path.join(".")}=${invalid}`);
+    }
+  }
+});
+
+test("parseDashboardSummary rejects count evidence contradictions", () => {
+  assert.equal(
+    parseDashboardSummary(summaryWithCountEvidence({ total: 30, known: 24, unknown: 5 })),
+    null,
+  );
+  assert.equal(
+    parseDashboardSummary(summaryWithCountEvidence({ confirmed: { active: 25 } })),
+    null,
+  );
+  const completeWithUnknownStatus = summaryWithCountEvidence({ total: 1, known: 0, unknown: 1 });
+  completeWithUnknownStatus.coverage = { status: "complete", notes: [] };
+  completeWithUnknownStatus.counts = zeroConfirmedCounts();
+  assert.equal(parseDashboardSummary(completeWithUnknownStatus), null);
+  for (const confirmed of [
+    { active: 1, executing: 2 },
+    { active: 1, monitoring_pr: 2, awaiting_human: 0 },
+    { active: 1, queued: 2 },
+    { active: 2, monitoring_pr: 1, awaiting_human: 2 },
+    { active: 2, executing: 2, awaiting_operator: 1 },
+    { active: 2, executing: 2, retrying: 1 },
+    { active: 3, executing: 1, monitoring_pr: 1, awaiting_operator: 1, retrying: 1 },
+    { active: 1, executing: 1, queued: 1 },
+  ]) {
+    assert.equal(
+      parseDashboardSummary(summaryWithCountEvidence({ confirmed })),
+      null,
+      `relationship contradiction ${JSON.stringify(confirmed)}`,
+    );
+  }
+});
+
+test("parseDashboardSummary rejects every exact and confirmed count mismatch", () => {
+  for (const key of countKeys) {
+    const payload = summaryWithCountEvidence();
+    payload.counts[key] = 1;
+    assert.equal(parseDashboardSummary(payload), null, `mismatch at ${key}`);
+  }
+});
+
+test("confirmed KPI lower bounds stay qualified while exact values win", () => {
+  const lowerBounds = parseDashboardSummary(
+    summaryWithCountEvidence({ confirmed: { active: 1, executing: 1 } }),
+  );
+  assert.ok(lowerBounds);
+  const lowerBoundKpis = fleetKpisFromDashboardSummary({
+    summary: lowerBounds,
+    summaryStale: true,
+    saturation: null,
+    saturationStale: false,
+    showCapacity: false,
+    includeSummary: true,
+  });
+  const active = lowerBoundKpis.find((item) => item.id === "active");
+  const monitoring = lowerBoundKpis.find((item) => item.id === "monitoring_pr");
+  const completed = lowerBoundKpis.find((item) => item.id === "completed");
+  assert.deepEqual(
+    { value: active.value, suffix: active.suffix, stale: active.stale },
+    { value: 1, suffix: " confirmed", stale: true },
+  );
+  assert.deepEqual(
+    { value: monitoring.value, suffix: monitoring.suffix },
+    { value: 0, suffix: " confirmed" },
+  );
+  assert.match(active.hint, /project total is incomplete/);
+  assert.match(completed.hint, /last 24h/);
+  assert.match(completed.hint, /project total is incomplete/);
+  assert.equal(lowerBounds.counts.active, null);
+
+  const exactPayload = summaryWithCountEvidence({ confirmed: { active: 1, executing: 1 } });
+  exactPayload.counts.active = 1;
+  exactPayload.counts.monitoring_pr = 0;
+  const exactSummary = parseDashboardSummary(exactPayload);
+  assert.ok(exactSummary);
+  const exactKpis = fleetKpisFromDashboardSummary({
+    summary: exactSummary,
+    summaryStale: false,
+    saturation: null,
+    saturationStale: false,
+    showCapacity: false,
+    includeSummary: true,
+  });
+  assert.deepEqual(
+    {
+      value: exactKpis.find((item) => item.id === "active").value,
+      suffix: exactKpis.find((item) => item.id === "active").suffix,
+    },
+    { value: 1, suffix: undefined },
+  );
+  assert.deepEqual(
+    {
+      value: exactKpis.find((item) => item.id === "monitoring_pr").value,
+      suffix: exactKpis.find((item) => item.id === "monitoring_pr").suffix,
+    },
+    { value: 0, suffix: undefined },
+  );
+});
+
+test("missing count evidence keeps null KPIs as honest dashes", () => {
+  const summary = parseDashboardSummary(
+    validSummary({
+      coverage: { status: "partial", notes: ["queued_count_unavailable"] },
+      counts: { ...fixture.counts, queued: null },
+    }),
+  );
+  assert.ok(summary);
+  const queued = fleetKpisFromDashboardSummary({
+    summary,
+    summaryStale: false,
+    saturation: null,
+    saturationStale: false,
+    showCapacity: false,
+    includeSummary: true,
+  }).find((item) => item.id === "queued");
+  assert.deepEqual(
+    { value: queued.value, suffix: queued.suffix, hint: queued.hint },
+    { value: "—", suffix: undefined, hint: undefined },
+  );
+});
+
+test("coverage notice quantifies statuses without hiding other evidence gaps", () => {
+  const parsed = parseDashboardSummary(
+    summaryWithCountEvidence({ total: 1, known: 1, unknown: 0 }),
+  );
+  assert.ok(parsed);
+  parsed.coverage.notes = ["terminal_timestamp_unavailable", "attention_evidence_unavailable"];
+  assert.equal(
+    formatDashboardCoverageNotice(parsed.coverage, parsed.count_evidence),
+    "partial coverage — 1 of 1 workflow statuses known; 0 unknown; terminal timestamp unavailable; attention evidence unavailable",
+  );
+  assert.equal(
+    formatDashboardCoverageNotice(
+      { status: "unknown", notes: ["provider_lag"] },
+      {
+        total_workspaces: 29,
+        status_known_workspaces: 24,
+        status_unknown_workspaces: 5,
+        confirmed_counts: zeroConfirmedCounts(),
+      },
+    ),
+    "coverage unknown — 24 of 29 workflow statuses known; 5 unknown; provider lag",
+  );
 });
 
 test("parseDashboardSummary rejects impossible calendar timestamps", () => {

--- a/apps/console/lib/console-dashboard-summary.test.mjs
+++ b/apps/console/lib/console-dashboard-summary.test.mjs
@@ -274,6 +274,18 @@ test("parseDashboardSummary rejects count evidence contradictions", () => {
     parseDashboardSummary(summaryWithCountEvidence({ confirmed: { active: 25 } })),
     null,
   );
+  assert.equal(
+    parseDashboardSummary(summaryWithCountEvidence({
+      confirmed: {
+        active: 20,
+        completed_last_window: 10,
+        cancelled_last_window: 10,
+        failed_last_window: 10,
+      },
+    })),
+    null,
+    "disjoint active and terminal statuses cannot exceed the known population",
+  );
   const completeWithUnknownStatus = summaryWithCountEvidence({ total: 1, known: 0, unknown: 1 });
   completeWithUnknownStatus.coverage = { status: "complete", notes: [] };
   completeWithUnknownStatus.counts = zeroConfirmedCounts();

--- a/apps/console/lib/console-dashboard-summary.ts
+++ b/apps/console/lib/console-dashboard-summary.ts
@@ -1,6 +1,8 @@
 import { capacityUtilizationPct } from "./format.ts";
 import type {
   ConsoleBackendKind,
+  ConsoleDashboardCountEvidence,
+  ConsoleDashboardCounts,
   ConsoleDashboardSummary,
   ResourceSaturationSummary,
 } from "./types.ts";
@@ -11,6 +13,19 @@ function expectedSummaryScope(backendKind: ConsoleBackendKind): "local" | "tenan
 }
 
 const DASH = "—";
+const DASHBOARD_COUNT_KEYS = [
+  "active",
+  "executing",
+  "monitoring_pr",
+  "awaiting_operator",
+  "awaiting_human",
+  "retrying",
+  "queued",
+  "completed_last_window",
+  "cancelled_last_window",
+  "failed_last_window",
+] as const;
+type DashboardCountKey = (typeof DASHBOARD_COUNT_KEYS)[number];
 
 /**
  * OpenAPI `format: date-time` / RFC 3339 profile: full date-time with `T`/`t`
@@ -80,12 +95,64 @@ export type SummaryFleetKpi = {
   stale?: boolean;
 };
 
-function displayCount(value: number | null | undefined): string | number {
-  // Null ≠ zero: incomplete/unknown counts render as an em dash.
-  if (value == null) {
-    return DASH;
+function countRelationshipsAreValid(counts: Record<DashboardCountKey, number | null>): boolean {
+  const {
+    active,
+    executing,
+    monitoring_pr: monitoringPr,
+    awaiting_operator: awaitingOperator,
+    awaiting_human: awaitingHuman,
+    retrying,
+    queued,
+  } = counts;
+  for (const subset of [executing, monitoringPr, queued, awaitingOperator, retrying]) {
+    if (active != null && subset != null && subset > active) {
+      return false;
+    }
   }
-  return value;
+  if (awaitingHuman != null && monitoringPr != null && awaitingHuman > monitoringPr) {
+    return false;
+  }
+  for (const disjointCount of [awaitingOperator, retrying]) {
+    if (
+      active != null &&
+      executing != null &&
+      disjointCount != null &&
+      disjointCount + executing > active
+    ) {
+      return false;
+    }
+  }
+  if (active != null) {
+    const disjointParts = [executing, monitoringPr, queued, awaitingOperator, retrying].filter(
+      (value): value is number => value != null,
+    );
+    if (disjointParts.length >= 2 && disjointParts.reduce((sum, value) => sum + value, 0) > active) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const CONFIRMED_COUNT_HINT = "confirmed lower bound; project total is incomplete";
+
+function displayCount(
+  exact: number | null | undefined,
+  confirmed: number | null | undefined,
+  baseHint?: string,
+): Pick<SummaryFleetKpi, "value" | "suffix" | "hint"> {
+  if (exact != null) {
+    return { value: exact, hint: baseHint };
+  }
+  if (confirmed != null) {
+    return {
+      value: confirmed,
+      suffix: " confirmed",
+      hint: baseHint ? `${baseHint} · ${CONFIRMED_COUNT_HINT}` : CONFIRMED_COUNT_HINT,
+    };
+  }
+  // Null ≠ zero: incomplete/unknown counts without evidence render as an em dash.
+  return { value: DASH };
 }
 
 const COVERAGE_NOTE_LABELS: Record<string, string> = {
@@ -111,6 +178,7 @@ function formatCoverageNote(note: string): string {
  */
 export function formatDashboardCoverageNotice(
   coverage: { status: string; notes?: readonly string[] | null } | null | undefined,
+  countEvidence?: ConsoleDashboardCountEvidence | null,
 ): string | null {
   if (!coverage || (coverage.status !== "partial" && coverage.status !== "unknown")) {
     return null;
@@ -118,6 +186,11 @@ export function formatDashboardCoverageNotice(
   const notes = (coverage.notes ?? [])
     .map((note) => formatCoverageNote(note))
     .filter((note) => note.length > 0);
+  if (countEvidence) {
+    notes.unshift(
+      `${countEvidence.status_known_workspaces} of ${countEvidence.total_workspaces} workflow statuses known; ${countEvidence.status_unknown_workspaces} unknown`,
+    );
+  }
   const headline = coverage.status === "partial" ? "partial coverage" : "coverage unknown";
   if (notes.length === 0) {
     return `${headline} — some counts are incomplete`;
@@ -143,8 +216,11 @@ export function fleetKpisFromDashboardSummary(options: {
     includeSummary,
   } = options;
   const counts = summary?.counts ?? null;
+  const confirmedCounts = summary?.count_evidence?.confirmed_counts ?? null;
   const windowHint = summary ? `last ${summary.window.since_hours}h` : undefined;
   const capacity = showCapacity && saturation ? capacityUtilizationPct(saturation) : null;
+  const displayedNumber = (key: DashboardCountKey): number | null =>
+    counts?.[key] ?? confirmedCounts?.[key] ?? null;
 
   // Contract: unsupported/omitted fleet_summary must omit the widget, not render dash shells.
   // Available-but-null summary still emits counters as — (loading / first-load failure).
@@ -153,77 +229,86 @@ export function fleetKpisFromDashboardSummary(options: {
         {
           id: "active",
           label: "Active",
-          value: displayCount(counts?.active),
+          ...displayCount(counts?.active, confirmedCounts?.active),
           stale: summaryStale,
         },
         {
           id: "running",
           label: "Running",
-          value: displayCount(counts?.executing),
-          tone: counts?.executing ? "info" : undefined,
+          ...displayCount(counts?.executing, confirmedCounts?.executing),
+          tone: displayedNumber("executing") ? "info" : undefined,
           stale: summaryStale,
         },
         {
           id: "monitoring_pr",
           label: "Monitoring PR",
-          value: displayCount(counts?.monitoring_pr),
-          tone: counts?.monitoring_pr ? "info" : undefined,
+          ...displayCount(counts?.monitoring_pr, confirmedCounts?.monitoring_pr),
+          tone: displayedNumber("monitoring_pr") ? "info" : undefined,
           stale: summaryStale,
         },
         {
           id: "blocked",
           label: "Awaiting operator",
-          value: displayCount(counts?.awaiting_operator),
-          tone: counts?.awaiting_operator ? "warn" : undefined,
+          ...displayCount(counts?.awaiting_operator, confirmedCounts?.awaiting_operator),
+          tone: displayedNumber("awaiting_operator") ? "warn" : undefined,
           stale: summaryStale,
         },
         {
           id: "recovering",
           label: "Auto-retrying",
-          value: displayCount(counts?.retrying),
-          tone: counts?.retrying ? "info" : undefined,
+          ...displayCount(counts?.retrying, confirmedCounts?.retrying),
+          tone: displayedNumber("retrying") ? "info" : undefined,
           stale: summaryStale,
         },
         {
           id: "awaiting_human",
           label: "Awaiting human",
-          value: displayCount(counts?.awaiting_human),
-          tone: counts?.awaiting_human ? "warn" : undefined,
+          ...displayCount(counts?.awaiting_human, confirmedCounts?.awaiting_human),
+          tone: displayedNumber("awaiting_human") ? "warn" : undefined,
           stale: summaryStale,
         },
         {
           id: "queued",
           label: "Queued",
-          value: displayCount(counts?.queued),
-          tone: counts?.queued ? "warn" : undefined,
-          hint:
-            counts?.queued != null && counts.queued > 0
-              ? "awaiting capacity"
-              : undefined,
+          ...displayCount(
+            counts?.queued,
+            confirmedCounts?.queued,
+            displayedNumber("queued") ? "awaiting capacity" : undefined,
+          ),
+          tone: displayedNumber("queued") ? "warn" : undefined,
           stale: summaryStale,
         },
         {
           id: "completed",
           label: "Completed",
-          value: displayCount(counts?.completed_last_window),
-          tone: counts?.completed_last_window ? "good" : undefined,
-          hint: counts?.completed_last_window != null ? windowHint : undefined,
+          ...displayCount(
+            counts?.completed_last_window,
+            confirmedCounts?.completed_last_window,
+            windowHint,
+          ),
+          tone: displayedNumber("completed_last_window") ? "good" : undefined,
           stale: summaryStale,
         },
         {
           id: "cancelled",
           label: "Cancelled",
-          value: displayCount(counts?.cancelled_last_window),
-          tone: counts?.cancelled_last_window ? "warn" : undefined,
-          hint: counts?.cancelled_last_window != null ? windowHint : undefined,
+          ...displayCount(
+            counts?.cancelled_last_window,
+            confirmedCounts?.cancelled_last_window,
+            windowHint,
+          ),
+          tone: displayedNumber("cancelled_last_window") ? "warn" : undefined,
           stale: summaryStale,
         },
         {
           id: "failed",
           label: "Failed",
-          value: displayCount(counts?.failed_last_window),
-          tone: counts?.failed_last_window ? "bad" : undefined,
-          hint: counts?.failed_last_window != null ? windowHint : undefined,
+          ...displayCount(
+            counts?.failed_last_window,
+            confirmedCounts?.failed_last_window,
+            windowHint,
+          ),
+          tone: displayedNumber("failed_last_window") ? "bad" : undefined,
           stale: summaryStale,
         },
       ]
@@ -260,7 +345,7 @@ export function parseDashboardSummary(
   const record = payload as Record<string, unknown>;
   if (!hasOnlyKeys(record, [
     "schema_version", "scope", "generated_at", "as_of", "last_success_at",
-    "window", "coverage", "counts", "overlap",
+    "window", "coverage", "counts", "count_evidence", "overlap",
   ])) {
     return null;
   }
@@ -351,23 +436,11 @@ export function parseDashboardSummary(
     return null;
   }
   const counts = record.counts as Record<string, unknown>;
-  const requiredCountKeys = [
-    "active",
-    "executing",
-    "monitoring_pr",
-    "awaiting_operator",
-    "awaiting_human",
-    "retrying",
-    "queued",
-    "completed_last_window",
-    "cancelled_last_window",
-    "failed_last_window",
-  ] as const;
-  if (!hasOnlyKeys(counts, requiredCountKeys)) {
+  if (!hasOnlyKeys(counts, DASHBOARD_COUNT_KEYS)) {
     return null;
   }
   let anyCountNull = false;
-  for (const key of requiredCountKeys) {
+  for (const key of DASHBOARD_COUNT_KEYS) {
     if (!(key in counts)) {
       return null;
     }
@@ -384,27 +457,6 @@ export function parseDashboardSummary(
   // Reject complete + null so hosted snapshots cannot replace last-good KPIs
   // with dashes under a purported complete result.
   if (anyCountNull && coverage.status === "complete") {
-    return null;
-  }
-  // Immediately after the per-value loop: reject contradictory domain subsets
-  // among related non-null counts so malformed hosted snapshots fail closed and
-  // the console retains the last-good KPI snapshot.
-  const active = counts.active as number | null;
-  const executing = counts.executing as number | null;
-  const monitoringPr = counts.monitoring_pr as number | null;
-  const awaitingHuman = counts.awaiting_human as number | null;
-  const awaitingOperator = counts.awaiting_operator as number | null;
-  const retrying = counts.retrying as number | null;
-  const queued = counts.queued as number | null;
-  if (active != null && executing != null && executing > active) {
-    return null;
-  }
-  // monitoring_pr is a non-terminal status bucket ⊆ active.
-  if (active != null && monitoringPr != null && monitoringPr > active) {
-    return null;
-  }
-  // queued (requested) is a non-terminal status bucket ⊆ active.
-  if (active != null && queued != null && queued > active) {
     return null;
   }
   if (!record.overlap || typeof record.overlap !== "object" || Array.isArray(record.overlap)) {
@@ -425,57 +477,67 @@ export function parseDashboardSummary(
       return null;
     }
   }
-  if (
-    awaitingHuman != null &&
-    monitoringPr != null &&
-    awaitingHuman > monitoringPr
-  ) {
+  const exactCounts = counts as unknown as ConsoleDashboardCounts;
+  if (!countRelationshipsAreValid(exactCounts)) {
     return null;
   }
-  if (awaitingOperator != null) {
-    if (active != null && awaitingOperator > active) {
+
+  if ("count_evidence" in record && record.count_evidence !== null) {
+    if (
+      !record.count_evidence ||
+      typeof record.count_evidence !== "object" ||
+      Array.isArray(record.count_evidence)
+    ) {
       return null;
     }
-    if (active != null && executing != null && awaitingOperator + executing > active) {
+    const evidence = record.count_evidence as Record<string, unknown>;
+    const evidenceKeys = [
+      "total_workspaces",
+      "status_known_workspaces",
+      "status_unknown_workspaces",
+      "confirmed_counts",
+    ] as const;
+    if (!hasOnlyKeys(evidence, evidenceKeys) || !evidenceKeys.every((key) => key in evidence)) {
       return null;
     }
-  }
-  if (retrying != null) {
-    if (active != null && retrying > active) {
+    if (
+      !isNonNegativeInteger(evidence.total_workspaces) ||
+      !isNonNegativeInteger(evidence.status_known_workspaces) ||
+      !isNonNegativeInteger(evidence.status_unknown_workspaces) ||
+      evidence.status_known_workspaces + evidence.status_unknown_workspaces !==
+        evidence.total_workspaces
+    ) {
       return null;
     }
-    if (active != null && executing != null && retrying + executing > active) {
+    if (
+      !evidence.confirmed_counts ||
+      typeof evidence.confirmed_counts !== "object" ||
+      Array.isArray(evidence.confirmed_counts)
+    ) {
       return null;
     }
-  }
-  // Combined disjoint active status buckets: pairwise subset checks miss cases
-  // like active=3 with executing=monitoring_pr=awaiting_operator=retrying=1.
-  // executing, monitoring_pr, and queued are always distinct statuses;
-  // awaiting_operator / retrying are always in active ∉ executing under v1.
-  if (active != null) {
-    let disjointActiveSum = 0;
-    let partCount = 0;
-    if (executing != null) {
-      disjointActiveSum += executing;
-      partCount += 1;
+    const confirmed = evidence.confirmed_counts as Record<string, unknown>;
+    if (
+      !hasOnlyKeys(confirmed, DASHBOARD_COUNT_KEYS) ||
+      !DASHBOARD_COUNT_KEYS.every(
+        (key) =>
+          key in confirmed &&
+          isNonNegativeInteger(confirmed[key]) &&
+          confirmed[key] <= (evidence.status_known_workspaces as number),
+      )
+    ) {
+      return null;
     }
-    if (monitoringPr != null) {
-      disjointActiveSum += monitoringPr;
-      partCount += 1;
+    const confirmedCounts = confirmed as Record<DashboardCountKey, number>;
+    if (!countRelationshipsAreValid(confirmedCounts)) {
+      return null;
     }
-    if (queued != null) {
-      disjointActiveSum += queued;
-      partCount += 1;
+    for (const key of DASHBOARD_COUNT_KEYS) {
+      if (exactCounts[key] != null && exactCounts[key] !== confirmedCounts[key]) {
+        return null;
+      }
     }
-    if (awaitingOperator != null) {
-      disjointActiveSum += awaitingOperator;
-      partCount += 1;
-    }
-    if (retrying != null) {
-      disjointActiveSum += retrying;
-      partCount += 1;
-    }
-    if (partCount >= 2 && disjointActiveSum > active) {
+    if (coverage.status === "complete" && evidence.status_unknown_workspaces !== 0) {
       return null;
     }
   }

--- a/apps/console/lib/console-dashboard-summary.ts
+++ b/apps/console/lib/console-dashboard-summary.ts
@@ -529,6 +529,15 @@ export function parseDashboardSummary(
       return null;
     }
     const confirmedCounts = confirmed as Record<DashboardCountKey, number>;
+    if (
+      confirmedCounts.active +
+        confirmedCounts.completed_last_window +
+        confirmedCounts.cancelled_last_window +
+        confirmedCounts.failed_last_window >
+      evidence.status_known_workspaces
+    ) {
+      return null;
+    }
     if (!countRelationshipsAreValid(confirmedCounts)) {
       return null;
     }

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -991,6 +991,26 @@ export interface ConsoleDashboardCounts {
   failed_last_window: number | null;
 }
 
+export interface ConsoleDashboardConfirmedCounts {
+  active: number;
+  executing: number;
+  monitoring_pr: number;
+  awaiting_operator: number;
+  awaiting_human: number;
+  retrying: number;
+  queued: number;
+  completed_last_window: number;
+  cancelled_last_window: number;
+  failed_last_window: number;
+}
+
+export interface ConsoleDashboardCountEvidence {
+  total_workspaces: number;
+  status_known_workspaces: number;
+  status_unknown_workspaces: number;
+  confirmed_counts: ConsoleDashboardConfirmedCounts;
+}
+
 export interface ConsoleDashboardSummary {
   schema_version: number;
   scope: ConsoleSummaryScope;
@@ -1008,6 +1028,7 @@ export interface ConsoleDashboardSummary {
     notes: string[];
   };
   counts: ConsoleDashboardCounts;
+  count_evidence?: ConsoleDashboardCountEvidence | null;
   overlap: {
     awaiting_human_subset_of_monitoring_pr: true;
     awaiting_operator_in_active_not_executing: true;

--- a/apps/console/tests/dashboard-inspector.spec.ts
+++ b/apps/console/tests/dashboard-inspector.spec.ts
@@ -12,6 +12,14 @@ async function clickWorkspaceTitle(page: Page, workspaceId: string) {
   await page.mouse.click(titleBox.x + titleBox.width / 2, titleBox.y + titleBox.height / 2);
 }
 
+async function expectInsideViewport(locator: ReturnType<Page["locator"]>, width: number) {
+  await expect(locator).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, `expected a box at ${width}px`).not.toBeNull();
+  expect(box!.x, `left edge at ${width}px`).toBeGreaterThanOrEqual(-1);
+  expect(box!.x + box!.width, `right edge at ${width}px`).toBeLessThanOrEqual(width + 1);
+}
+
 // Since we don't have a real API running in the CI for this test, we need to mock it.
 test.describe("Dashboard Workspace Inspector", () => {
   test.beforeEach(async ({ page }) => {
@@ -320,6 +328,140 @@ test.describe("Dashboard Workspace Inspector", () => {
     const overlay = page.locator(".fixed.inset-0.z-40").first();
     await expect(overlay).toBeVisible();
     await expect(inspectorDrawer).toHaveClass(/w-full/);
+  });
+
+  test("long workspace summary stays inside the inspector at supported widths", async ({ page }) => {
+    const workspaceId = "ws_layout_overflow";
+    const longToken = "pathological-unbroken-workspace-value-".repeat(18);
+    const layoutWorkspace = {
+      workspace_id: workspaceId,
+      task_id: `task_${workspaceId}`,
+      task_key: `AWF-${longToken}`,
+      title: `Inspector layout ${longToken}`,
+      task_prompt: "Verify the workspace inspector layout.",
+      repo_url: `https://github.com/example/${longToken}.git`,
+      base_branch: `base/${longToken}`,
+      branch_name: `awf/${longToken}`,
+      agent: "codex",
+      agent_model: `gpt-${longToken}`,
+      agent_effort: "high",
+      agent_model_source: "task_policy",
+      agent_effort_source: "default",
+      requested_model: `requested-${longToken}`,
+      requested_model_source: "task_policy",
+      confirmed_execution_model: `confirmed-${longToken}`,
+      confirmed_execution_model_source: "execution_evidence",
+      status: "running",
+      subphase: null,
+      current_phase: "running",
+      active_operation: null,
+      created_at: "2026-09-11T12:00:00Z",
+      updated_at: "2026-09-11T12:05:00Z",
+      last_activity_at: "2026-09-11T12:05:00Z",
+      lifecycle: [],
+      llm_usage: null,
+      recovery: null,
+      coordination_warnings: [],
+      is_stale_running: false,
+      pr_url: "https://github.com/example/repo/pull/963",
+      pr_number: 963,
+    };
+
+    await page.route("/api/awf/workspaces/overview*", async (route) => {
+      await fulfillJson(route, { items: [layoutWorkspace], next_cursor: null, has_more: false });
+    });
+    await page.route(/\/api\/awf\/workspaces\/ws_layout_overflow(?:\/.*)?(?:\?.*)?$/, async (route) => {
+      const path = new URL(route.request().url()).pathname;
+      if (path === `/api/awf/workspaces/${workspaceId}`) {
+        await fulfillJson(route, { ...layoutWorkspace, id: workspaceId, version: 1 });
+      } else if (path.endsWith("/runtime")) {
+        await fulfillJson(route, { status: "running" });
+      } else if (path.endsWith("/stream")) {
+        await route.fulfill({
+          status: 200,
+          headers: { "content-type": "text/event-stream; charset=utf-8" },
+          body: `data: ${JSON.stringify({ type: "connected", workspace_id: workspaceId })}\n\n`,
+        });
+      } else {
+        await fulfillJson(route, { items: [], next_cursor: null, has_more: false });
+      }
+    });
+
+    await page.goto(`/?workspaceId=${workspaceId}`);
+    const inspector = page.locator(".fixed.inset-y-0.right-0").first();
+    await expect(inspector).toHaveClass(/translate-x-0/);
+    await inspector.evaluate(async (element) => {
+      await Promise.all(element.getAnimations().map((animation) => animation.finished));
+    });
+    const summary = inspector
+      .locator("section")
+      .filter({ has: page.getByRole("heading", { name: "Workspace", exact: true }) })
+      .first();
+    await expect(summary).toBeVisible();
+
+    const viewports = [
+      { width: 320, columns: 1 },
+      { width: 375, columns: 1 },
+      { width: 390, columns: 1 },
+      { width: 430, columns: 1 },
+      { width: 768, columns: 2 },
+      { width: 1280, columns: 4 },
+      { width: 1720, columns: 4 },
+    ];
+    for (const viewport of viewports) {
+      await page.setViewportSize({ width: viewport.width, height: 1000 });
+      await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+
+      const overflowingDescendants = await summary.evaluate((element) => {
+        const bounds = element.getBoundingClientRect();
+        return Array.from(element.querySelectorAll<HTMLElement>("*"))
+          .filter((descendant) => {
+            const style = getComputedStyle(descendant);
+            const box = descendant.getBoundingClientRect();
+            return (
+              style.display !== "none" &&
+              style.visibility !== "hidden" &&
+              box.width > 1 &&
+              box.height > 1 &&
+              (box.left < bounds.left - 1 || box.right > bounds.right + 1)
+            );
+          })
+          .map((descendant) => ({
+            tag: descendant.tagName,
+            className: descendant.className,
+            left: descendant.getBoundingClientRect().left,
+            right: descendant.getBoundingClientRect().right,
+            summaryLeft: bounds.left,
+            summaryRight: bounds.right,
+          }));
+      });
+      expect(overflowingDescendants, `summary descendants at ${viewport.width}px`).toEqual([]);
+
+      const status = summary.getByText("running", { exact: true }).first();
+      const pullRequest = summary.getByRole("link", { name: "PR #963", exact: true });
+      const reload = inspector.getByRole("button", { name: "Reload workspace", exact: true });
+      const close = inspector.getByRole("button", { name: "Close inspector", exact: true });
+      for (const reachable of [status, pullRequest, reload, close]) {
+        await expectInsideViewport(reachable, viewport.width);
+      }
+
+      const factColumns = await Promise.all(
+        ["Workspace", "Task key", "Agent", "Requested model"].map(async (label) => {
+          const fact = summary.locator(".label-caps", { hasText: label }).first().locator("..");
+          const box = await fact.boundingBox();
+          expect(box, `${label} fact at ${viewport.width}px`).not.toBeNull();
+          return Math.round(box!.x);
+        }),
+      );
+      expect(new Set(factColumns).size, `fact columns at ${viewport.width}px`).toBe(
+        viewport.columns,
+      );
+    }
+
+    await inspector.getByRole("button", { name: "Reload workspace", exact: true }).click();
+    await expect(summary.getByText("running", { exact: true }).first()).toBeVisible();
+    await inspector.getByRole("button", { name: "Close inspector", exact: true }).click();
+    await expect(inspector).toHaveClass(/translate-x-full/);
   });
 });
 

--- a/apps/console/tests/dashboard-overview-performance.spec.ts
+++ b/apps/console/tests/dashboard-overview-performance.spec.ts
@@ -567,17 +567,30 @@ test("filtered continuation backfills unchanged first-page membership", async ({
   const statusGroup = page.getByRole("group", { name: "Status" });
   await statusGroup.getByRole("button", { name: /Status all/ }).click();
   await statusGroup.getByLabel("completed").check();
-  await page.getByRole("button", { name: "Load more workspaces" }).click();
-  await expect.poll(() => completedRequests).toContain("completed-page-2");
+  const loadMore = page.getByRole("button", { name: "Load more workspaces" });
+  // This regression exercises filtered cursor backfill. Dispatch setup loads
+  // without Playwright scrolling the footer into the independent near-bottom
+  // loader, which can otherwise advance the stale cursor before membership
+  // changes and leave an extra retained row in the test fixture.
+  const requestHistoryWithoutScrolling = async (expectedCursor: string) => {
+    await expect(async () => {
+      if (!completedRequests.includes(expectedCursor)) {
+        await loadMore.evaluate((button: HTMLButtonElement) => button.click());
+      }
+      expect(completedRequests).toContain(expectedCursor);
+    }).toPass({ intervals: [100, 250, 500], timeout: 5_000 });
+  };
+  await requestHistoryWithoutScrolling("completed-page-2");
+  await expect(page.getByText(`1–${PAGE_SIZE} of ${PAGE_SIZE * 2} loaded`, { exact: true }))
+    .toBeVisible();
 
   // Membership can change after the latest page-one poll. The continuation
   // itself must be armed to replay the loaded range; waiting for another poll
   // would leave a window where the stale page-three cursor skips this row.
   membershipGrew = true;
   const firstPageRequests = completedRequests.filter((cursor) => cursor === null).length;
-  await page.getByRole("button", { name: "Load more workspaces" }).click();
+  await requestHistoryWithoutScrolling("shifted-completed-page-3");
 
-  await expect.poll(() => completedRequests).toContain("shifted-completed-page-3");
   expect(completedRequests.filter((cursor) => cursor === null)).toHaveLength(firstPageRequests);
   await expect(page.getByText(new RegExp(`of ${PAGE_SIZE * 3} loaded$`))).toBeVisible();
   await page.getByPlaceholder("Search workspaces").fill("Newly matching off-page workspace");

--- a/apps/console/tests/dashboard-summary-kpis.spec.ts
+++ b/apps/console/tests/dashboard-summary-kpis.spec.ts
@@ -1,5 +1,7 @@
 import { expect, type Page, test } from "@playwright/test";
 
+import type { ConsoleDashboardSummary } from "@/lib/types";
+
 import { localDashboardSummary, hostedDashboardSummary, mockAwfConsoleApi } from "./fixtures/console-api";
 
 async function waitForConsoleReady(page: Page) {
@@ -9,6 +11,46 @@ async function waitForConsoleReady(page: Page) {
 
 const kpi = (page: Page, label: string) =>
   page.getByText(label, { exact: true }).locator("..").filter({ has: page.locator(".kpi-value") });
+
+function hostedCountEvidenceSummary(): ConsoleDashboardSummary {
+  const base = hostedDashboardSummary() as ConsoleDashboardSummary;
+  return {
+    ...base,
+    coverage: {
+      status: "partial",
+      notes: ["terminal_timestamp_unavailable", "attention_evidence_unavailable"],
+    },
+    counts: {
+      active: 1,
+      executing: null,
+      monitoring_pr: null,
+      awaiting_operator: 0,
+      awaiting_human: null,
+      retrying: null,
+      queued: null,
+      completed_last_window: null,
+      cancelled_last_window: null,
+      failed_last_window: null,
+    },
+    count_evidence: {
+      total_workspaces: 30,
+      status_known_workspaces: 25,
+      status_unknown_workspaces: 5,
+      confirmed_counts: {
+        active: 1,
+        executing: 1,
+        monitoring_pr: 0,
+        awaiting_operator: 0,
+        awaiting_human: 0,
+        retrying: 0,
+        queued: 0,
+        completed_last_window: 0,
+        cancelled_last_window: 0,
+        failed_last_window: 0,
+      },
+    },
+  };
+}
 
 test("KPI values come from dashboard-summary when saturation absent", async ({ page }) => {
   const requested: string[] = [];
@@ -101,6 +143,54 @@ test("unknown dashboard coverage renders an explicit notice without a request er
   await expect(coverage).toContainText("provider lag");
   await expect(page.getByTestId("dashboard-summary-error")).toHaveCount(0);
 });
+
+for (const viewport of [
+  { name: "desktop", width: 1280, height: 900 },
+  { name: "mobile", width: 390, height: 844 },
+]) {
+  test(`count evidence stays qualified and readable on ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await mockAwfConsoleApi(page, {
+      mode: "hosted",
+      dashboardSummary: hostedCountEvidenceSummary(),
+    });
+
+    await page.goto("/");
+    await waitForConsoleReady(page);
+
+    // Exact values retain their existing naked rendering and win over matching evidence.
+    await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("1");
+    await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("0");
+    // Null exact values use explicit, visible lower-bound qualification, including zero.
+    await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("1 confirmed");
+    await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("0 confirmed");
+    await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("0 confirmed");
+    await expect(kpi(page, "Running")).toContainText("project total is incomplete");
+    await expect(kpi(page, "Completed")).toContainText("last 24h");
+    await expect(kpi(page, "Completed")).toContainText("project total is incomplete");
+
+    const coverage = page.getByTestId("dashboard-summary-coverage");
+    await expect(coverage).toContainText("25 of 30 workflow statuses known; 5 unknown");
+    await expect(coverage).toContainText("terminal timestamp unavailable");
+    await expect(coverage).toContainText("attention evidence unavailable");
+    await expect(page.getByTestId("dashboard-summary-error")).toHaveCount(0);
+
+    for (const label of ["Running", "Monitoring PR", "Completed"]) {
+      const card = kpi(page, label);
+      const valueBox = await card.locator(".kpi-value").boundingBox();
+      const hintBox = await card.getByText(/project total is incomplete/).boundingBox();
+      expect(valueBox, `${label} value is measurable`).not.toBeNull();
+      expect(hintBox, `${label} incomplete-total hint is measurable`).not.toBeNull();
+      expect(valueBox!.y + valueBox!.height, `${label} value does not overlap its hint`).toBeLessThanOrEqual(
+        hintBox!.y + 1,
+      );
+    }
+    const hasHorizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(hasHorizontalOverflow).toBe(false);
+  });
+}
 
 test("status counters stay consistent for escalation/retry/terminal fixtures", async ({ page }) => {
   await mockAwfConsoleApi(page, {

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -1,0 +1,306 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import type {
+  WorkspaceLifecycleStage,
+  WorkspaceOverview,
+  WorkspaceStatus,
+} from "@/lib/types";
+import { formatDateTime } from "@/lib/format";
+
+import { mockAwfConsoleApi } from "./fixtures/console-api";
+
+async function waitForConsoleReady(page: Page) {
+  await expect(page.locator("header").filter({ hasText: "AWF Console" })).toBeVisible();
+  await expect(page.getByText("API: ok")).toBeVisible();
+}
+
+function overview(
+  workspaceId: string,
+  status: WorkspaceStatus,
+  overrides: Partial<WorkspaceOverview> = {},
+): WorkspaceOverview {
+  return {
+    workspace_id: workspaceId,
+    task_id: `task_${workspaceId}`,
+    title: `${status} timing workspace`,
+    task_prompt: "Verify workspace card timing",
+    repo_url: "https://github.com/example/awf.git",
+    base_branch: "development",
+    branch_name: `awf/${workspaceId}`,
+    agent: "codex",
+    agent_model: "gpt-5.5",
+    agent_effort: "high",
+    agent_model_source: "task_policy",
+    agent_effort_source: "default",
+    network_posture: "restricted",
+    lifecycle: [],
+    llm_usage: {
+      input_tokens: null,
+      output_tokens: null,
+      total_tokens: null,
+      cost_estimate: null,
+      currency: null,
+      status: "unavailable",
+      source: "none",
+      reason: "usage_not_reported",
+    },
+    recovery: null,
+    coordination_warnings: [],
+    provider_readiness_preflight: null,
+    status,
+    subphase: null,
+    last_activity_at: "2026-09-06T12:15:00Z",
+    last_log_at: "2026-09-06T12:14:00Z",
+    is_stale_running: false,
+    current_phase: status,
+    active_operation: null,
+    last_event: null,
+    pr_url: null,
+    pr_number: null,
+    failure_reason: null,
+    failure_message: null,
+    created_at: "2026-09-06T12:00:00Z",
+    updated_at: "2026-09-06T12:45:00Z",
+    ...overrides,
+  };
+}
+
+function stage(
+  name: string,
+  startedAt: string | null,
+  endedAt: string | null,
+  durationSeconds: number | null,
+): WorkspaceLifecycleStage {
+  return {
+    stage: name,
+    started_at: startedAt,
+    ended_at: endedAt,
+    duration_seconds: durationSeconds,
+    status: startedAt ? "completed" : "pending",
+  };
+}
+
+const surfaces = [
+  { name: "local desktop", mode: "local" as const, width: 1280, height: 900 },
+  { name: "hosted mobile", mode: "hosted" as const, width: 390, height: 844 },
+];
+
+for (const surface of surfaces) {
+  test(`active cards show activity without Updated on ${surface.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: surface.width, height: surface.height });
+    const running = overview("ws_running_timing", "running");
+    const monitoring = overview("ws_monitoring_timing", "monitoring_pr", {
+      last_activity_at: "2026-09-06T12:20:00Z",
+      pr_url: "https://github.com/example/awf/pull/12",
+      pr_number: 12,
+    });
+    const requestedWithoutActivity = overview("ws_requested_timing", "requested", {
+      last_activity_at: null,
+    });
+    await mockAwfConsoleApi(page, {
+      mode: surface.mode,
+      overviewItems: [running, monitoring, requestedWithoutActivity],
+    });
+
+    await page.goto("/");
+    await waitForConsoleReady(page);
+
+    for (const item of [running, monitoring]) {
+      const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
+      const timing = card.getByTestId(`workspace-card-timing-${item.workspace_id}`);
+      await expect(timing).toContainText("Created");
+      await expect(timing).toContainText("Last activity");
+      await expect(timing).not.toContainText("Updated");
+      await expect(timing).not.toContainText("Finished");
+      await expect(timing).not.toContainText("Duration");
+    }
+    await expect(
+      page.getByTestId("workspace-last-activity-ws_requested_timing"),
+    ).toContainText("not recorded");
+
+    const runningCard = page.getByTestId("workspace-card-ws_running_timing");
+    await runningCard.getByRole("button", { name: "Details", exact: true }).click();
+    const details = page.getByRole("dialog", { name: /Task details/i });
+    await expect(details).toBeVisible();
+    await expect(details.getByText("Updated", { exact: true })).toBeVisible();
+  });
+}
+
+test("hosted terminal cards use workflow finish and recorded duration for every terminal status", async ({
+  page,
+}) => {
+  const terminals = (["completed", "failed", "cancelled", "destroyed"] as const).map(
+    (status, index) =>
+      overview(`ws_hosted_${status}`, status, {
+        started_at: "2026-09-06T12:00:00Z",
+        workflow_finished_at: `2026-09-06T12:${20 + index}:00Z`,
+        finished_at: null,
+        duration_seconds: 1200 + index * 60,
+        native_runtime_finished_at: "2026-09-06T12:05:00Z",
+        last_activity_at: "2026-09-06T12:40:00Z",
+        updated_at: "2026-09-06T12:45:00Z",
+      }),
+  );
+  await mockAwfConsoleApi(page, { mode: "hosted", overviewItems: terminals });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  for (const [index, item] of terminals.entries()) {
+    const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
+    const timing = card.getByTestId(`workspace-card-timing-${item.workspace_id}`);
+    await expect(timing).toContainText("Created");
+    await expect(timing).toContainText("Finished");
+    await expect(timing).toContainText("Duration");
+    await expect(timing).not.toContainText("Last activity");
+    await expect(timing).not.toContainText("Updated");
+    await expect(card.getByTestId(`workspace-card-finished-${item.workspace_id}`)).toContainText(
+      formatDateTime(item.workflow_finished_at),
+    );
+    await expect(card.getByTestId(`workspace-card-duration-${item.workspace_id}`)).toContainText(
+      `${20 + index}m 0s`,
+    );
+  }
+});
+
+test("local terminal cards use one complete lifecycle interval", async ({ page }) => {
+  const completed = overview("ws_local_completed", "completed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:02:00Z", 120),
+      stage("running", "2026-09-06T12:02:00Z", "2026-09-06T12:10:00Z", 480),
+      stage("completed", "2026-09-06T12:10:00Z", "2026-09-06T12:10:00Z", 0),
+    ],
+  });
+  const failed = overview("ws_local_failed", "failed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
+    ],
+  });
+  const destroyed = overview("ws_local_destroyed", "destroyed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:09:00Z", 480),
+      // Cleanup closes the completed stage later; workflow finish remains its start.
+      stage("completed", "2026-09-06T12:09:00Z", "2026-09-06T12:30:00Z", 1260),
+    ],
+  });
+  await mockAwfConsoleApi(page, {
+    overviewItems: [completed, failed, destroyed],
+  });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  for (const [item, finished, duration] of [
+    [completed, "2026-09-06T12:10:00Z", "10m 0s"],
+    [failed, "2026-09-06T12:08:00Z", "8m 0s"],
+    [destroyed, "2026-09-06T12:09:00Z", "9m 0s"],
+  ] as const) {
+    const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
+    await expect(card.getByTestId(`workspace-card-finished-${item.workspace_id}`)).toContainText(
+      formatDateTime(finished),
+    );
+    await expect(card.getByTestId(`workspace-card-duration-${item.workspace_id}`)).toContainText(
+      duration,
+    );
+  }
+});
+
+test("terminal cards call missing or ambiguous timing not recorded while preserving zero", async ({
+  page,
+}) => {
+  const missing = overview("ws_timing_missing", "completed", {
+    native_runtime_finished_at: "2026-09-06T12:05:00Z",
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [],
+  });
+  const invalid = overview("ws_timing_invalid", "failed", {
+    workflow_finished_at: "not-a-timestamp",
+    duration_seconds: -1,
+    lifecycle: [stage("running", "2026-09-06T12:00:00Z", "2026-09-06T12:11:00Z", 660)],
+  });
+  const missingDuration = overview("ws_duration_missing", "completed", {
+    workflow_finished_at: "2026-09-06T12:12:00Z",
+    duration_seconds: null,
+  });
+  const mismatchedDuration = overview("ws_duration_mismatch", "completed", {
+    workflow_finished_at: "2026-09-06T12:12:00Z",
+    finished_at: "2026-09-06T12:10:00Z",
+    duration_seconds: 600,
+  });
+  const lifecycleGap = overview("ws_duration_gap", "failed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("running", "2026-09-06T12:02:00Z", "2026-09-06T12:05:00Z", 180),
+    ],
+  });
+  const retryAmbiguous = overview("ws_timing_retry", "destroyed", {
+    recovery: {
+      from_state: "failed",
+      to_state: "requested",
+      reason_code: "retry",
+      action: "retry",
+      recovery_mode: null,
+      started_at: "2026-09-06T12:10:00Z",
+      current_operation: null,
+      summary: "Workflow retried.",
+      payload: null,
+    },
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
+      // A later completion no longer matches the collapsed earlier-stage lifecycle.
+      stage("completed", "2026-09-06T12:20:00Z", "2026-09-06T12:30:00Z", 600),
+    ],
+  });
+  const zero = overview("ws_timing_zero", "cancelled", {
+    workflow_finished_at: null,
+    finished_at: "2026-09-06T12:00:00Z",
+    duration_seconds: 0,
+  });
+  await mockAwfConsoleApi(page, {
+    overviewItems: [
+      missing,
+      invalid,
+      missingDuration,
+      mismatchedDuration,
+      lifecycleGap,
+      retryAmbiguous,
+      zero,
+    ],
+  });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  for (const item of [missing, invalid, retryAmbiguous]) {
+    const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
+    await expect(card.getByTestId(`workspace-card-finished-${item.workspace_id}`)).toContainText(
+      "not recorded",
+    );
+    await expect(card.getByTestId(`workspace-card-duration-${item.workspace_id}`)).toContainText(
+      "not recorded",
+    );
+  }
+
+  for (const item of [missingDuration, mismatchedDuration, lifecycleGap]) {
+    const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
+    await expect(card.getByTestId(`workspace-card-finished-${item.workspace_id}`)).not.toContainText(
+      "not recorded",
+    );
+    await expect(card.getByTestId(`workspace-card-duration-${item.workspace_id}`)).toContainText(
+      "not recorded",
+    );
+  }
+
+  const zeroCard = page.getByTestId("workspace-card-ws_timing_zero");
+  await expect(zeroCard.getByTestId("workspace-card-finished-ws_timing_zero")).not.toContainText(
+    "not recorded",
+  );
+  await expect(zeroCard.getByTestId("workspace-card-duration-ws_timing_zero")).toContainText(
+    "0s",
+  );
+});

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -107,7 +107,7 @@ for (const surface of surfaces) {
 
     for (const item of [running, monitoring]) {
       const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
-      const timing = card.getByTestId(`workspace-card-timing-${item.workspace_id}`);
+      const timing = card.getByTestId(`workspace-timing-${item.workspace_id}`);
       await expect(timing).toContainText("Created");
       await expect(timing).toContainText("Last activity");
       await expect(timing).not.toContainText("Updated");
@@ -148,16 +148,16 @@ test("hosted terminal cards use workflow finish and recorded duration for every 
 
   for (const [index, item] of terminals.entries()) {
     const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
-    const timing = card.getByTestId(`workspace-card-timing-${item.workspace_id}`);
+    const timing = card.getByTestId(`workspace-timing-${item.workspace_id}`);
     await expect(timing).toContainText("Created");
     await expect(timing).toContainText("Finished");
     await expect(timing).toContainText("Duration");
     await expect(timing).not.toContainText("Last activity");
     await expect(timing).not.toContainText("Updated");
-    await expect(card.getByTestId(`workspace-card-finished-${item.workspace_id}`)).toContainText(
+    await expect(card.getByTestId(`workspace-finished-${item.workspace_id}`)).toContainText(
       formatDateTime(item.workflow_finished_at),
     );
-    await expect(card.getByTestId(`workspace-card-duration-${item.workspace_id}`)).toContainText(
+    await expect(card.getByTestId(`workspace-duration-${item.workspace_id}`)).toContainText(
       `${20 + index}m 0s`,
     );
   }
@@ -199,10 +199,10 @@ test("local terminal cards use one complete lifecycle interval", async ({ page }
     [destroyed, "2026-09-06T12:09:00Z", "9m 0s"],
   ] as const) {
     const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
-    await expect(card.getByTestId(`workspace-card-finished-${item.workspace_id}`)).toContainText(
+    await expect(card.getByTestId(`workspace-finished-${item.workspace_id}`)).toContainText(
       formatDateTime(finished),
     );
-    await expect(card.getByTestId(`workspace-card-duration-${item.workspace_id}`)).toContainText(
+    await expect(card.getByTestId(`workspace-duration-${item.workspace_id}`)).toContainText(
       duration,
     );
   }
@@ -222,10 +222,10 @@ test("local terminal task details use the card lifecycle timing", async ({ page 
   await waitForConsoleReady(page);
 
   const card = page.getByTestId(`workspace-card-${completed.workspace_id}`);
-  await expect(card.getByTestId(`workspace-card-finished-${completed.workspace_id}`)).toContainText(
+  await expect(card.getByTestId(`workspace-finished-${completed.workspace_id}`)).toContainText(
     formatDateTime("2026-09-06T12:10:00Z"),
   );
-  await expect(card.getByTestId(`workspace-card-duration-${completed.workspace_id}`)).toContainText(
+  await expect(card.getByTestId(`workspace-duration-${completed.workspace_id}`)).toContainText(
     "10m 0s",
   );
 
@@ -321,29 +321,29 @@ test("terminal cards call missing or ambiguous timing not recorded while preserv
 
   for (const item of [missing, invalid, completedStageWithoutStart, retryAmbiguous]) {
     const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
-    await expect(card.getByTestId(`workspace-card-finished-${item.workspace_id}`)).toContainText(
+    await expect(card.getByTestId(`workspace-finished-${item.workspace_id}`)).toContainText(
       "not recorded",
     );
-    await expect(card.getByTestId(`workspace-card-duration-${item.workspace_id}`)).toContainText(
+    await expect(card.getByTestId(`workspace-duration-${item.workspace_id}`)).toContainText(
       "not recorded",
     );
   }
 
   for (const item of [missingDuration, mismatchedDuration, lifecycleGap]) {
     const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
-    await expect(card.getByTestId(`workspace-card-finished-${item.workspace_id}`)).not.toContainText(
+    await expect(card.getByTestId(`workspace-finished-${item.workspace_id}`)).not.toContainText(
       "not recorded",
     );
-    await expect(card.getByTestId(`workspace-card-duration-${item.workspace_id}`)).toContainText(
+    await expect(card.getByTestId(`workspace-duration-${item.workspace_id}`)).toContainText(
       "not recorded",
     );
   }
 
   const zeroCard = page.getByTestId("workspace-card-ws_timing_zero");
-  await expect(zeroCard.getByTestId("workspace-card-finished-ws_timing_zero")).not.toContainText(
+  await expect(zeroCard.getByTestId("workspace-finished-ws_timing_zero")).not.toContainText(
     "not recorded",
   );
-  await expect(zeroCard.getByTestId("workspace-card-duration-ws_timing_zero")).toContainText(
+  await expect(zeroCard.getByTestId("workspace-duration-ws_timing_zero")).toContainText(
     "0s",
   );
 });

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -208,6 +208,35 @@ test("local terminal cards use one complete lifecycle interval", async ({ page }
   }
 });
 
+test("local terminal task details use the card lifecycle timing", async ({ page }) => {
+  const completed = overview("ws_local_details_timing", "completed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:02:00Z", 120),
+      stage("running", "2026-09-06T12:02:00Z", "2026-09-06T12:10:00Z", 480),
+      stage("completed", "2026-09-06T12:10:00Z", "2026-09-06T12:20:00Z", 600),
+    ],
+  });
+  await mockAwfConsoleApi(page, { overviewItems: [completed] });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  const card = page.getByTestId(`workspace-card-${completed.workspace_id}`);
+  await expect(card.getByTestId(`workspace-card-finished-${completed.workspace_id}`)).toContainText(
+    formatDateTime("2026-09-06T12:10:00Z"),
+  );
+  await expect(card.getByTestId(`workspace-card-duration-${completed.workspace_id}`)).toContainText(
+    "10m 0s",
+  );
+
+  await card.getByRole("button", { name: "Details", exact: true }).click();
+  const details = page.getByRole("dialog", { name: /Task details/i });
+  const workflowFinished = details.getByText("Workflow finished", { exact: true }).locator("..");
+  await expect(workflowFinished).toContainText(formatDateTime("2026-09-06T12:10:00Z"));
+  const duration = details.getByText("Duration", { exact: true }).locator("..");
+  await expect(duration).toContainText("10m 0s");
+});
+
 test("terminal cards call missing or ambiguous timing not recorded while preserving zero", async ({
   page,
 }) => {

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -175,6 +175,7 @@ test("local terminal cards use one complete lifecycle interval", async ({ page }
     lifecycle: [
       stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
       stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
+      stage("validating", null, null, null),
     ],
   });
   const destroyed = overview("ws_local_destroyed", "destroyed", {
@@ -237,6 +238,18 @@ test("terminal cards call missing or ambiguous timing not recorded while preserv
       stage("running", "2026-09-06T12:02:00Z", "2026-09-06T12:05:00Z", 180),
     ],
   });
+  const completedStageWithoutStart = overview("ws_timing_missing_stage_start", "failed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      {
+        stage: "running",
+        started_at: null,
+        ended_at: null,
+        duration_seconds: null,
+        status: "completed",
+      },
+    ],
+  });
   const retryAmbiguous = overview("ws_timing_retry", "destroyed", {
     recovery: {
       from_state: "failed",
@@ -268,6 +281,7 @@ test("terminal cards call missing or ambiguous timing not recorded while preserv
       missingDuration,
       mismatchedDuration,
       lifecycleGap,
+      completedStageWithoutStart,
       retryAmbiguous,
       zero,
     ],
@@ -276,7 +290,7 @@ test("terminal cards call missing or ambiguous timing not recorded while preserv
   await page.goto("/");
   await waitForConsoleReady(page);
 
-  for (const item of [missing, invalid, retryAmbiguous]) {
+  for (const item of [missing, invalid, completedStageWithoutStart, retryAmbiguous]) {
     const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
     await expect(card.getByTestId(`workspace-card-finished-${item.workspace_id}`)).toContainText(
       "not recorded",

--- a/docs/CONSOLE_BACKEND_CONTRACT.md
+++ b/docs/CONSOLE_BACKEND_CONTRACT.md
@@ -78,7 +78,61 @@ Never guess mode from hostname, browser location, query strings, or failed metri
 | `*_last_window` | Terminal statuses in the rolling window by `updated_at` |
 
 **Null ≠ zero.** Incomplete fields stay `null` with `coverage.status=partial|unknown`.
-UI renders `—` and never coerces null to `0`.
+UI renders `—` and never coerces null to `0`. When the optional
+`count_evidence` object is present and valid, the UI may render a confirmed
+lower bound for a null exact count, but it visibly qualifies the value as
+`N confirmed`; it never replaces the null exact value or presents the lower
+bound as an exact total. A non-null exact count always takes precedence.
+
+### Optional count evidence
+
+`count_evidence` is an optional, nullable schema-version-1 extension. When
+non-null it has four required fields and permits no unknown fields:
+
+| Field | Contract |
+| --- | --- |
+| `total_workspaces` | Strict nonnegative integer population in the authorized project-wide snapshot |
+| `status_known_workspaces` | Strict nonnegative integer count with authoritative workflow status |
+| `status_unknown_workspaces` | Strict nonnegative integer count without authoritative workflow status |
+| `confirmed_counts` | Object containing the same ten required names as `counts`, each a strict nonnegative integer lower bound |
+
+All evidence comes from the same authorized project-wide snapshot as the
+summary. The following invariants are required:
+
+- `status_known_workspaces + status_unknown_workspaces = total_workspaces`.
+- Every confirmed counter is at most `status_known_workspaces`.
+- The documented subset, overlap, and disjoint-active constraints apply to
+  `confirmed_counts` exactly as they apply to non-null exact counts.
+- Every non-null exact counter equals its confirmed counterpart when evidence
+  is present. Null exact counters remain null.
+- `coverage.status=complete` cannot coexist with a nonzero unknown-status
+  population.
+- Missing, invalid, or stale current-attempt status is status-unknown and
+  contributes to no confirmed counter.
+- A known authoritative workflow status can still lack attention evidence or
+  the authoritative original terminal timestamp. Those counters remain
+  incomplete, and `coverage.status` plus notes continue to name the attention
+  or terminal-window gap independently of status coverage.
+- Terminal-window confirmation requires the authoritative original terminal
+  timestamp. A later observation, collection, or unrelated update timestamp
+  must not be substituted.
+- `status_unknown_workspaces=0` does not by itself upgrade overall coverage to
+  `complete`; attention, terminal-time, and other required evidence may still
+  be partial.
+
+For example, a snapshot of 29 workspaces with 24 known statuses and five
+unknown statuses may publish all ten confirmed counters as zero. The UI shows
+`0 confirmed` for null exact counters and reports
+`24 of 29 workflow statuses known; 5 unknown`. If the next same-scope snapshot
+adds one authoritative running workflow, the evidence is total 30, known 25,
+unknown five, with `active=1` and `executing=1` in `confirmed_counts`; those
+null exact counters render as `1 confirmed`.
+
+Omission and explicit null are accepted for reader compatibility. Core's local
+exact-summary producer omits the field when unused, so its existing serialized
+payload shape does not gain a null key. Shared readers that predate this
+extension continue to receive the old shape; compatible shared readers must be
+deployed before a hosted producer begins emitting evidence.
 
 A stopped **native** execution is **not** a completed overall workflow. Native
 runtime finish and workflow finish remain distinct presentation concepts.
@@ -203,9 +257,13 @@ feeds.
 ### Dashboard summary (required)
 `schema_version`, `scope`, `generated_at`, `as_of`, `last_success_at`, `window`, `coverage`, `counts`, `overlap`
 
+Optional: `count_evidence` (object or `null`, as defined above).
+
 `last_success_at` must be present. The value is an RFC 3339 timestamp or `null`
 when no fully successful summary exists yet. `coverage.status=complete` requires
 a timestamp.
 
 ### Counts
-Each count key is required on the object; values may be `number | null`.
+Each count key is required on the object; values are strict nonnegative
+`integer | null`. The ten exact fields and their meanings are unchanged by the
+optional evidence extension.

--- a/openapi.json
+++ b/openapi.json
@@ -1686,6 +1686,108 @@
         "title": "ConsoleCapabilityItemResponse",
         "type": "object"
       },
+      "ConsoleDashboardConfirmedCountsResponse": {
+        "additionalProperties": false,
+        "description": "Strict confirmed lower bounds using the exact v1 count-key inventory.",
+        "properties": {
+          "active": {
+            "minimum": 0.0,
+            "title": "Active",
+            "type": "integer"
+          },
+          "awaiting_human": {
+            "minimum": 0.0,
+            "title": "Awaiting Human",
+            "type": "integer"
+          },
+          "awaiting_operator": {
+            "minimum": 0.0,
+            "title": "Awaiting Operator",
+            "type": "integer"
+          },
+          "cancelled_last_window": {
+            "minimum": 0.0,
+            "title": "Cancelled Last Window",
+            "type": "integer"
+          },
+          "completed_last_window": {
+            "minimum": 0.0,
+            "title": "Completed Last Window",
+            "type": "integer"
+          },
+          "executing": {
+            "minimum": 0.0,
+            "title": "Executing",
+            "type": "integer"
+          },
+          "failed_last_window": {
+            "minimum": 0.0,
+            "title": "Failed Last Window",
+            "type": "integer"
+          },
+          "monitoring_pr": {
+            "minimum": 0.0,
+            "title": "Monitoring Pr",
+            "type": "integer"
+          },
+          "queued": {
+            "minimum": 0.0,
+            "title": "Queued",
+            "type": "integer"
+          },
+          "retrying": {
+            "minimum": 0.0,
+            "title": "Retrying",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "active",
+          "executing",
+          "monitoring_pr",
+          "awaiting_operator",
+          "awaiting_human",
+          "retrying",
+          "queued",
+          "completed_last_window",
+          "cancelled_last_window",
+          "failed_last_window"
+        ],
+        "title": "ConsoleDashboardConfirmedCountsResponse",
+        "type": "object"
+      },
+      "ConsoleDashboardCountEvidenceResponse": {
+        "additionalProperties": false,
+        "description": "Population coverage and confirmed lower bounds from the summary snapshot.\n\nKnown plus unknown equals total; every confirmed counter is at most the\nknown population and follows the v1 count relationships. At the summary\nlevel, every non-null exact counter equals its confirmed counterpart.",
+        "properties": {
+          "confirmed_counts": {
+            "$ref": "#/components/schemas/ConsoleDashboardConfirmedCountsResponse"
+          },
+          "status_known_workspaces": {
+            "minimum": 0.0,
+            "title": "Status Known Workspaces",
+            "type": "integer"
+          },
+          "status_unknown_workspaces": {
+            "minimum": 0.0,
+            "title": "Status Unknown Workspaces",
+            "type": "integer"
+          },
+          "total_workspaces": {
+            "minimum": 0.0,
+            "title": "Total Workspaces",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_workspaces",
+          "status_known_workspaces",
+          "status_unknown_workspaces",
+          "confirmed_counts"
+        ],
+        "title": "ConsoleDashboardCountEvidenceResponse",
+        "type": "object"
+      },
       "ConsoleDashboardCountsResponse": {
         "additionalProperties": false,
         "description": "Nullable nonnegative fleet counts as strict ints (no string/bool coerce).",
@@ -1887,6 +1989,17 @@
             "format": "date-time",
             "title": "As Of",
             "type": "string"
+          },
+          "count_evidence": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConsoleDashboardCountEvidenceResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional same-snapshot population evidence and confirmed lower bounds; semantic sibling-field invariants are enforced by producers and readers."
           },
           "counts": {
             "$ref": "#/components/schemas/ConsoleDashboardCountsResponse"

--- a/src/awf/api/routes/console.py
+++ b/src/awf/api/routes/console.py
@@ -642,6 +642,17 @@ class ConsoleDashboardCountEvidenceResponse(BaseModel):
         confirmed = self.confirmed_counts.model_dump()
         if any(value > self.status_known_workspaces for value in confirmed.values()):
             raise ValueError("every confirmed count must be <= status_known_workspaces")
+        confirmed_status_categories = (
+            confirmed["active"]
+            + confirmed["completed_last_window"]
+            + confirmed["cancelled_last_window"]
+            + confirmed["failed_last_window"]
+        )
+        if confirmed_status_categories > self.status_known_workspaces:
+            raise ValueError(
+                "sum of confirmed active and terminal status categories must be "
+                "<= status_known_workspaces"
+            )
         _validate_dashboard_count_relationships(confirmed, label="confirmed_counts")
         return self
 

--- a/src/awf/api/routes/console.py
+++ b/src/awf/api/routes/console.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Annotated, Any, Literal, Self
 
@@ -535,6 +536,116 @@ class ConsoleDashboardCountsResponse(BaseModel):
     failed_last_window: StrictInt | None = Field(ge=0)
 
 
+_DASHBOARD_COUNT_FIELDS = (
+    "active",
+    "executing",
+    "monitoring_pr",
+    "awaiting_operator",
+    "awaiting_human",
+    "retrying",
+    "queued",
+    "completed_last_window",
+    "cancelled_last_window",
+    "failed_last_window",
+)
+
+
+def _validate_dashboard_count_relationships(
+    counts: Mapping[str, int | None],
+    *,
+    label: str,
+) -> None:
+    """Enforce the shared v1 subset/disjoint rules for exacts or lower bounds."""
+    active = counts["active"]
+    executing = counts["executing"]
+    monitoring_pr = counts["monitoring_pr"]
+    awaiting_operator = counts["awaiting_operator"]
+    awaiting_human = counts["awaiting_human"]
+    retrying = counts["retrying"]
+    queued = counts["queued"]
+
+    for subset_name, subset in (
+        ("executing", executing),
+        ("monitoring_pr", monitoring_pr),
+        ("queued", queued),
+        ("awaiting_operator", awaiting_operator),
+        ("retrying", retrying),
+    ):
+        if active is not None and subset is not None and subset > active:
+            raise ValueError(f"{label}.{subset_name} must be <= {label}.active")
+    if awaiting_human is not None and monitoring_pr is not None and awaiting_human > monitoring_pr:
+        raise ValueError(f"{label}.awaiting_human must be <= {label}.monitoring_pr")
+    for disjoint_name, disjoint_count in (
+        ("awaiting_operator", awaiting_operator),
+        ("retrying", retrying),
+    ):
+        if (
+            active is not None
+            and executing is not None
+            and disjoint_count is not None
+            and disjoint_count + executing > active
+        ):
+            raise ValueError(
+                f"{label}.{disjoint_name} + {label}.executing must be <= {label}.active"
+            )
+
+    # Current active status buckets are mutually disjoint. With nullable exact
+    # counters, validate the relationship among the available parts only.
+    if active is not None:
+        disjoint_parts = [
+            value
+            for value in (executing, monitoring_pr, queued, awaiting_operator, retrying)
+            if value is not None
+        ]
+        if len(disjoint_parts) >= 2 and sum(disjoint_parts) > active:
+            raise ValueError(f"sum of disjoint {label} active status buckets must be <= active")
+
+
+class ConsoleDashboardConfirmedCountsResponse(BaseModel):
+    """Strict confirmed lower bounds using the exact v1 count-key inventory."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    active: StrictInt = Field(ge=0)
+    executing: StrictInt = Field(ge=0)
+    monitoring_pr: StrictInt = Field(ge=0)
+    awaiting_operator: StrictInt = Field(ge=0)
+    awaiting_human: StrictInt = Field(ge=0)
+    retrying: StrictInt = Field(ge=0)
+    queued: StrictInt = Field(ge=0)
+    completed_last_window: StrictInt = Field(ge=0)
+    cancelled_last_window: StrictInt = Field(ge=0)
+    failed_last_window: StrictInt = Field(ge=0)
+
+
+class ConsoleDashboardCountEvidenceResponse(BaseModel):
+    """Population coverage and confirmed lower bounds from the summary snapshot.
+
+    Known plus unknown equals total; every confirmed counter is at most the
+    known population and follows the v1 count relationships. At the summary
+    level, every non-null exact counter equals its confirmed counterpart.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_workspaces: StrictInt = Field(ge=0)
+    status_known_workspaces: StrictInt = Field(ge=0)
+    status_unknown_workspaces: StrictInt = Field(ge=0)
+    confirmed_counts: ConsoleDashboardConfirmedCountsResponse
+
+    @model_validator(mode="after")
+    def population_and_confirmed_counts_are_consistent(self) -> Self:
+        if self.status_known_workspaces + self.status_unknown_workspaces != self.total_workspaces:
+            raise ValueError(
+                "status_known_workspaces + status_unknown_workspaces must equal total_workspaces"
+            )
+        confirmed = self.confirmed_counts.model_dump()
+        if any(value > self.status_known_workspaces for value in confirmed.values()):
+            raise ValueError("every confirmed count must be <= status_known_workspaces")
+        _validate_dashboard_count_relationships(confirmed, label="confirmed_counts")
+        return self
+
+
 class ConsoleDashboardOverlapResponse(BaseModel):
     """Fixed v1 count-semantics invariants (literal true; no provider toggles).
 
@@ -561,6 +672,14 @@ class ConsoleDashboardSummaryResponse(BaseModel):
     window: ConsoleDashboardWindowResponse
     coverage: ConsoleDashboardCoverageResponse
     counts: ConsoleDashboardCountsResponse
+    count_evidence: ConsoleDashboardCountEvidenceResponse | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Optional same-snapshot population evidence and confirmed lower bounds; "
+            "semantic sibling-field invariants are enforced by producers and readers."
+        ),
+    )
     overlap: ConsoleDashboardOverlapResponse
 
     @model_validator(mode="after")
@@ -599,84 +718,24 @@ class ConsoleDashboardSummaryResponse(BaseModel):
         payloads fail closed rather than rendering impossible KPI relationships.
         """
         counts = self.counts
-        count_values = (
-            counts.active,
-            counts.executing,
-            counts.monitoring_pr,
-            counts.awaiting_operator,
-            counts.awaiting_human,
-            counts.retrying,
-            counts.queued,
-            counts.completed_last_window,
-            counts.cancelled_last_window,
-            counts.failed_last_window,
-        )
+        exact = counts.model_dump()
         # Contract: null counters require coverage.status partial|unknown.
-        if self.coverage.status == "complete" and any(value is None for value in count_values):
+        if self.coverage.status == "complete" and any(
+            exact[key] is None for key in _DASHBOARD_COUNT_FIELDS
+        ):
             raise ValueError("coverage.status complete requires all counts to be non-null")
-        if (
-            counts.active is not None
-            and counts.executing is not None
-            and counts.executing > counts.active
-        ):
-            raise ValueError("counts.executing must be <= counts.active")
-        if (
-            counts.active is not None
-            and counts.monitoring_pr is not None
-            and counts.monitoring_pr > counts.active
-        ):
-            raise ValueError("counts.monitoring_pr must be <= counts.active")
-        if (
-            counts.active is not None
-            and counts.queued is not None
-            and counts.queued > counts.active
-        ):
-            raise ValueError("counts.queued must be <= counts.active")
-        # Overlap flags are Literal[True] fixed v1 invariants; always enforce when
-        # related counts are present (null counts + partial/unknown coverage instead).
-        if (
-            counts.awaiting_human is not None
-            and counts.monitoring_pr is not None
-            and counts.awaiting_human > counts.monitoring_pr
-        ):
-            raise ValueError("counts.awaiting_human must be <= counts.monitoring_pr")
-        if counts.awaiting_operator is not None:
-            if counts.active is not None and counts.awaiting_operator > counts.active:
-                raise ValueError("counts.awaiting_operator must be <= counts.active")
-            if (
-                counts.active is not None
-                and counts.executing is not None
-                and counts.awaiting_operator + counts.executing > counts.active
-            ):
+        _validate_dashboard_count_relationships(exact, label="counts")
+        if self.count_evidence is not None:
+            evidence = self.count_evidence
+            confirmed = evidence.confirmed_counts.model_dump()
+            for key in _DASHBOARD_COUNT_FIELDS:
+                exact_value = exact[key]
+                if exact_value is not None and exact_value != confirmed[key]:
+                    raise ValueError(f"exact count counts.{key} must equal confirmed_counts.{key}")
+            if self.coverage.status == "complete" and evidence.status_unknown_workspaces != 0:
                 raise ValueError(
-                    "counts.awaiting_operator + counts.executing must be <= counts.active"
+                    "coverage.status complete requires status_unknown_workspaces to be zero"
                 )
-        if counts.retrying is not None:
-            if counts.active is not None and counts.retrying > counts.active:
-                raise ValueError("counts.retrying must be <= counts.active")
-            if (
-                counts.active is not None
-                and counts.executing is not None
-                and counts.retrying + counts.executing > counts.active
-            ):
-                raise ValueError("counts.retrying + counts.executing must be <= counts.active")
-        # Combined disjoint active status buckets: pairwise checks miss cases
-        # like active=3 with executing=monitoring_pr=awaiting_operator=retrying=1.
-        # queued (requested) is always a distinct non-terminal status ⊆ active.
-        if counts.active is not None:
-            disjoint_parts: list[int] = []
-            if counts.executing is not None:
-                disjoint_parts.append(counts.executing)
-            if counts.monitoring_pr is not None:
-                disjoint_parts.append(counts.monitoring_pr)
-            if counts.queued is not None:
-                disjoint_parts.append(counts.queued)
-            if counts.awaiting_operator is not None:
-                disjoint_parts.append(counts.awaiting_operator)
-            if counts.retrying is not None:
-                disjoint_parts.append(counts.retrying)
-            if len(disjoint_parts) >= 2 and sum(disjoint_parts) > counts.active:
-                raise ValueError("sum of disjoint active status buckets must be <= counts.active")
         return self
 
 

--- a/tests/unit/api/test_console_dashboard_summary.py
+++ b/tests/unit/api/test_console_dashboard_summary.py
@@ -11,7 +11,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 from httpx import AsyncClient
+from jsonschema import Draft202012Validator
 from pydantic import ValidationError
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.api.routes.console import ConsoleDashboardSummaryResponse
@@ -21,10 +24,77 @@ from awf.db.session import make_session_factory
 from tests.unit.helpers import create_workspace
 
 _FIXTURES = Path(__file__).resolve().parents[3] / "docs" / "console" / "fixtures" / "v1"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_OPENAPI_JSON = _REPO_ROOT / "openapi.json"
+_COUNT_KEYS = (
+    "active",
+    "executing",
+    "monitoring_pr",
+    "awaiting_operator",
+    "awaiting_human",
+    "retrying",
+    "queued",
+    "completed_last_window",
+    "cancelled_last_window",
+    "failed_last_window",
+)
 
 
 def _dashboard_summary_payload() -> dict[str, Any]:
     return json.loads((_FIXTURES / "dashboard-summary.local.json").read_text(encoding="utf-8"))
+
+
+def _zero_confirmed_counts() -> dict[str, int]:
+    return dict.fromkeys(_COUNT_KEYS, 0)
+
+
+def _summary_with_count_evidence(
+    *,
+    total: int = 29,
+    known: int = 24,
+    unknown: int = 5,
+    confirmed_patch: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    payload = _dashboard_summary_payload()
+    payload["coverage"] = {"status": "partial", "notes": ["workflow_status_incomplete"]}
+    payload["counts"] = dict.fromkeys(_COUNT_KEYS, None)
+    confirmed = _zero_confirmed_counts()
+    confirmed.update(confirmed_patch or {})
+    payload["count_evidence"] = {
+        "total_workspaces": total,
+        "status_known_workspaces": known,
+        "status_unknown_workspaces": unknown,
+        "confirmed_counts": confirmed,
+    }
+    return payload
+
+
+def _rewrite_component_refs(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        if "$ref" in obj:
+            ref = obj["$ref"]
+            assert isinstance(ref, str)
+            assert ref.startswith("#/components/schemas/")
+            return {"$ref": f"urn:awf:schemas/{ref.rsplit('/', 1)[-1]}"}
+        return {key: _rewrite_component_refs(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_rewrite_component_refs(item) for item in obj]
+    return obj
+
+
+def _dashboard_summary_openapi_validator() -> Draft202012Validator:
+    spec = json.loads(_OPENAPI_JSON.read_text(encoding="utf-8"))
+    schemas = spec["components"]["schemas"]
+    rewritten = {
+        f"urn:awf:schemas/{name}": Resource(
+            contents=_rewrite_component_refs(schema),
+            specification=DRAFT202012,
+        )
+        for name, schema in schemas.items()
+    }
+    registry = Registry().with_resources(rewritten.items())
+    root = _rewrite_component_refs(copy.deepcopy(schemas["ConsoleDashboardSummaryResponse"]))
+    return Draft202012Validator(root, registry=registry)
 
 
 @pytest.mark.unit
@@ -113,6 +183,7 @@ async def test_dashboard_summary_independent_of_capacity(
     assert body["overlap"]["awaiting_operator_in_active_not_executing"] is True
     assert body["window"]["anchor"] == "generated_at"
     assert body["window"]["since_hours"] == 24
+    assert "count_evidence" not in body
     docker_probe.assert_not_called()
 
 
@@ -178,6 +249,215 @@ async def test_dashboard_summary_null_not_zero_on_partial(
     assert body["counts"]["cancelled_last_window"] is None
     assert "queued" in body["counts"]
     assert body["counts"]["failed_last_window"] == 0
+
+
+@pytest.mark.unit
+def test_dashboard_summary_count_evidence_is_optional_nullable_and_omitted_when_unused() -> None:
+    payload = _dashboard_summary_payload()
+    absent = ConsoleDashboardSummaryResponse.model_validate(payload)
+    assert absent.count_evidence is None
+    assert "count_evidence" not in absent.model_dump(mode="json")
+
+    payload["count_evidence"] = None
+    explicit_null = ConsoleDashboardSummaryResponse.model_validate(payload)
+    assert explicit_null.count_evidence is None
+    assert "count_evidence" not in explicit_null.model_dump(mode="json")
+
+
+@pytest.mark.unit
+def test_dashboard_summary_accepts_confirmed_lower_bound_examples() -> None:
+    all_zero = ConsoleDashboardSummaryResponse.model_validate(_summary_with_count_evidence())
+    assert all_zero.count_evidence is not None
+    assert all_zero.count_evidence.total_workspaces == 29
+    assert all_zero.count_evidence.status_known_workspaces == 24
+    assert all_zero.count_evidence.status_unknown_workspaces == 5
+    assert all_zero.count_evidence.confirmed_counts.active == 0
+
+    running_payload = _summary_with_count_evidence(
+        total=30,
+        known=25,
+        unknown=5,
+        confirmed_patch={"active": 1, "executing": 1},
+    )
+    running = ConsoleDashboardSummaryResponse.model_validate(running_payload)
+    assert running.count_evidence is not None
+    assert running.count_evidence.confirmed_counts.active == 1
+    assert running.count_evidence.confirmed_counts.executing == 1
+    assert running.counts.active is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("object_name", ["count_evidence", "confirmed_counts"])
+def test_dashboard_summary_count_evidence_rejects_unknown_object_keys(object_name: str) -> None:
+    payload = _summary_with_count_evidence()
+    target = payload["count_evidence"]
+    if object_name == "confirmed_counts":
+        target = target["confirmed_counts"]
+    target["unpublished_field"] = 0
+    with pytest.raises(ValidationError):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("object_name", "required_key"),
+    [
+        ("count_evidence", "total_workspaces"),
+        ("count_evidence", "status_known_workspaces"),
+        ("count_evidence", "status_unknown_workspaces"),
+        ("count_evidence", "confirmed_counts"),
+        *(("confirmed_counts", key) for key in _COUNT_KEYS),
+    ],
+)
+def test_dashboard_summary_count_evidence_rejects_missing_required_fields(
+    object_name: str,
+    required_key: str,
+) -> None:
+    payload = _summary_with_count_evidence()
+    target = payload["count_evidence"]
+    if object_name == "confirmed_counts":
+        target = target["confirmed_counts"]
+    del target[required_key]
+    with pytest.raises(ValidationError):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("invalid", ["1", True, -1, 1.5])
+@pytest.mark.parametrize(
+    "field_path",
+    [
+        ("total_workspaces",),
+        ("status_known_workspaces",),
+        ("status_unknown_workspaces",),
+        ("confirmed_counts", "active"),
+    ],
+)
+def test_dashboard_summary_count_evidence_rejects_non_strict_nonnegative_integers(
+    field_path: tuple[str, ...],
+    invalid: object,
+) -> None:
+    payload = _summary_with_count_evidence()
+    target = payload["count_evidence"]
+    for key in field_path[:-1]:
+        target = target[key]
+    target[field_path[-1]] = invalid
+    with pytest.raises(ValidationError):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_dashboard_summary_count_evidence_rejects_population_contradictions() -> None:
+    bad_sum = _summary_with_count_evidence(total=30, known=24, unknown=5)
+    with pytest.raises(ValidationError, match="known.*unknown.*total"):
+        ConsoleDashboardSummaryResponse.model_validate(bad_sum)
+
+    above_known = _summary_with_count_evidence(confirmed_patch={"active": 25})
+    with pytest.raises(ValidationError, match="confirmed.*known"):
+        ConsoleDashboardSummaryResponse.model_validate(above_known)
+
+    complete_with_unknown_status = _summary_with_count_evidence(total=1, known=0, unknown=1)
+    complete_with_unknown_status["coverage"] = {"status": "complete", "notes": []}
+    complete_with_unknown_status["counts"] = _zero_confirmed_counts()
+    with pytest.raises(ValidationError, match="complete.*unknown"):
+        ConsoleDashboardSummaryResponse.model_validate(complete_with_unknown_status)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "confirmed_patch",
+    [
+        {"active": 1, "executing": 2},
+        {"active": 1, "monitoring_pr": 2, "awaiting_human": 0},
+        {"active": 1, "queued": 2},
+        {"active": 2, "monitoring_pr": 1, "awaiting_human": 2},
+        {"active": 2, "executing": 2, "awaiting_operator": 1},
+        {"active": 2, "executing": 2, "retrying": 1},
+        {
+            "active": 3,
+            "executing": 1,
+            "monitoring_pr": 1,
+            "awaiting_operator": 1,
+            "retrying": 1,
+        },
+        {"active": 1, "executing": 1, "queued": 1},
+    ],
+)
+def test_dashboard_summary_count_evidence_rejects_relationship_contradictions(
+    confirmed_patch: dict[str, int],
+) -> None:
+    payload = _summary_with_count_evidence(confirmed_patch=confirmed_patch)
+    with pytest.raises(ValidationError):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("count_key", _COUNT_KEYS)
+def test_dashboard_summary_count_evidence_rejects_exact_count_mismatch(count_key: str) -> None:
+    payload = _summary_with_count_evidence()
+    payload["counts"][count_key] = 1
+    with pytest.raises(ValidationError, match="exact.*confirmed"):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_dashboard_summary_count_evidence_keeps_coverage_reasons_independent() -> None:
+    payload = _summary_with_count_evidence(total=1, known=1, unknown=0)
+    payload["coverage"]["notes"] = [
+        "terminal_timestamp_unavailable",
+        "attention_evidence_unavailable",
+    ]
+    payload["counts"].update(_zero_confirmed_counts())
+    payload["counts"]["completed_last_window"] = None
+    payload["counts"]["awaiting_human"] = None
+    model = ConsoleDashboardSummaryResponse.model_validate(payload)
+    assert model.coverage.status == "partial"
+    assert model.count_evidence is not None
+    assert model.count_evidence.status_unknown_workspaces == 0
+    assert model.counts.completed_last_window is None
+    assert model.counts.awaiting_human is None
+    assert model.coverage.notes == [
+        "terminal_timestamp_unavailable",
+        "attention_evidence_unavailable",
+    ]
+
+
+@pytest.mark.unit
+def test_dashboard_summary_openapi_exposes_strict_optional_count_evidence() -> None:
+    validator = _dashboard_summary_openapi_validator()
+    legacy = _dashboard_summary_payload()
+    assert not list(validator.iter_errors(legacy))
+
+    explicit_null = copy.deepcopy(legacy)
+    explicit_null["count_evidence"] = None
+    assert not list(validator.iter_errors(explicit_null))
+
+    valid = _summary_with_count_evidence()
+    assert not list(validator.iter_errors(valid))
+
+    malformed_payloads: list[dict[str, Any]] = []
+    for field_path, invalid in (
+        (("total_workspaces",), "29"),
+        (("status_known_workspaces",), True),
+        (("status_unknown_workspaces",), -1),
+        (("confirmed_counts", "active"), 0.5),
+    ):
+        payload = _summary_with_count_evidence()
+        target = payload["count_evidence"]
+        for key in field_path[:-1]:
+            target = target[key]
+        target[field_path[-1]] = invalid
+        malformed_payloads.append(payload)
+
+    missing = _summary_with_count_evidence()
+    del missing["count_evidence"]["confirmed_counts"]["queued"]
+    malformed_payloads.append(missing)
+    extra = _summary_with_count_evidence()
+    extra["count_evidence"]["extra"] = 0
+    malformed_payloads.append(extra)
+
+    for malformed in malformed_payloads:
+        assert list(validator.iter_errors(malformed))
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_console_dashboard_summary.py
+++ b/tests/unit/api/test_console_dashboard_summary.py
@@ -356,6 +356,17 @@ def test_dashboard_summary_count_evidence_rejects_population_contradictions() ->
     with pytest.raises(ValidationError, match="confirmed.*known"):
         ConsoleDashboardSummaryResponse.model_validate(above_known)
 
+    disjoint_statuses_above_known = _summary_with_count_evidence(
+        confirmed_patch={
+            "active": 20,
+            "completed_last_window": 10,
+            "cancelled_last_window": 10,
+            "failed_last_window": 10,
+        }
+    )
+    with pytest.raises(ValidationError, match="status categories.*known"):
+        ConsoleDashboardSummaryResponse.model_validate(disjoint_statuses_above_known)
+
     complete_with_unknown_status = _summary_with_count_evidence(total=1, known=0, unknown=1)
     complete_with_unknown_status["coverage"] = {"status": "complete", "notes": []}
     complete_with_unknown_status["counts"] = _zero_confirmed_counts()

--- a/tests/unit/contracts/test_console_contract_fixtures.py
+++ b/tests/unit/contracts/test_console_contract_fixtures.py
@@ -51,8 +51,12 @@ def test_capabilities_fixtures_validate(name: str) -> None:
 )
 def test_dashboard_summary_fixtures_validate(name: str) -> None:
     payload = _load(name)
+    assert isinstance(payload, dict)
+    assert "count_evidence" not in payload
     model = ConsoleDashboardSummaryResponse.model_validate(payload)
     assert model.schema_version == 1
+    assert model.count_evidence is None
+    assert "count_evidence" not in model.model_dump(mode="json")
     if name.endswith("no-prior-success.json"):
         assert model.coverage.status == "partial"
         assert model.last_success_at is None

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_fix_pass_parts/test_pr_monitor_pre_push_validation_fix_pass_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_fix_pass_parts/test_pr_monitor_pre_push_validation_fix_pass_part_005.py
@@ -349,6 +349,7 @@ async def test_pre_push_validation_fix_pass_timeout_head_probe_is_bounded_best_e
         message="tagged process still running",
     )
     cleanup_error.agent_reason_code = "AGENT_TIMEOUT"
+    probe_started = asyncio.Event()
 
     async def _run_agent_with_recovery(**_kwargs: object) -> None:
         raise cleanup_error
@@ -357,6 +358,7 @@ async def test_pre_push_validation_fix_pass_timeout_head_probe_is_bounded_best_e
         return fix_start_head
 
     async def _verify_head_object_exists(_worktree_path: Path) -> bool:
+        probe_started.set()
         if probe_failure == "raises":
             raise OSError("cannot spawn git")
         if probe_failure == "cancels":
@@ -386,27 +388,31 @@ async def test_pre_push_validation_fix_pass_timeout_head_probe_is_bounded_best_e
     expected_exception = (
         asyncio.CancelledError if probe_failure == "cancels" else ComposeExecCleanupError
     )
-    with pytest.raises(expected_exception) as raised:
-        await asyncio.wait_for(
-            pre_push_validation._run_pre_push_validation_fix_pass(
-                runner,
-                workspace_id=workspace_id,
-                compose_project="proj",
-                compose_file=tmp_path / "compose.yml",
-                remote_branch="codex/pr",
-                remote_url=None,
-                state=None,
-                validation_result=_failed_validation_result(
-                    pre_push_validation,
-                    tmp_path,
-                    workspace_head_sha=fix_start_head,
-                ),
-                pass_number=1,
-                total_passes=1,
-                validation_commands=("pytest -q",),
+    fix_pass_task = asyncio.create_task(
+        pre_push_validation._run_pre_push_validation_fix_pass(
+            runner,
+            workspace_id=workspace_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            remote_branch="codex/pr",
+            remote_url=None,
+            state=None,
+            validation_result=_failed_validation_result(
+                pre_push_validation,
+                tmp_path,
+                workspace_head_sha=fix_start_head,
             ),
-            timeout=0.5,
+            pass_number=1,
+            total_passes=1,
+            validation_commands=("pytest -q",),
         )
+    )
+    # Give unrelated setup and database scheduling their own generous guard.
+    # The tight bound below begins only when the preservation probe actually
+    # starts, which keeps this assertion meaningful under loaded CI shards.
+    await asyncio.wait_for(probe_started.wait(), timeout=5.0)
+    with pytest.raises(expected_exception) as raised:
+        await asyncio.wait_for(fix_pass_task, timeout=0.5)
 
     if probe_failure != "cancels":
         assert raised.value is cleanup_error


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_4ed1d7e7354b4cf0bd6b2e58` (agent: `codex`, model: `gpt-5.6-sol`, effort: `xhigh`).


### Task
Environment: /workspace is the public agent-workspace-fabric repository. Use its existing .awf/workspace.yml, dependency setup and validation; no overrides. This is only the shared console consumer/contract half of a narrow post-deployment Fleet health correction. Cloud backend is a separate repository; do not implement SQL/GKE/tenant aggregation here. Git is functional in /workspace. Commit necessary changes before exiting. Do not push: AWF owns push, PR creation and review monitoring.

Evidence: deployed Core main7f70cca75be94d158e231118c1acbc689ce1e2e3 and Cloud main2764cae4720b4bebfa447a05d94e43d3b5d95777. Production Cloud observation collector is healthy (read-only check2026-09-11 13:52UTC, generation3882). It scans29 project records:24 authoritative workflow statuses,5 legacy native runtimes with no workflow authority/phase/PR evidence. Cloud console_projection.py makes ALL10 exact counts null when any status is incomplete. Shared console renders those nulls as dashes. Synthetic test using actual deployed Cloud projection:24 known old-terminal records=>all0; add5unknown=>allnull; add1knownrunning=>stillallnull. Missing history must stay unknown but it must not hide all confirmed activity forever. PR958/631 and deployment are DONE. Do not reopen their broad work or change lifecycle semantics.

Implement one optional backend-neutral evidence extension to the existing v1 dashboard-summary contract, with strict TDD. Existing exact counts remain int-or-null, unchanged. Add optional count_evidence (absent/null supported) with required strict nonnegative integer total_workspaces, status_known_workspaces, status_unknown_workspaces; and required confirmed_counts containing the SAME ten field names as counts, each a strict nonnegative integer. Example: total29, known24, unknown5, confirmed_counts all0. With a new knownrunning row: total30, known25, unknown5, confirmed active1/executing1. Confirmed values are lower bounds from the same project-wide snapshot, NOT exact totals. Cloud will implement the producer after the operator audits this actual contract.

Semantics and validation: known+unknown=total. Each confirmed counter <=known population. Apply existing overlap/subset/disjoint-active constraints to confirmed counters. Every non-null exact counter must equal its confirmed counterpart when evidence is provided. Reject contradiction, coerced strings/bools, negative/fractional numbers, missing required fields or unknown object keys consistently across Python, checked-in generated OpenAPI and TypeScript. Existing scope/window/coverage/last-success invariants remain. Partial coverage can have known workflow status with missing terminal time or attention: preserve existing notes; do not infer complete coverage from unknown-status-count0. Missing/invalid/stale current-attempt status never contributes to confirmed counts; terminal-window evidence needs its authoritative original timestamp. Document these producer semantics in the existing backend contract document. No Cloud field names/IDs/GCP libraries in Core.

Shared UI: prefer exact count when non-null. Otherwise, only if valid count_evidence is present, render the confirmed number WITH visible qualifier (e.g. '1 confirmed', '0 confirmed') and an accessible hint that project total is incomplete. Never show a naked lower-bound0 as exact zero or replace null exact totals internally. Alongside coverage reasons show concise quantitative coverage such as '24 of 29 workflow statuses known; 5 unknown'. Unknown status vs incomplete attention/window evidence must remain distinguishable. Missing optional evidence retains current honest dash/error behavior. Keep stale status, last-success, auth/revocation clearing and tenant scope checks. No new fetch, no page-size aggregation, no hostname sniffing. This should primarily touch lib/console-dashboard-summary.ts, lib/types.ts and the existing overview rendering; do not refactor dashboard hooks or scrolling.

Compatibility: this is a reader-first optional extension on schema_version1, not a separate Cloud UI, new capability version, endpoint or polling loop. Existing local exact summary payload/serialization must remain compatible when count_evidence is unused (avoid accidentally emitting newly added null keys to old consumers). Old Cloud summaries with no evidence still parse. Operator will deploy compatible shared reader BEFORE Cloud starts emitting count_evidence. No production deployments from this workspace.

Tests: first failing Python/schema/TS tests for matching optional extension and contradictory inputs; exact zero vs qualified confirmed zero/positive; unchanged old payload; missing evidence notzero; known status but missing time/attention; coverage reasons; partial/stale/error state; scope/auth-revocation. Use actual generated Core schema/DTO, not independently invented schema mocks. Focused desktop/mobile browser tests for visible labels/coverage and no text overlap. Keep existing local exact fleet rendering and bounded list/inspector performance unchanged. Bounded parallel targeted tests during development; normal repo CI remains authoritative for full suite. No skips, timeout inflation, coverage threshold or CI weakening.

Scope boundary: summary contracts/parsing/presentation, focused tests, generated openapi.json and existing docs/CONSOLE_BACKEND_CONTRACT.md ONLY. No runtime, scheduler, monitor, lifecycle, GKE, dependencies, packaging, CI/profile changes, broad extraction/refactor or telemetry. Save local plan/validation as required; never stage plans/*_PLAN.md or plans/*_VALIDATION.md. In PR report exact changed contract, red/green evidence, payload example and old/new consumer compatibility. Follow-up Cloud producer is separate and not your task.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared dashboard-summary parsing and fleet KPI presentation; bugs could misstate counts or timing, though strict validation rejects contradictory evidence payloads.
> 
> **Overview**
> Adds an optional **`count_evidence`** block to the v1 **dashboard-summary** contract (TypeScript parser, Python DTOs, OpenAPI, backend contract docs). When exact **`counts`** are null under partial coverage, fleet KPIs can show **confirmed lower bounds** (e.g. `1 confirmed`) with hints that the project total is incomplete; exact non-null values still win. Coverage banners can include **known vs unknown workflow status** totals (e.g. `24 of 29 workflow statuses known`).
> 
> **Workspace cards** and the **task details** modal share a new **`resolveWorkflowTiming`** helper: **terminal** workspaces show **Finished** and **Duration** (with honest `not recorded` fallbacks); active rows show **Last activity** instead of **Updated** on the card. Lifecycle-derived timing is used for local summaries when explicit fields are missing or ambiguous.
> 
> Playwright and unit tests cover count evidence, KPI qualification, card timing, and inspector layout; a few unrelated test stability tweaks are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00b87a9f2efe4a9fd71d01e5d7a8a5dad1d33ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->