### PR TITLE
Release: merge development into main

### DIFF
--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -39,7 +39,11 @@ useRef,
 useState
 } from "react";
 
-import { formatAgentLabel,formatAgentTitle } from "@/lib/agent-format";
+import {
+formatAgentLabel,
+formatAgentTitle,
+resolveWorkflowTiming
+} from "@/lib/agent-format";
 import {
   displayedTaskKey,
   MAX_FULLSCREEN_LOG_WORKSPACES,
@@ -59,6 +63,7 @@ compactDuration,
 compactId,
 formatDateTime,
 lifecycleStages,
+recordedDurationLabel,
 relativeTime,
 toneClass,
 type StatusTone
@@ -68,6 +73,7 @@ import {
 formatRecoveryBadge
 } from "@/lib/recovery-format";
 import type {
+ConsoleDashboardCountEvidence,
 WorkspaceOverview
 } from "@/lib/types";
 import {
@@ -258,12 +264,14 @@ export function FleetHealthStrip({
   lastSuccessAt,
   coverageStatus,
   coverageNotes,
+  countEvidence,
 }: {
   kpis: FleetKpi[];
   error?: string | null;
   lastSuccessAt?: string | null;
   coverageStatus?: "complete" | "partial" | "unknown" | null;
   coverageNotes?: readonly string[] | null;
+  countEvidence?: ConsoleDashboardCountEvidence | null;
 }) {
   const anyStale = kpis.some((kpi) => kpi.stale);
   // HTTP 200 can still be incomplete. Do not treat partial/unknown as a request
@@ -271,6 +279,7 @@ export function FleetHealthStrip({
   // look fully current either.
   const coverageNotice = formatDashboardCoverageNotice(
     coverageStatus ? { status: coverageStatus, notes: coverageNotes ?? [] } : null,
+    countEvidence,
   );
   return (
     <div className="border-b border-line bg-canvas px-4 py-3" aria-label="Fleet health">
@@ -737,6 +746,13 @@ type WorkspaceCardProps = {
   onCopy: (event: SyntheticEvent<HTMLElement>, workspaceId: string) => void;
 };
 
+const TERMINAL_WORKSPACE_CARD_STATUSES = new Set<WorkspaceOverview["status"]>([
+  "completed",
+  "failed",
+  "cancelled",
+  "destroyed",
+]);
+
 const WorkspaceCard = memo(function WorkspaceCard({
   item,
   selected,
@@ -757,6 +773,8 @@ const WorkspaceCard = memo(function WorkspaceCard({
     ? attentionAgeSeconds(attentionSince(item))
     : null;
   const taskKey = displayedTaskKey(item);
+  const terminal = TERMINAL_WORKSPACE_CARD_STATUSES.has(item.status);
+  const terminalTiming = terminal ? resolveWorkflowTiming(item) : null;
   return (
     <div
       data-testid={`workspace-card-${item.workspace_id}`}
@@ -818,14 +836,32 @@ const WorkspaceCard = memo(function WorkspaceCard({
                         </span>
                       ) : null}
                     </span>
-                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-slate-500">
-                      <span>created {formatDateTime(item.created_at)}</span>
-                      <span>updated {formatDateTime(item.updated_at)}</span>
-                      {item.last_activity_at ? (
+                    <div
+                      className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-slate-500"
+                      data-testid={`workspace-timing-${item.workspace_id}`}
+                    >
+                      <span>Created {formatDateTime(item.created_at)}</span>
+                      {terminal ? (
+                        <>
+                          <span data-testid={`workspace-finished-${item.workspace_id}`}>
+                            Finished{" "}
+                            {terminalTiming?.finishedAt
+                              ? formatDateTime(terminalTiming.finishedAt)
+                              : "not recorded"}
+                          </span>
+                          <span data-testid={`workspace-duration-${item.workspace_id}`}>
+                            Duration{" "}
+                            {recordedDurationLabel(terminalTiming?.durationSeconds) ?? "not recorded"}
+                          </span>
+                        </>
+                      ) : (
                         <span data-testid={`workspace-last-activity-${item.workspace_id}`}>
-                          activity {formatDateTime(item.last_activity_at)}
+                          Last activity{" "}
+                          {item.last_activity_at
+                            ? formatDateTime(item.last_activity_at)
+                            : "not recorded"}
                         </span>
-                      ) : null}
+                      )}
                     </div>
                     <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-600">
                       <Bot size={13} aria-hidden className="shrink-0" />

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -66,20 +66,15 @@ formatDateTime,
 lifecycleStages,
 recordedDurationLabel,
 relativeTime,
-toneClass,
-type StatusTone
+toneClass, type StatusTone
 } from "@/lib/format";
 import type { OperatorPreferences } from "@/lib/operator-preferences";
 import {
 formatRecoveryBadge
 } from "@/lib/recovery-format";
-import type {
-ConsoleDashboardCountEvidence,
-WorkspaceOverview
-} from "@/lib/types";
+import type { ConsoleDashboardCountEvidence, WorkspaceOverview } from "@/lib/types";
 import {
-Badge,
-KpiStat,
+Badge, KpiStat,
 SmallExternalAnchor,
 SortDirection,
 WorkspaceSortKey,
@@ -704,6 +699,7 @@ export const WORKSPACE_RENDER_WINDOW_SIZE = 100;
 export const WORKSPACE_RENDER_OVERSCAN_ROWS = 2;
 export const WORKSPACE_HISTORY_SCROLL_THRESHOLD_PX = 240;
 const WORKSPACE_RENDER_ROW_HEIGHT_ESTIMATE_PX = 240;
+const WORKSPACE_LIST_TOP_EDGE_TOLERANCE_PX = 0.5;
 
 function workspaceRowAtOffset(rowOffsets: readonly number[], offset: number): number {
   let low = 0;
@@ -1016,6 +1012,7 @@ export function WorkspaceList({
   const nearBottomTriggeredRef = useRef(false);
   const previousSelectedIdRef = useRef<string | null>(null);
   const selectedWasLoadedRef = useRef(false);
+  const selectionOwnsScrollAnchorRef = useRef(false);
   const committedListGeometryRef = useRef<{
     workspaceIds: readonly string[];
     rowOffsets: readonly number[];
@@ -1064,6 +1061,12 @@ export function WorkspaceList({
       previous.workspaceIds.some((workspaceId, index) => workspaceId !== workspaceIds[index]);
     const scrollContainer = scrollContainerRef.current;
     if (!membershipChanged || !scrollContainer || previous.workspaceIds.length === 0) return;
+    if (scrollContainer.scrollTop <= WORKSPACE_LIST_TOP_EDGE_TOLERANCE_PX) {
+      setPageStart(0);
+      setWindowStart(0);
+      scrollWithoutLoading(0);
+      return;
+    }
 
     const previousAnchorIndex = workspaceRowAtOffset(
       previous.rowOffsets,
@@ -1114,6 +1117,7 @@ export function WorkspaceList({
     const selectedIndex = selectedId
       ? items.findIndex((item) => item.workspace_id === selectedId)
       : -1;
+    const selectionChanged = selectedId !== previousSelectedIdRef.current;
     const selectedBecameLoaded =
       selectedIndex >= 0 &&
       selectedId === previousSelectedIdRef.current &&
@@ -1121,6 +1125,9 @@ export function WorkspaceList({
     const shouldFollowSelection =
       selectedIndex >= 0 &&
       (selectedId !== previousSelectedIdRef.current || selectedBecameLoaded);
+    if (selectionChanged || selectedIndex < 0) {
+      selectionOwnsScrollAnchorRef.current = false;
+    }
     previousSelectedIdRef.current = selectedId;
     selectedWasLoadedRef.current = selectedIndex >= 0;
     const scrollContainer = scrollContainerRef.current;
@@ -1134,6 +1141,14 @@ export function WorkspaceList({
       const viewportEnd = viewportStart + scrollContainer.clientHeight - controlsHeight;
       return selectedRowEnd > viewportStart && selectedRowStart < viewportEnd;
     })();
+    if (shouldFollowSelection && scrollContainer) {
+      const selectionOwnsScrollAnchor = !selectedIsVisible ||
+        Math.abs(scrollContainer.scrollTop - selectedRowStart) <= WORKSPACE_LIST_TOP_EDGE_TOLERANCE_PX;
+      selectionOwnsScrollAnchorRef.current = selectionOwnsScrollAnchor;
+      if (selectionOwnsScrollAnchor) {
+        preserveScrollTopRef.current = null;
+      }
+    }
     const selectedWindowStart = shouldFollowSelection && !selectedIsVisible
       ? Math.floor(selectedIndex / WORKSPACE_RENDER_WINDOW_SIZE) *
         WORKSPACE_RENDER_WINDOW_SIZE
@@ -1229,7 +1244,11 @@ export function WorkspaceList({
       preserveScrollTopRef.current;
     preserveScrollTopRef.current = null;
     if (scrollTop !== null) {
-      scrollWithoutLoading(scrollTop);
+      const scrollContainer = scrollContainerRef.current;
+      const atTop =
+        scrollContainer !== null &&
+        scrollContainer.scrollTop <= WORKSPACE_LIST_TOP_EDGE_TOLERANCE_PX;
+      scrollWithoutLoading(atTop ? 0 : scrollTop);
     }
   }, [items, rowOffsets, scrollWithoutLoading]);
 
@@ -1315,6 +1334,14 @@ export function WorkspaceList({
     );
 
     if (suppressScrollLoadRef.current) return;
+    selectionOwnsScrollAnchorRef.current = false;
+    if (
+      preserveScrollTopRef.current !== null &&
+      Math.abs(element.scrollTop - preserveScrollTopRef.current) >
+        WORKSPACE_LIST_TOP_EDGE_TOLERANCE_PX
+    ) {
+      preserveScrollTopRef.current = null;
+    }
     const remaining = element.scrollHeight - element.scrollTop - element.clientHeight;
     if (remaining > WORKSPACE_HISTORY_SCROLL_THRESHOLD_PX) {
       nearBottomTriggeredRef.current = false;
@@ -1341,10 +1368,12 @@ export function WorkspaceList({
         suppressNextButtonLoadRef.current = true;
       }
     }
-  }, [hasMore, items.length, loadingMore, maxPageStart, maxWindowStart, requestHistoryPage, rowOffsets]);
+  }, [hasMore, items, loadingMore, maxPageStart, maxWindowStart, requestHistoryPage, rowOffsets]);
 
   const showWindow = useCallback((nextStart: number) => {
     const boundedStart = Math.max(0, Math.min(nextStart, maxPageStart));
+    selectionOwnsScrollAnchorRef.current = false;
+    preserveScrollTopRef.current = null;
     setPageStart(boundedStart);
     setWindowStart(Math.min(boundedStart, maxWindowStart));
     scrollWithoutLoading(rowOffsets[boundedStart] ?? 0);

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -42,6 +42,7 @@ useState
 import {
 formatAgentLabel,
 formatAgentTitle,
+hasTerminalWorkflowTiming,
 resolveWorkflowTiming
 } from "@/lib/agent-format";
 import {
@@ -746,13 +747,6 @@ type WorkspaceCardProps = {
   onCopy: (event: SyntheticEvent<HTMLElement>, workspaceId: string) => void;
 };
 
-const TERMINAL_WORKSPACE_CARD_STATUSES = new Set<WorkspaceOverview["status"]>([
-  "completed",
-  "failed",
-  "cancelled",
-  "destroyed",
-]);
-
 const WorkspaceCard = memo(function WorkspaceCard({
   item,
   selected,
@@ -773,7 +767,7 @@ const WorkspaceCard = memo(function WorkspaceCard({
     ? attentionAgeSeconds(attentionSince(item))
     : null;
   const taskKey = displayedTaskKey(item);
-  const terminal = TERMINAL_WORKSPACE_CARD_STATUSES.has(item.status);
+  const terminal = hasTerminalWorkflowTiming(item);
   const terminalTiming = terminal ? resolveWorkflowTiming(item) : null;
   return (
     <div

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -29,6 +29,7 @@ formatRequestedEffort,
 formatRequestedModel,
 mergeWorkspacePresentationFields,
 resolveWorkflowFinishedAt,
+resolveWorkflowTiming,
 } from "@/lib/agent-format";
 import { displayedTaskKey } from "@/lib/console-dashboard-derived";
 import {
@@ -115,9 +116,10 @@ export function TaskDetailsModal({
 }) {
   const labelId = `task-details-label-${workspace.workspace_id}`;
   const titleId = `task-details-title-${workspace.workspace_id}`;
-  const workflowFinishedAt = resolveWorkflowFinishedAt(workspace);
+  const workflowTiming = resolveWorkflowTiming(workspace);
+  const workflowFinishedAt = workflowTiming.finishedAt;
   const finishedAt = distinctFinishedAt(workspace);
-  const recordedDuration = recordedDurationLabel(workspace.duration_seconds);
+  const recordedDuration = recordedDurationLabel(workflowTiming.durationSeconds);
   const taskKey = displayedTaskKey(workspace);
 
   useIsomorphicLayoutEffect(() => {
@@ -575,7 +577,7 @@ export function WorkspaceSummary({
         </div>
       }
     >
-      <div className="grid min-w-0 gap-4">
+      <div className="grid min-w-0 grid-cols-1 gap-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
             <h2 className="truncate text-lg font-semibold">{overview.title}</h2>

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -522,18 +522,9 @@ export function WorkspaceSummary({
   const coordinationWarnings =
     workspace?.coordination_warnings ?? overview.coordination_warnings ?? [];
   const presentationFields = mergeWorkspacePresentationFields(overview, workspace);
-  const workflowTimingInput = {
-    ...overview,
-    status: workspace?.status ?? overview.status,
-    lifecycle: workspace?.lifecycle ?? overview.lifecycle,
-    recovery,
-    workflow_finished_at: workspace?.workflow_finished_at ?? overview.workflow_finished_at,
-    finished_at: workspace?.finished_at ?? overview.finished_at,
-    duration_seconds: workspace?.duration_seconds ?? overview.duration_seconds,
-  };
-  const workflowTiming = resolveWorkflowTiming(workflowTimingInput);
+  const workflowTiming = resolveWorkflowTiming(overview);
   const workflowFinishedAt = workflowTiming.finishedAt;
-  const finishedAt = distinctFinishedAt(workflowTimingInput);
+  const finishedAt = distinctFinishedAt(overview);
   const taskKey = displayedTaskKey(workspace) ?? displayedTaskKey(overview);
 
   return (

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -28,7 +28,6 @@ formatConfirmedExecutionModel,
 formatRequestedEffort,
 formatRequestedModel,
 mergeWorkspacePresentationFields,
-resolveWorkflowFinishedAt,
 resolveWorkflowTiming,
 } from "@/lib/agent-format";
 import { displayedTaskKey } from "@/lib/console-dashboard-derived";
@@ -523,12 +522,18 @@ export function WorkspaceSummary({
   const coordinationWarnings =
     workspace?.coordination_warnings ?? overview.coordination_warnings ?? [];
   const presentationFields = mergeWorkspacePresentationFields(overview, workspace);
-  const workflowTiming = {
+  const workflowTimingInput = {
+    ...overview,
+    status: workspace?.status ?? overview.status,
+    lifecycle: workspace?.lifecycle ?? overview.lifecycle,
+    recovery,
     workflow_finished_at: workspace?.workflow_finished_at ?? overview.workflow_finished_at,
     finished_at: workspace?.finished_at ?? overview.finished_at,
+    duration_seconds: workspace?.duration_seconds ?? overview.duration_seconds,
   };
-  const workflowFinishedAt = resolveWorkflowFinishedAt(workflowTiming);
-  const finishedAt = distinctFinishedAt(workflowTiming);
+  const workflowTiming = resolveWorkflowTiming(workflowTimingInput);
+  const workflowFinishedAt = workflowTiming.finishedAt;
+  const finishedAt = distinctFinishedAt(workflowTimingInput);
   const taskKey = displayedTaskKey(workspace) ?? displayedTaskKey(overview);
 
   return (
@@ -648,10 +653,10 @@ export function WorkspaceSummary({
           {finishedAt ? (
             <Fact label="Finished" value={formatDateTime(finishedAt)} />
           ) : null}
-          {(workspace?.duration_seconds ?? overview.duration_seconds) != null ? (
+          {workflowTiming.durationSeconds != null ? (
             <Fact
               label="Duration"
-              value={compactDuration(workspace?.duration_seconds ?? overview.duration_seconds)}
+              value={compactDuration(workflowTiming.durationSeconds)}
             />
           ) : null}
         </div>

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -1182,6 +1182,9 @@ export function ConsoleDashboard() {
           coverageNotes={
             fleetSummaryAvailable ? (dashboardSummary?.coverage.notes ?? null) : null
           }
+          countEvidence={
+            fleetSummaryAvailable ? (dashboardSummary?.count_evidence ?? null) : null
+          }
         />
       ) : null}
       <SectionNav

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -42,7 +42,7 @@ import { getWorkspaceOperatorControls } from "@/lib/workspace-operator-controls"
 import { ConsoleDashboardFleetPanels } from "./console-dashboard-fleet-panels";
 import { ConsoleDashboardInspector } from "./console-dashboard-inspector";
 import { ConsoleDashboardOverlays } from "./console-dashboard-overlays";
-import { type FleetKpi,FleetHealthStrip,SectionNav,TopBar } from "./console-dashboard-overview";
+import { type FleetKpi, FleetHealthStrip, SectionNav, TopBar } from "./console-dashboard-overview";
 import { ConsoleDashboardWorkspaceRail } from "./console-dashboard-workspace-rail";
 import {
   DROP_ALL_GATED_DETAIL_FEEDS,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1892,39 +1892,134 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
       { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
       `a resumed running -> ${terminalStatus} transition must use the retained finish`,
     );
+    for (const [cleanupStatus, cleanupEvent] of [
+      [
+        "destroying",
+        stateChanged(terminalStatus, "destroying", "2026-09-06T12:20:00Z"),
+      ],
+      [
+        "destroyed",
+        stateChanged("destroying", "destroyed", "2026-09-06T12:30:00Z"),
+      ],
+    ]) {
+      assert.deepEqual(
+        resolveWorkflowTiming({
+          ...item,
+          status: cleanupStatus,
+          latest_state_change: cleanupEvent,
+          latest_workflow_terminal_state_change: terminalEvent,
+          last_event: cleanupEvent,
+        }),
+        { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
+        `a ${cleanupStatus} cleanup must retain the resumed ${terminalStatus} finish`,
+      );
+    }
   }
   const postPrTerminalEvent = {
     ...stateChanged("monitoring_pr", "completed", "2026-09-06T12:10:00Z"),
     id: "event_resumed_post_pr_completed",
   };
+  const postPrLifecycle = [
+    item.lifecycle[0],
+    item.lifecycle[1],
+    {
+      stage: "monitoring_pr",
+      started_at: "2026-09-06T12:05:00Z",
+      ended_at: "2026-09-06T12:06:00Z",
+      duration_seconds: 60,
+      status: "completed",
+    },
+    {
+      stage: "completed",
+      started_at: "2026-09-06T12:10:00Z",
+      ended_at: "2026-09-06T12:10:00Z",
+      duration_seconds: 0,
+      status: "completed",
+    },
+  ];
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,
       status: "completed",
-      lifecycle: [
-        item.lifecycle[0],
-        item.lifecycle[1],
-        {
-          stage: "monitoring_pr",
-          started_at: "2026-09-06T12:05:00Z",
-          ended_at: "2026-09-06T12:06:00Z",
-          duration_seconds: 60,
-          status: "completed",
-        },
-        {
-          stage: "completed",
-          started_at: "2026-09-06T12:10:00Z",
-          ended_at: "2026-09-06T12:10:00Z",
-          duration_seconds: 0,
-          status: "completed",
-        },
-      ],
+      lifecycle: postPrLifecycle,
       latest_state_change: postPrTerminalEvent,
       latest_workflow_terminal_state_change: postPrTerminalEvent,
       last_event: postPrTerminalEvent,
     }),
     { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
     "a resumed post-PR pause must use the retained completion finish",
+  );
+  for (const [cleanupStatus, cleanupEvent] of [
+    [
+      "destroying",
+      stateChanged("completed", "destroying", "2026-09-06T12:20:00Z"),
+    ],
+    [
+      "destroyed",
+      stateChanged("destroying", "destroyed", "2026-09-06T12:30:00Z"),
+    ],
+  ]) {
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        ...item,
+        status: cleanupStatus,
+        lifecycle: postPrLifecycle,
+        latest_state_change: cleanupEvent,
+        latest_workflow_terminal_state_change: postPrTerminalEvent,
+        last_event: cleanupEvent,
+      }),
+      { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
+      `a ${cleanupStatus} cleanup must retain the resumed post-PR finish`,
+    );
+  }
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "destroyed",
+      latest_state_change: stateChanged(
+        "destroying",
+        "destroyed",
+        "2026-09-06T12:09:00Z",
+      ),
+      latest_workflow_terminal_state_change: {
+        ...stateChanged("running", "failed", "2026-09-06T12:10:00Z"),
+        id: "event_resumed_after_cleanup",
+      },
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "an earlier cleanup transition must not corroborate a later retained finish",
+  );
+  const tiedTerminalEvent = {
+    ...stateChanged("running", "failed", "2026-09-06T12:10:00Z"),
+    id: "event_resumed_before_tied_cleanup",
+    event_order: 40,
+  };
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "destroyed",
+      latest_state_change: {
+        ...stateChanged("destroying", "destroyed", "2026-09-06T12:10:00Z"),
+        event_order: 41,
+      },
+      latest_workflow_terminal_state_change: tiedTerminalEvent,
+    }),
+    { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
+    "event order must corroborate cleanup recorded at the terminal timestamp",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "destroyed",
+      latest_state_change: stateChanged(
+        "destroying",
+        "destroyed",
+        "2026-09-06T12:10:00Z",
+      ),
+      latest_workflow_terminal_state_change: tiedTerminalEvent,
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "a tied cleanup without event order must not corroborate the retained finish",
   );
   assert.deepEqual(
     resolveWorkflowTiming({

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1040,6 +1040,30 @@ test("resolveWorkflowTiming rejects stage durations that contradict their timest
     },
     "duration validation must retain Core's microsecond precision",
   );
+  const nanosecondItem = {
+    ...item,
+    lifecycle: [
+      {
+        ...item.lifecycle[0],
+        started_at: "2026-09-06T12:00:00.0000009Z",
+        ended_at: "2026-09-06T12:00:01.0000001Z",
+        duration_seconds: 0,
+      },
+      {
+        ...item.lifecycle[1],
+        started_at: "2026-09-06T12:00:01.0000001Z",
+        ended_at: "2026-09-06T12:00:01.0000001Z",
+      },
+    ],
+  };
+  assert.deepEqual(
+    resolveWorkflowTiming(nanosecondItem),
+    {
+      finishedAt: "2026-09-06T12:00:01.0000001Z",
+      durationSeconds: 0,
+    },
+    "duration validation must retain hosted nanosecond precision",
+  );
   assert.deepEqual(
     resolveWorkflowTiming({
       ...submillisecondItem,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -666,6 +666,28 @@ test("resolveWorkflowTiming rejects lifecycle stages that end before they start"
     finishedAt: null,
     durationSeconds: null,
   });
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      lifecycle: [
+        {
+          ...item.lifecycle[0],
+          started_at: "2026-09-06T12:02:00Z",
+          ended_at: "2026-09-06T12:01:00Z",
+        },
+        {
+          ...item.lifecycle[1],
+          ended_at: "2026-09-06T12:06:00Z",
+        },
+      ],
+      last_event: {
+        ...item.last_event,
+        occurred_at: "2026-09-06T12:06:00Z",
+      },
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "an inverted earlier stage must invalidate an otherwise trustworthy terminal boundary",
+  );
 });
 
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -441,3 +441,47 @@ test("distinctFinishedAt omits finished_at already shown as Workflow finished", 
   );
   assert.equal(distinctFinishedAt({}), null);
 });
+
+test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const requested = {
+    stage: "requested",
+    started_at: "2026-09-06T12:00:00Z",
+    ended_at: "2026-09-06T12:10:00Z",
+    duration_seconds: 600,
+    status: "completed",
+  };
+  const running = {
+    stage: "running",
+    started_at: "2026-09-06T12:10:00Z",
+    ended_at: "2026-09-06T12:20:00Z",
+    duration_seconds: 600,
+    status: "completed",
+  };
+  const validating = {
+    stage: "validating",
+    started_at: "2026-09-06T12:10:00Z",
+    ended_at: "2026-09-06T12:30:00Z",
+    duration_seconds: 1200,
+    status: "completed",
+  };
+  const timingFor = (latestStages) =>
+    resolveWorkflowTiming({
+      status: "failed",
+      recovery: null,
+      workflow_finished_at: null,
+      finished_at: null,
+      duration_seconds: null,
+      lifecycle: [requested, ...latestStages],
+    });
+
+  const runningFirst = timingFor([running, validating]);
+  const validatingFirst = timingFor([validating, running]);
+
+  assert.deepEqual(
+    runningFirst,
+    validatingFirst,
+    "ambiguous fallback timing must not depend on lifecycle array order",
+  );
+  assert.deepEqual(runningFirst, { finishedAt: null, durationSeconds: null });
+});

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -706,6 +706,55 @@ test("resolveWorkflowTiming rejects lifecycle stages that end before they start"
   );
 });
 
+test("resolveWorkflowTiming rejects lifecycle timing that contradicts stage status", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const completedStage = {
+    stage: "completed",
+    started_at: "2026-09-06T12:10:00Z",
+    ended_at: "2026-09-06T12:10:00Z",
+    duration_seconds: 0,
+    status: "completed",
+  };
+  const contradictoryStages = [
+    {
+      stage: "requested",
+      started_at: "2026-09-06T12:00:00Z",
+      ended_at: "2026-09-06T12:10:00Z",
+      duration_seconds: 600,
+      status: "pending",
+    },
+    {
+      stage: "requested",
+      started_at: "2026-09-06T12:00:00Z",
+      ended_at: "2026-09-06T12:10:00Z",
+      duration_seconds: 600,
+      status: "terminal_skipped",
+    },
+    {
+      stage: "requested",
+      started_at: "2026-09-06T12:00:00Z",
+      ended_at: "2026-09-06T12:10:00Z",
+      duration_seconds: 600,
+      status: "active",
+    },
+  ];
+
+  for (const contradictoryStage of contradictoryStages) {
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        status: "completed",
+        recovery: null,
+        workflow_finished_at: null,
+        finished_at: null,
+        duration_seconds: null,
+        lifecycle: [contradictoryStage, completedStage],
+      }),
+      { finishedAt: null, durationSeconds: null },
+      `${contradictoryStage.status} timing must invalidate lifecycle fallback`,
+    );
+  }
+});
+
 test("resolveWorkflowTiming rejects stage durations that contradict their timestamps", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const item = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -753,6 +753,31 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
     }),
     { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
   );
+  for (const terminalStatus of ["failed", "cancelled"]) {
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        ...item,
+        status: "destroyed",
+        latest_workflow_terminal_state_change: stateChanged(
+          "running",
+          terminalStatus,
+          "2026-09-06T12:05:00Z",
+        ),
+        latest_state_change: stateChanged(
+          "destroying",
+          "destroyed",
+          "2026-09-06T12:20:00Z",
+        ),
+        last_event: stateChanged(
+          "destroying",
+          "destroyed",
+          "2026-09-06T12:20:00Z",
+        ),
+      }),
+      { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+      `destroy cleanup must not hide the earlier ${terminalStatus} transition`,
+    );
+  }
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1175,6 +1175,76 @@ test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array
   assert.deepEqual(runningFirst, { finishedAt: null, durationSeconds: null });
 });
 
+test("resolveWorkflowTiming orders exact lifecycle timestamp ties by stage", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const terminalEvent = {
+    event_type: "workspace.state_changed",
+    old_state: "pushing",
+    new_state: "failed",
+    occurred_at: "2026-09-06T12:30:00Z",
+  };
+  const item = {
+    status: "failed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [
+      {
+        stage: "requested",
+        started_at: "2026-09-06T12:00:00Z",
+        ended_at: "2026-09-06T12:10:00Z",
+        duration_seconds: 600,
+        status: "completed",
+      },
+      {
+        stage: "running",
+        started_at: "2026-09-06T12:10:00Z",
+        ended_at: "2026-09-06T12:20:00Z",
+        duration_seconds: 600,
+        status: "completed",
+      },
+      {
+        stage: "validating",
+        started_at: "2026-09-06T12:20:00Z",
+        ended_at: "2026-09-06T12:20:00Z",
+        duration_seconds: 0,
+        status: "completed",
+      },
+      {
+        stage: "pushing",
+        started_at: "2026-09-06T12:20:00Z",
+        ended_at: "2026-09-06T12:30:00Z",
+        duration_seconds: 600,
+        status: "completed",
+      },
+    ],
+    latest_workflow_terminal_state_change: terminalEvent,
+    last_event: terminalEvent,
+  };
+
+  assert.deepEqual(resolveWorkflowTiming(item), {
+    finishedAt: "2026-09-06T12:30:00Z",
+    durationSeconds: 1800,
+  });
+  assert.deepEqual(
+    resolveWorkflowTiming({ ...item, lifecycle: [...item.lifecycle, item.lifecycle[3]] }),
+    {
+      finishedAt: null,
+      durationSeconds: null,
+    },
+    "a duplicate stage cannot resolve an exact timestamp tie",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      lifecycle: [...item.lifecycle, { ...item.lifecycle[3], stage: "future_stage" }],
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "an unknown stage cannot resolve an exact timestamp tie",
+  );
+});
+
 test("resolveWorkflowTiming orders latest lifecycle stages at full recorded precision", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const item = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1162,6 +1162,25 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,
+      lifecycle: [
+        item.lifecycle[0],
+        {
+          ...item.lifecycle[1],
+          ended_at: "2026-09-06T12:05:00.000100Z",
+        },
+      ],
+      latest_workflow_terminal_state_change: stateChanged(
+        "running",
+        "failed",
+        "2026-09-06T12:05:00.000900Z",
+      ),
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "a same-millisecond terminal event at a different instant must not corroborate the lifecycle finish",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
       status: "destroying",
       last_event: stateChanged("running", "destroying", "2026-09-06T12:05:00Z"),
     }),

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -542,6 +542,40 @@ test("hasTerminalWorkflowTiming requires a workflow terminal cleanup chain for d
   );
 });
 
+test("hasTerminalWorkflowTiming honors explicit workflow finishes for destroyed legacy rows", async () => {
+  const { hasTerminalWorkflowTiming } = await import("./agent-format.ts");
+
+  for (const timing of [
+    { workflow_finished_at: "2026-09-06T12:08:00Z" },
+    { finished_at: "2026-09-06T12:08:00Z" },
+  ]) {
+    assert.equal(
+      hasTerminalWorkflowTiming({
+        status: "destroyed",
+        latest_state_change: null,
+        latest_destroying_state_change: null,
+        latest_workflow_terminal_state_change: null,
+        ...timing,
+      }),
+      true,
+      "a documented workflow finish must replace optional Core event projections",
+    );
+  }
+
+  assert.equal(
+    hasTerminalWorkflowTiming({
+      status: "destroyed",
+      workflow_finished_at: "not-a-timestamp",
+      finished_at: null,
+      latest_state_change: null,
+      latest_destroying_state_change: null,
+      latest_workflow_terminal_state_change: null,
+    }),
+    false,
+    "a malformed explicit finish must not bypass direct-destroy safeguards",
+  );
+});
+
 test("hasTerminalWorkflowTiming requires a workflow terminal boundary before cleanup failure", async () => {
   const { hasTerminalWorkflowTiming } = await import("./agent-format.ts");
   const cleanupFailure = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -543,6 +543,7 @@ test("resolveWorkflowTiming uses the retained terminal event after recovery", as
     started_at: "2026-09-06T12:10:00Z",
   };
   const terminalEvent = {
+    id: "event_terminal",
     event_type: "workspace.state_changed",
     old_state: "validating",
     new_state: "completed",
@@ -555,6 +556,7 @@ test("resolveWorkflowTiming uses the retained terminal event after recovery", as
     finished_at: null,
     duration_seconds: null,
     lifecycle: [],
+    latest_state_change: terminalEvent,
     latest_workflow_terminal_state_change: terminalEvent,
   };
 
@@ -562,6 +564,35 @@ test("resolveWorkflowTiming uses the retained terminal event after recovery", as
     finishedAt: "2026-09-06T12:20:00Z",
     durationSeconds: null,
   });
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      recovery: { started_at: terminalEvent.occurred_at },
+    }),
+    { finishedAt: "2026-09-06T12:20:00Z", durationSeconds: null },
+    "backend event ordering must retain a terminal transition at the recovery timestamp",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "destroyed",
+      recovery: { started_at: terminalEvent.occurred_at },
+      latest_state_change: {
+        id: "event_destroyed",
+        event_type: "workspace.state_changed",
+        old_state: "destroying",
+        new_state: "destroyed",
+        occurred_at: "2026-09-06T12:30:00Z",
+      },
+      latest_workflow_terminal_state_change: {
+        ...terminalEvent,
+        old_state: "running",
+        new_state: "failed",
+      },
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "timestamp equality alone must not reuse a pre-recovery terminal event",
+  );
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -630,6 +630,44 @@ test("resolveWorkflowTiming rejects non-RFC and impossible recorded timestamps",
   );
 });
 
+test("resolveWorkflowTiming rejects lifecycle stages that end before they start", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const item = {
+    status: "failed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [
+      {
+        stage: "requested",
+        started_at: "2026-09-06T12:00:00Z",
+        ended_at: "2026-09-06T12:01:00Z",
+        duration_seconds: 60,
+        status: "completed",
+      },
+      {
+        stage: "running",
+        started_at: "2026-09-06T12:05:00Z",
+        ended_at: "2026-09-06T12:04:00Z",
+        duration_seconds: 60,
+        status: "completed",
+      },
+    ],
+    last_event: {
+      event_type: "workspace.state_changed",
+      old_state: "running",
+      new_state: "failed",
+      occurred_at: "2026-09-06T12:04:00Z",
+    },
+  };
+
+  assert.deepEqual(resolveWorkflowTiming(item), {
+    finishedAt: null,
+    durationSeconds: null,
+  });
+});
+
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const requested = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -442,6 +442,26 @@ test("distinctFinishedAt omits finished_at already shown as Workflow finished", 
   assert.equal(distinctFinishedAt({}), null);
 });
 
+test("resolveWorkflowTiming preserves explicit duration without a terminal finish", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const item = {
+    status: "completed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    lifecycle: [],
+  };
+
+  assert.deepEqual(resolveWorkflowTiming({ ...item, duration_seconds: 125 }), {
+    finishedAt: null,
+    durationSeconds: 125,
+  });
+  assert.deepEqual(resolveWorkflowTiming({ ...item, duration_seconds: -1 }), {
+    finishedAt: null,
+    durationSeconds: null,
+  });
+});
+
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const requested = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1341,6 +1341,85 @@ test("resolveWorkflowTiming requires the immediately preceding stage to reach co
   );
 });
 
+test("resolveWorkflowTiming rejects completed lifecycle timing contradicted by terminal status", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const lifecycle = [
+    {
+      stage: "requested",
+      started_at: "2026-09-06T12:00:00Z",
+      ended_at: "2026-09-06T12:01:00Z",
+      duration_seconds: 60,
+      status: "completed",
+    },
+    {
+      stage: "running",
+      started_at: "2026-09-06T12:01:00Z",
+      ended_at: "2026-09-06T12:15:00Z",
+      duration_seconds: 840,
+      status: "completed",
+    },
+    {
+      stage: "completed",
+      started_at: "2026-09-06T12:15:00Z",
+      ended_at: "2026-09-06T12:15:00Z",
+      duration_seconds: 0,
+      status: "completed",
+    },
+  ];
+
+  for (const terminalStatus of ["failed", "cancelled"]) {
+    const terminalEvent = {
+      event_type: "workspace.state_changed",
+      old_state: "running",
+      new_state: terminalStatus,
+      occurred_at: "2026-09-06T12:20:00Z",
+    };
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        status: terminalStatus,
+        recovery: null,
+        workflow_finished_at: null,
+        finished_at: null,
+        duration_seconds: null,
+        lifecycle,
+        latest_workflow_terminal_state_change: terminalEvent,
+        latest_state_change: terminalEvent,
+        last_event: terminalEvent,
+      }),
+      { finishedAt: null, durationSeconds: null },
+      `a later ${terminalStatus} transition must override an inconsistent completed stage`,
+    );
+  }
+
+  const completedEvent = {
+    event_type: "workspace.state_changed",
+    old_state: "running",
+    new_state: "completed",
+    occurred_at: "2026-09-06T12:15:00Z",
+  };
+  const cleanupFailure = {
+    event_type: "workspace.state_changed",
+    old_state: "destroying",
+    new_state: "failed",
+    occurred_at: "2026-09-06T12:20:00Z",
+  };
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      status: "failed",
+      recovery: null,
+      workflow_finished_at: null,
+      finished_at: null,
+      duration_seconds: null,
+      lifecycle,
+      latest_workflow_terminal_state_change: completedEvent,
+      latest_state_change: cleanupFailure,
+      last_event: cleanupFailure,
+    }),
+    { finishedAt: "2026-09-06T12:15:00Z", durationSeconds: 900 },
+    "a corroborated completed boundary must survive a later cleanup failure",
+  );
+});
+
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const requested = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -982,6 +982,45 @@ test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array
   assert.deepEqual(runningFirst, { finishedAt: null, durationSeconds: null });
 });
 
+test("resolveWorkflowTiming orders latest lifecycle stages at full recorded precision", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const item = {
+    status: "completed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [
+      {
+        stage: "requested",
+        started_at: "2026-09-06T12:00:00.000100Z",
+        ended_at: "2026-09-06T12:00:01.000100Z",
+        duration_seconds: 1,
+        status: "completed",
+      },
+      {
+        stage: "pushing",
+        started_at: "2026-09-06T12:00:01.000100Z",
+        ended_at: "2026-09-06T12:00:01.000800Z",
+        duration_seconds: 0,
+        status: "completed",
+      },
+      {
+        stage: "completed",
+        started_at: "2026-09-06T12:00:01.000800Z",
+        ended_at: "2026-09-06T12:00:01.000800Z",
+        duration_seconds: 0,
+        status: "completed",
+      },
+    ],
+  };
+
+  assert.deepEqual(resolveWorkflowTiming(item), {
+    finishedAt: "2026-09-06T12:00:01.000800Z",
+    durationSeconds: 1,
+  });
+});
+
 test("resolveWorkflowTiming requires terminal evidence after the latest represented stage", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const item = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -572,6 +572,64 @@ test("resolveWorkflowTiming skips malformed explicit finish candidates", async (
   );
 });
 
+test("resolveWorkflowTiming rejects non-RFC and impossible recorded timestamps", async () => {
+  const { resolveWorkflowFinishedAt, resolveWorkflowTiming } =
+    await import("./agent-format.ts");
+
+  for (const invalidTimestamp of [
+    "09/07/2026",
+    "2026-02-30T12:00:00Z",
+    "2026-09-07T12:00:00+24:00",
+    "2026-09-07T12:00:00+00:60",
+  ]) {
+    assert.equal(
+      resolveWorkflowFinishedAt({ workflow_finished_at: invalidTimestamp }),
+      null,
+      `${invalidTimestamp} must not be accepted as an explicit finish`,
+    );
+  }
+  assert.equal(
+    resolveWorkflowFinishedAt({
+      workflow_finished_at: "2026-09-07t12:00:00z",
+    }),
+    "2026-09-07t12:00:00z",
+  );
+  assert.equal(
+    resolveWorkflowFinishedAt({
+      workflow_finished_at: "2026-09-07T12:00:00+02:30",
+    }),
+    "2026-09-07T12:00:00+02:30",
+  );
+
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      status: "completed",
+      recovery: null,
+      workflow_finished_at: null,
+      finished_at: null,
+      duration_seconds: null,
+      lifecycle: [
+        {
+          stage: "requested",
+          started_at: "2026-02-30T11:00:00Z",
+          ended_at: "2026-02-30T12:00:00Z",
+          duration_seconds: 3600,
+          status: "completed",
+        },
+        {
+          stage: "completed",
+          started_at: "2026-02-30T12:00:00Z",
+          ended_at: "2026-02-30T12:00:00Z",
+          duration_seconds: 0,
+          status: "completed",
+        },
+      ],
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "an impossible lifecycle boundary must not fabricate a finish or duration",
+  );
+});
+
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const requested = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -740,6 +740,26 @@ test("resolveWorkflowTiming rejects lifecycle stages that end before they start"
       lifecycle: [
         {
           ...item.lifecycle[0],
+          started_at: "2026-09-06T12:00:00.000900Z",
+          ended_at: "2026-09-06T12:00:00.000800Z",
+          duration_seconds: 0,
+        },
+      ],
+      last_event: {
+        ...item.last_event,
+        old_state: "requested",
+        occurred_at: "2026-09-06T12:00:00.000800Z",
+      },
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "a reversed sub-millisecond stage must not become the terminal finish",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      lifecycle: [
+        {
+          ...item.lifecycle[0],
           started_at: "2026-09-06T12:02:00Z",
           ended_at: "2026-09-06T12:01:00Z",
         },

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -379,6 +379,20 @@ test("resolveWorkflowFinishedAt falls back to finished_at", async () => {
   );
   assert.equal(
     resolveWorkflowFinishedAt({
+      workflow_finished_at: "not-a-timestamp",
+      finished_at: "2026-09-06T16:30:00Z",
+    }),
+    "2026-09-06T16:30:00Z",
+  );
+  assert.equal(
+    resolveWorkflowFinishedAt({
+      workflow_finished_at: "not-a-timestamp",
+      finished_at: "also-not-a-timestamp",
+    }),
+    null,
+  );
+  assert.equal(
+    resolveWorkflowFinishedAt({
       workflow_finished_at: null,
       finished_at: null,
     }),
@@ -431,6 +445,14 @@ test("distinctFinishedAt omits finished_at already shown as Workflow finished", 
       finished_at: "2026-09-06T16:00:00Z",
     }),
     "2026-09-06T16:00:00Z",
+  );
+  assert.equal(
+    distinctFinishedAt({
+      workflow_finished_at: "not-a-timestamp",
+      finished_at: "2026-09-06T16:00:00Z",
+    }),
+    null,
+    "a valid finished_at fallback must not render under both finish labels",
   );
   assert.equal(
     distinctFinishedAt({
@@ -495,6 +517,51 @@ test("resolveWorkflowTiming preserves duration when an unused finished_at differ
   assert.deepEqual(
     resolveWorkflowTiming({ ...item, finished_at: "not-a-timestamp" }),
     { finishedAt: "2026-09-06T12:12:00Z", durationSeconds: 600 },
+  );
+});
+
+test("resolveWorkflowTiming skips malformed explicit finish candidates", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      status: "completed",
+      recovery: null,
+      workflow_finished_at: "not-a-timestamp",
+      finished_at: "2026-09-06T12:12:00Z",
+      duration_seconds: 600,
+      lifecycle: [],
+    }),
+    { finishedAt: "2026-09-06T12:12:00Z", durationSeconds: 600 },
+    "a malformed workflow_finished_at must not hide a valid finished_at",
+  );
+
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      status: "completed",
+      recovery: null,
+      workflow_finished_at: "not-a-timestamp",
+      finished_at: "also-not-a-timestamp",
+      duration_seconds: null,
+      lifecycle: [
+        {
+          stage: "running",
+          started_at: "2026-09-06T12:00:00Z",
+          ended_at: "2026-09-06T12:10:00Z",
+          duration_seconds: 600,
+          status: "completed",
+        },
+        {
+          stage: "completed",
+          started_at: "2026-09-06T12:10:00Z",
+          ended_at: "2026-09-06T12:10:00Z",
+          duration_seconds: 0,
+          status: "completed",
+        },
+      ],
+    }),
+    { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: 600 },
+    "malformed explicit fields must not hide trustworthy lifecycle timing",
   );
 });
 

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -441,6 +441,22 @@ test("distinctFinishedAt omits finished_at already shown as Workflow finished", 
   );
   assert.equal(
     distinctFinishedAt({
+      workflow_finished_at: null,
+      finished_at: "not-a-timestamp",
+    }),
+    null,
+    "malformed finished_at must not bypass a missing workflow finish",
+  );
+  assert.equal(
+    distinctFinishedAt({
+      workflow_finished_at: "also-not-a-timestamp",
+      finished_at: "not-a-timestamp",
+    }),
+    null,
+    "malformed finished_at must not bypass a rejected workflow finish",
+  );
+  assert.equal(
+    distinctFinishedAt({
       workflow_finished_at: "2026-09-06T17:00:00Z",
       finished_at: "2026-09-06T16:00:00Z",
     }),

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1420,6 +1420,62 @@ test("resolveWorkflowTiming rejects completed lifecycle timing contradicted by t
   );
 });
 
+test("resolveWorkflowTiming infers destroyed timing without a retained completed transition", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const lifecycle = [
+    {
+      stage: "requested",
+      started_at: "2026-09-06T12:00:00Z",
+      ended_at: "2026-09-06T12:01:00Z",
+      duration_seconds: 60,
+      status: "completed",
+    },
+    {
+      stage: "running",
+      started_at: "2026-09-06T12:01:00Z",
+      ended_at: "2026-09-06T12:15:00Z",
+      duration_seconds: 840,
+      status: "completed",
+    },
+    {
+      stage: "completed",
+      started_at: "2026-09-06T12:15:00Z",
+      ended_at: "2026-09-06T12:20:00Z",
+      duration_seconds: 300,
+      status: "completed",
+    },
+  ];
+  const item = {
+    status: "destroyed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle,
+  };
+
+  assert.deepEqual(resolveWorkflowTiming(item), {
+    finishedAt: "2026-09-06T12:15:00Z",
+    durationSeconds: 900,
+  });
+
+  for (const terminalStatus of ["failed", "cancelled"]) {
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        ...item,
+        latest_workflow_terminal_state_change: {
+          event_type: "workspace.state_changed",
+          old_state: "running",
+          new_state: terminalStatus,
+          occurred_at: "2026-09-06T12:15:00Z",
+        },
+      }),
+      { finishedAt: null, durationSeconds: null },
+      `a retained ${terminalStatus} transition must override a contradictory completed stage`,
+    );
+  }
+});
+
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const requested = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1021,6 +1021,45 @@ test("resolveWorkflowTiming orders latest lifecycle stages at full recorded prec
   });
 });
 
+test("resolveWorkflowTiming truncates aggregate lifecycle duration once", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const item = {
+    status: "completed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [
+      {
+        stage: "requested",
+        started_at: "2026-09-06T12:00:00.000000Z",
+        ended_at: "2026-09-06T12:00:00.600000Z",
+        duration_seconds: 0,
+        status: "completed",
+      },
+      {
+        stage: "pushing",
+        started_at: "2026-09-06T12:00:00.600000Z",
+        ended_at: "2026-09-06T12:00:01.200000Z",
+        duration_seconds: 0,
+        status: "completed",
+      },
+      {
+        stage: "completed",
+        started_at: "2026-09-06T12:00:01.200000Z",
+        ended_at: "2026-09-06T12:00:01.200000Z",
+        duration_seconds: 0,
+        status: "completed",
+      },
+    ],
+  };
+
+  assert.deepEqual(resolveWorkflowTiming(item), {
+    finishedAt: "2026-09-06T12:00:01.200000Z",
+    durationSeconds: 1,
+  });
+});
+
 test("resolveWorkflowTiming requires terminal evidence after the latest represented stage", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const item = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1229,6 +1229,51 @@ test("resolveWorkflowTiming rejects repeated lifecycle stages at different times
   );
 });
 
+test("resolveWorkflowTiming rejects chronologically backward lifecycle stages", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      status: "completed",
+      recovery: null,
+      workflow_finished_at: null,
+      finished_at: null,
+      duration_seconds: null,
+      lifecycle: [
+        {
+          stage: "requested",
+          started_at: "2026-09-06T12:00:00Z",
+          ended_at: "2026-09-06T12:10:00Z",
+          duration_seconds: 600,
+          status: "completed",
+        },
+        {
+          stage: "pushing",
+          started_at: "2026-09-06T12:10:00Z",
+          ended_at: "2026-09-06T12:20:00Z",
+          duration_seconds: 600,
+          status: "completed",
+        },
+        {
+          stage: "running",
+          started_at: "2026-09-06T12:20:00Z",
+          ended_at: "2026-09-06T12:30:00Z",
+          duration_seconds: 600,
+          status: "completed",
+        },
+        {
+          stage: "completed",
+          started_at: "2026-09-06T12:30:00Z",
+          ended_at: "2026-09-06T12:30:00Z",
+          duration_seconds: 0,
+          status: "completed",
+        },
+      ],
+    }),
+    { finishedAt: null, durationSeconds: null },
+  );
+});
+
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const requested = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -460,6 +460,22 @@ test("resolveWorkflowTiming preserves explicit duration without a terminal finis
     finishedAt: null,
     durationSeconds: null,
   });
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      workflow_finished_at: "not-a-timestamp",
+      duration_seconds: 125,
+    }),
+    { finishedAt: null, durationSeconds: 125 },
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      workflow_finished_at: "not-a-timestamp",
+      duration_seconds: -1,
+    }),
+    { finishedAt: null, durationSeconds: null },
+  );
 });
 
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -437,7 +437,8 @@ test("distinctFinishedAt omits finished_at already shown as Workflow finished", 
       workflow_finished_at: "2026-09-06T17:00:00Z",
       finished_at: "not-a-timestamp",
     }),
-    "not-a-timestamp",
+    null,
+    "malformed finished_at must not render beside a valid workflow finish",
   );
   assert.equal(
     distinctFinishedAt({

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -562,6 +562,26 @@ test("resolveWorkflowTiming uses the retained terminal event after recovery", as
     finishedAt: "2026-09-06T12:20:00Z",
     durationSeconds: null,
   });
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "destroyed",
+      recovery: { started_at: "2026-09-06T12:21:00Z" },
+      latest_state_change: {
+        event_type: "workspace.state_changed",
+        old_state: "destroying",
+        new_state: "destroyed",
+        occurred_at: "2026-09-06T12:30:00Z",
+      },
+      latest_workflow_terminal_state_change: {
+        ...terminalEvent,
+        old_state: "running",
+        new_state: "failed",
+      },
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "destroy after remonitor must not reuse the pre-remonitor failed event",
+  );
 
   for (const [label, overrides] of [
     [

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -537,6 +537,90 @@ test("resolveWorkflowTiming preserves duration when an unused finished_at differ
   );
 });
 
+test("resolveWorkflowTiming uses the retained terminal event after recovery", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const recovery = {
+    started_at: "2026-09-06T12:10:00Z",
+  };
+  const terminalEvent = {
+    event_type: "workspace.state_changed",
+    old_state: "validating",
+    new_state: "completed",
+    occurred_at: "2026-09-06T12:20:00Z",
+  };
+  const item = {
+    status: "completed",
+    recovery,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [],
+    latest_workflow_terminal_state_change: terminalEvent,
+  };
+
+  assert.deepEqual(resolveWorkflowTiming(item), {
+    finishedAt: "2026-09-06T12:20:00Z",
+    durationSeconds: null,
+  });
+
+  for (const [label, overrides] of [
+    [
+      "non-state event",
+      {
+        latest_workflow_terminal_state_change: {
+          ...terminalEvent,
+          event_type: "workspace.test_marker",
+        },
+      },
+    ],
+    [
+      "mismatched terminal status",
+      {
+        latest_workflow_terminal_state_change: {
+          ...terminalEvent,
+          new_state: "failed",
+        },
+      },
+    ],
+    [
+      "destroy transition instead of workflow terminal event",
+      {
+        status: "destroyed",
+        latest_workflow_terminal_state_change: {
+          ...terminalEvent,
+          old_state: "destroying",
+          new_state: "destroyed",
+        },
+      },
+    ],
+    [
+      "malformed event timestamp",
+      {
+        latest_workflow_terminal_state_change: {
+          ...terminalEvent,
+          occurred_at: "not-a-timestamp",
+        },
+      },
+    ],
+    [
+      "event predating recovery",
+      {
+        latest_workflow_terminal_state_change: {
+          ...terminalEvent,
+          occurred_at: "2026-09-06T12:09:59Z",
+        },
+      },
+    ],
+    ["malformed recovery timestamp", { recovery: { started_at: "not-a-timestamp" } }],
+  ]) {
+    assert.deepEqual(
+      resolveWorkflowTiming({ ...item, ...overrides }),
+      { finishedAt: null, durationSeconds: null },
+      label,
+    );
+  }
+});
+
 test("resolveWorkflowTiming compares explicit and lifecycle finishes at full recorded precision", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const lifecycle = [

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -2024,6 +2024,69 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
       `a ${cleanupStatus} cleanup must retain the resumed post-PR finish`,
     );
   }
+  // Regression for PR #964 review thread PRRT_kwDOSJAM6s6hs6im: when the
+  // first cleanup fails, a retry replaces the retained cleanup entry with
+  // failed -> destroying. That retry must preserve an earlier resumed
+  // completed/cancelled finish through each retry outcome.
+  for (const [terminalStatus, terminalEvent, lifecycle] of [
+    [
+      "cancelled",
+      {
+        ...stateChanged("running", "cancelled", "2026-09-06T12:10:00Z"),
+        id: "event_resumed_cancelled_before_destroy_retry",
+      },
+      item.lifecycle,
+    ],
+    ["completed", postPrTerminalEvent, postPrLifecycle],
+  ]) {
+    const retryDestroyingEvent = stateChanged(
+      "failed",
+      "destroying",
+      "2026-09-06T12:40:00Z",
+    );
+    for (const [cleanupStatus, cleanupEvent] of [
+      ["destroying", retryDestroyingEvent],
+      [
+        "destroyed",
+        stateChanged("destroying", "destroyed", "2026-09-06T12:50:00Z"),
+      ],
+      ["failed", stateChanged("destroying", "failed", "2026-09-06T12:50:00Z")],
+    ]) {
+      assert.deepEqual(
+        resolveWorkflowTiming({
+          ...item,
+          status: cleanupStatus,
+          lifecycle,
+          latest_state_change: cleanupEvent,
+          latest_destroying_state_change: retryDestroyingEvent,
+          latest_workflow_terminal_state_change: terminalEvent,
+          last_event: cleanupEvent,
+        }),
+        { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
+        `a ${cleanupStatus} destroy retry must retain the resumed ${terminalStatus} finish`,
+      );
+    }
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        ...item,
+        status: "destroyed",
+        lifecycle,
+        latest_state_change: stateChanged(
+          "destroying",
+          "destroyed",
+          "2026-09-06T12:30:00Z",
+        ),
+        latest_destroying_state_change: stateChanged(
+          "failed",
+          "destroying",
+          "2026-09-06T12:09:00Z",
+        ),
+        latest_workflow_terminal_state_change: terminalEvent,
+      }),
+      { finishedAt: null, durationSeconds: null },
+      `a destroy retry that predates the resumed ${terminalStatus} finish must not corroborate it`,
+    );
+  }
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1871,6 +1871,61 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
       );
     }
   }
+  // Regression for PR #964 review thread PRRT_kwDOSJAM6s6hskU-: after a
+  // blocked/recovering pause resumes through running, Core keeps the first
+  // running interval in the collapsed lifecycle and does not emit `recovery`.
+  // The matching retained/current state transition is the authoritative finish,
+  // but the missing pause interval keeps the duration ambiguous.
+  for (const terminalStatus of ["failed", "cancelled"]) {
+    const terminalEvent = {
+      ...stateChanged("running", terminalStatus, "2026-09-06T12:10:00Z"),
+      id: `event_resumed_${terminalStatus}`,
+    };
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        ...item,
+        status: terminalStatus,
+        latest_state_change: terminalEvent,
+        latest_workflow_terminal_state_change: terminalEvent,
+        last_event: terminalEvent,
+      }),
+      { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
+      `a resumed running -> ${terminalStatus} transition must use the retained finish`,
+    );
+  }
+  const postPrTerminalEvent = {
+    ...stateChanged("monitoring_pr", "completed", "2026-09-06T12:10:00Z"),
+    id: "event_resumed_post_pr_completed",
+  };
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "completed",
+      lifecycle: [
+        item.lifecycle[0],
+        item.lifecycle[1],
+        {
+          stage: "monitoring_pr",
+          started_at: "2026-09-06T12:05:00Z",
+          ended_at: "2026-09-06T12:06:00Z",
+          duration_seconds: 60,
+          status: "completed",
+        },
+        {
+          stage: "completed",
+          started_at: "2026-09-06T12:10:00Z",
+          ended_at: "2026-09-06T12:10:00Z",
+          duration_seconds: 0,
+          status: "completed",
+        },
+      ],
+      latest_state_change: postPrTerminalEvent,
+      latest_workflow_terminal_state_change: postPrTerminalEvent,
+      last_event: postPrTerminalEvent,
+    }),
+    { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
+    "a resumed post-PR pause must use the retained completion finish",
+  );
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1183,6 +1183,52 @@ test("resolveWorkflowTiming rejects stage durations that contradict their timest
   );
 });
 
+test("resolveWorkflowTiming rejects repeated lifecycle stages at different timestamps", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const terminalEvent = {
+    event_type: "workspace.state_changed",
+    old_state: "running",
+    new_state: "failed",
+    occurred_at: "2026-09-06T12:20:00Z",
+  };
+
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      status: "failed",
+      recovery: null,
+      workflow_finished_at: null,
+      finished_at: null,
+      duration_seconds: null,
+      lifecycle: [
+        {
+          stage: "requested",
+          started_at: "2026-09-06T12:00:00Z",
+          ended_at: "2026-09-06T12:05:00Z",
+          duration_seconds: 300,
+          status: "completed",
+        },
+        {
+          stage: "requested",
+          started_at: "2026-09-06T12:05:00Z",
+          ended_at: "2026-09-06T12:10:00Z",
+          duration_seconds: 300,
+          status: "completed",
+        },
+        {
+          stage: "running",
+          started_at: "2026-09-06T12:10:00Z",
+          ended_at: "2026-09-06T12:20:00Z",
+          duration_seconds: 600,
+          status: "completed",
+        },
+      ],
+      latest_workflow_terminal_state_change: terminalEvent,
+      last_event: terminalEvent,
+    }),
+    { finishedAt: null, durationSeconds: null },
+  );
+});
+
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const requested = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -485,3 +485,88 @@ test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array
   );
   assert.deepEqual(runningFirst, { finishedAt: null, durationSeconds: null });
 });
+
+test("resolveWorkflowTiming requires terminal evidence after the latest represented stage", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const item = {
+    status: "failed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [
+      {
+        stage: "requested",
+        started_at: "2026-09-06T12:00:00Z",
+        ended_at: "2026-09-06T12:01:00Z",
+        duration_seconds: 60,
+        status: "completed",
+      },
+      {
+        stage: "running",
+        started_at: "2026-09-06T12:01:00Z",
+        ended_at: "2026-09-06T12:05:00Z",
+        duration_seconds: 240,
+        status: "completed",
+      },
+    ],
+  };
+  const stateChanged = (oldState, newState, occurredAt) => ({
+    event_type: "workspace.state_changed",
+    old_state: oldState,
+    new_state: newState,
+    occurred_at: occurredAt,
+  });
+
+  assert.deepEqual(resolveWorkflowTiming({ ...item, last_event: null }), {
+    finishedAt: null,
+    durationSeconds: null,
+  });
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "cancelled",
+      last_event: stateChanged("blocked", "cancelled", "2026-09-06T12:10:00Z"),
+    }),
+    { finishedAt: null, durationSeconds: null },
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      last_event: stateChanged("recovering", "failed", "2026-09-06T12:10:00Z"),
+    }),
+    { finishedAt: null, durationSeconds: null },
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      last_event: stateChanged("running", "cancelled", "2026-09-06T12:05:00Z"),
+    }),
+    { finishedAt: null, durationSeconds: null },
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      last_event: stateChanged("running", "failed", "2026-09-06T12:05:00Z"),
+    }),
+    { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "completed",
+      last_event: null,
+      lifecycle: [
+        ...item.lifecycle,
+        {
+          stage: "completed",
+          started_at: "2026-09-06T12:05:00Z",
+          ended_at: "2026-09-06T12:05:00Z",
+          duration_seconds: 0,
+          status: "completed",
+        },
+      ],
+    }),
+    { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+  );
+});

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1303,6 +1303,44 @@ test("resolveWorkflowTiming rejects chronologically backward lifecycle stages", 
   );
 });
 
+test("resolveWorkflowTiming requires the immediately preceding stage to reach completed", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      status: "completed",
+      recovery: null,
+      workflow_finished_at: null,
+      finished_at: null,
+      duration_seconds: null,
+      lifecycle: [
+        {
+          stage: "requested",
+          started_at: "2026-09-06T12:00:00Z",
+          ended_at: "2026-09-06T12:10:00Z",
+          duration_seconds: 600,
+          status: "completed",
+        },
+        {
+          stage: "running",
+          started_at: "2026-09-06T12:01:00Z",
+          ended_at: "2026-09-06T12:05:00Z",
+          duration_seconds: 240,
+          status: "completed",
+        },
+        {
+          stage: "completed",
+          started_at: "2026-09-06T12:10:00Z",
+          ended_at: "2026-09-06T12:10:00Z",
+          duration_seconds: 0,
+          status: "completed",
+        },
+      ],
+    }),
+    { finishedAt: null, durationSeconds: null },
+  );
+});
+
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const requested = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1358,6 +1358,41 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
     { finishedAt: null, durationSeconds: null },
     "an omitted pause must not be accepted when timestamps happen to coincide",
   );
+  // Regression for PR #964 review thread PRRT_kwDOSJAM6s6hrdNM: Core's
+  // dedicated retained terminal event proves the finish after an omitted pause,
+  // but the collapsed lifecycle still cannot prove the complete duration.
+  for (const pauseStatus of ["blocked", "recovering"]) {
+    for (const terminalStatus of ["failed", "cancelled"]) {
+      const terminalEvent = stateChanged(
+        pauseStatus,
+        terminalStatus,
+        "2026-09-06T12:10:00Z",
+      );
+      assert.deepEqual(
+        resolveWorkflowTiming({
+          ...item,
+          status: terminalStatus,
+          latest_workflow_terminal_state_change: terminalEvent,
+          last_event: terminalEvent,
+        }),
+        { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
+        `${pauseStatus} -> ${terminalStatus} must use the retained terminal finish`,
+      );
+    }
+  }
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "completed",
+      latest_workflow_terminal_state_change: stateChanged(
+        "blocked",
+        "completed",
+        "2026-09-06T12:10:00Z",
+      ),
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "an unsupported blocked -> completed event must not bypass recovery corroboration",
+  );
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -690,6 +690,55 @@ test("resolveWorkflowTiming rejects lifecycle stages that end before they start"
   );
 });
 
+test("resolveWorkflowTiming rejects stage durations that contradict their timestamps", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const item = {
+    status: "completed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [
+      {
+        stage: "requested",
+        started_at: "2026-09-06T12:00:00Z",
+        ended_at: "2026-09-06T12:10:00.999Z",
+        duration_seconds: 600,
+        status: "completed",
+      },
+      {
+        stage: "completed",
+        started_at: "2026-09-06T12:10:00.999Z",
+        ended_at: "2026-09-06T12:10:00.999Z",
+        duration_seconds: 0,
+        status: "completed",
+      },
+    ],
+  };
+
+  assert.deepEqual(resolveWorkflowTiming(item), {
+    finishedAt: "2026-09-06T12:10:00.999Z",
+    durationSeconds: 600,
+  });
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      lifecycle: [
+        {
+          ...item.lifecycle[0],
+          duration_seconds: 1,
+        },
+        item.lifecycle[1],
+      ],
+    }),
+    {
+      finishedAt: "2026-09-06T12:10:00.999Z",
+      durationSeconds: null,
+    },
+    "a supplied duration must not override the validated stage interval",
+  );
+});
+
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const requested = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -540,6 +540,14 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,
+      last_event: stateChanged("blocked", "failed", "2026-09-06T12:05:00Z"),
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "an omitted pause must not be accepted when timestamps happen to coincide",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
       last_event: stateChanged("running", "cancelled", "2026-09-06T12:05:00Z"),
     }),
     { finishedAt: null, durationSeconds: null },

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -499,6 +499,10 @@ test("resolveWorkflowTiming preserves explicit duration without a terminal finis
     finishedAt: null,
     durationSeconds: null,
   });
+  assert.deepEqual(resolveWorkflowTiming({ ...item, duration_seconds: 1.5 }), {
+    finishedAt: null,
+    durationSeconds: null,
+  });
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,
@@ -515,6 +519,34 @@ test("resolveWorkflowTiming preserves explicit duration without a terminal finis
     }),
     { finishedAt: null, durationSeconds: null },
   );
+});
+
+test("resolveWorkflowTiming validates explicit duration for non-terminal workspaces", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const item = {
+    status: "running",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    lifecycle: [],
+  };
+
+  assert.deepEqual(resolveWorkflowTiming({ ...item, duration_seconds: 125 }), {
+    finishedAt: null,
+    durationSeconds: 125,
+  });
+  assert.deepEqual(resolveWorkflowTiming({ ...item, duration_seconds: 0 }), {
+    finishedAt: null,
+    durationSeconds: 0,
+  });
+  assert.deepEqual(resolveWorkflowTiming({ ...item, duration_seconds: -1 }), {
+    finishedAt: null,
+    durationSeconds: null,
+  });
+  assert.deepEqual(resolveWorkflowTiming({ ...item, duration_seconds: 1.5 }), {
+    finishedAt: null,
+    durationSeconds: null,
+  });
 });
 
 test("resolveWorkflowTiming preserves duration when an unused finished_at differs", async () => {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -841,6 +841,29 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,
+      status: "failed",
+      latest_workflow_terminal_state_change: stateChanged(
+        "running",
+        "cancelled",
+        "2026-09-06T12:05:00Z",
+      ),
+      latest_state_change: stateChanged(
+        "destroying",
+        "failed",
+        "2026-09-06T12:20:00Z",
+      ),
+      last_event: stateChanged(
+        "destroying",
+        "failed",
+        "2026-09-06T12:20:00Z",
+      ),
+    }),
+    { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+    "cleanup failure must not hide the earlier cancellation transition",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
       latest_state_change: stateChanged(
         "running",
         "failed",

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -2456,6 +2456,26 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
     }),
     { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
   );
+  // Regression for PR #964 review thread PRRT_kwDOSJAM6s6huEEr: Core orders
+  // running -> blocked -> running -> failed transitions that can share one
+  // timestamp. The collapsed lifecycle retains the first running boundary, so
+  // an ordered terminal event at that same instant proves the finish but cannot
+  // prove that the retained interval represents the final running visit.
+  const tiedOrderedTerminalEvent = {
+    ...stateChanged("running", "failed", "2026-09-06T12:05:00Z"),
+    id: "event_after_same_tick_pause_resume",
+    event_order: 7,
+  };
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      latest_state_change: tiedOrderedTerminalEvent,
+      latest_workflow_terminal_state_change: tiedOrderedTerminalEvent,
+      last_event: tiedOrderedTerminalEvent,
+    }),
+    { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: null },
+    "an ordered terminal tie must retain only the authoritative finish",
+  );
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -2048,6 +2048,71 @@ test("resolveWorkflowTiming truncates aggregate lifecycle duration once", async 
   });
 });
 
+// Regression for PR #964 review thread PRRT_kwDOSJAM6s6huQ_X: the completed
+// stage must compare the retained completion order with the order that first
+// closed its collapsed source stage before trusting the lifecycle duration.
+test("resolveWorkflowTiming checks completed terminal order before deriving duration", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const terminalEvent = {
+    event_type: "workspace.state_changed",
+    old_state: "pushing",
+    new_state: "completed",
+    occurred_at: "2026-09-06T12:10:00Z",
+    event_order: 7,
+  };
+  const item = {
+    status: "completed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [
+      {
+        stage: "requested",
+        started_at: "2026-09-06T12:00:00Z",
+        ended_at: "2026-09-06T12:05:00Z",
+        duration_seconds: 300,
+        status: "completed",
+      },
+      {
+        stage: "pushing",
+        started_at: "2026-09-06T12:05:00Z",
+        ended_at: "2026-09-06T12:10:00Z",
+        ended_event_order: 7,
+        duration_seconds: 300,
+        status: "completed",
+      },
+      {
+        stage: "completed",
+        started_at: "2026-09-06T12:10:00Z",
+        ended_at: "2026-09-06T12:10:00Z",
+        duration_seconds: 0,
+        status: "completed",
+      },
+    ],
+    latest_state_change: terminalEvent,
+    latest_workflow_terminal_state_change: terminalEvent,
+    last_event: terminalEvent,
+  };
+
+  assert.deepEqual(resolveWorkflowTiming(item), {
+    finishedAt: "2026-09-06T12:10:00Z",
+    durationSeconds: 600,
+  });
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      lifecycle: [
+        item.lifecycle[0],
+        { ...item.lifecycle[1], ended_event_order: 5 },
+        item.lifecycle[2],
+      ],
+    }),
+    { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
+    "a later same-tick completion must not derive duration from the first collapsed pushing visit",
+  );
+});
+
 test("resolveWorkflowTiming requires terminal evidence after the latest represented stage", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const item = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -596,6 +596,58 @@ test("resolveWorkflowTiming uses the retained terminal event after recovery", as
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,
+      status: "destroyed",
+      recovery: {
+        started_at: terminalEvent.occurred_at,
+        started_event_order: 40,
+      },
+      latest_state_change: {
+        id: "event_destroyed",
+        event_type: "workspace.state_changed",
+        old_state: "destroying",
+        new_state: "destroyed",
+        occurred_at: "2026-09-06T12:30:00Z",
+        event_order: 43,
+      },
+      latest_workflow_terminal_state_change: {
+        ...terminalEvent,
+        old_state: "monitoring_pr",
+        new_state: "completed",
+        event_order: 41,
+      },
+    }),
+    { finishedAt: "2026-09-06T12:20:00Z", durationSeconds: null },
+    "event order must preserve a tied recovered finish after cleanup replaces the latest state change",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "destroyed",
+      recovery: {
+        started_at: terminalEvent.occurred_at,
+        started_event_order: 40,
+      },
+      latest_state_change: {
+        id: "event_destroyed",
+        event_type: "workspace.state_changed",
+        old_state: "destroying",
+        new_state: "destroyed",
+        occurred_at: "2026-09-06T12:30:00Z",
+        event_order: 43,
+      },
+      latest_workflow_terminal_state_change: {
+        ...terminalEvent,
+        old_state: "running",
+        new_state: "failed",
+        event_order: 39,
+      },
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "a tied terminal event ordered before recovery must remain rejected after cleanup",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
       status: "failed",
       latest_state_change: {
         event_type: "workspace.state_changed",

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -545,6 +545,13 @@ test("resolveWorkflowTiming skips malformed explicit finish candidates", async (
       duration_seconds: null,
       lifecycle: [
         {
+          stage: "requested",
+          started_at: "2026-09-06T12:00:00Z",
+          ended_at: "2026-09-06T12:00:00Z",
+          duration_seconds: 0,
+          status: "completed",
+        },
+        {
           stage: "running",
           started_at: "2026-09-06T12:00:00Z",
           ended_at: "2026-09-06T12:10:00Z",
@@ -699,5 +706,51 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
       ],
     }),
     { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+  );
+});
+
+test("resolveWorkflowTiming requires the initial requested stage before inferring duration", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const running = {
+    stage: "running",
+    started_at: "2026-09-06T12:01:00Z",
+    ended_at: "2026-09-06T12:05:00Z",
+    duration_seconds: 240,
+    status: "completed",
+  };
+  const item = {
+    status: "failed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    last_event: {
+      event_type: "workspace.state_changed",
+      old_state: "running",
+      new_state: "failed",
+      occurred_at: "2026-09-06T12:05:00Z",
+    },
+  };
+  const expected = {
+    finishedAt: "2026-09-06T12:05:00Z",
+    durationSeconds: null,
+  };
+
+  assert.deepEqual(resolveWorkflowTiming({ ...item, lifecycle: [running] }), expected);
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      lifecycle: [
+        {
+          stage: "requested",
+          started_at: null,
+          ended_at: null,
+          duration_seconds: null,
+          status: "pending",
+        },
+        running,
+      ],
+    }),
+    expected,
   );
 });

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1041,6 +1041,45 @@ test("resolveWorkflowTiming orders latest lifecycle stages at full recorded prec
   });
 });
 
+test("resolveWorkflowTiming rejects sub-millisecond gaps between lifecycle stages", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const item = {
+    status: "completed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [
+      {
+        stage: "requested",
+        started_at: "2026-09-06T12:00:00.000000Z",
+        ended_at: "2026-09-06T12:00:01.000100Z",
+        duration_seconds: 1,
+        status: "completed",
+      },
+      {
+        stage: "running",
+        started_at: "2026-09-06T12:00:01.000800Z",
+        ended_at: "2026-09-06T12:00:02.000800Z",
+        duration_seconds: 1,
+        status: "completed",
+      },
+      {
+        stage: "completed",
+        started_at: "2026-09-06T12:00:02.000800Z",
+        ended_at: "2026-09-06T12:00:02.000800Z",
+        duration_seconds: 0,
+        status: "completed",
+      },
+    ],
+  };
+
+  assert.deepEqual(resolveWorkflowTiming(item), {
+    finishedAt: "2026-09-06T12:00:02.000800Z",
+    durationSeconds: null,
+  });
+});
+
 test("resolveWorkflowTiming truncates aggregate lifecycle duration once", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const item = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -481,6 +481,67 @@ test("distinctFinishedAt omits finished_at already shown as Workflow finished", 
   assert.equal(distinctFinishedAt({}), null);
 });
 
+test("hasTerminalWorkflowTiming requires a workflow terminal cleanup chain for destroyed workspaces", async () => {
+  const { hasTerminalWorkflowTiming } = await import("./agent-format.ts");
+  const terminalTransition = {
+    event_type: "workspace.state_changed",
+    old_state: "running",
+    new_state: "failed",
+    occurred_at: "2026-09-06T12:08:00Z",
+  };
+  const destroyedTransition = {
+    event_type: "workspace.state_changed",
+    old_state: "destroying",
+    new_state: "destroyed",
+    occurred_at: "2026-09-06T12:30:00Z",
+  };
+
+  assert.equal(
+    hasTerminalWorkflowTiming({
+      status: "destroyed",
+      latest_state_change: destroyedTransition,
+      latest_destroying_state_change: {
+        event_type: "workspace.state_changed",
+        old_state: "failed",
+        new_state: "destroying",
+        occurred_at: "2026-09-06T12:20:00Z",
+      },
+      latest_workflow_terminal_state_change: terminalTransition,
+    }),
+    true,
+  );
+  assert.equal(
+    hasTerminalWorkflowTiming({
+      status: "destroyed",
+      latest_state_change: destroyedTransition,
+      latest_destroying_state_change: {
+        event_type: "workspace.state_changed",
+        old_state: "ready",
+        new_state: "destroying",
+        occurred_at: "2026-09-06T12:20:00Z",
+      },
+      latest_workflow_terminal_state_change: terminalTransition,
+    }),
+    false,
+    "a direct destroy must not reuse an older workflow terminal transition",
+  );
+  assert.equal(
+    hasTerminalWorkflowTiming({
+      status: "destroyed",
+      latest_state_change: destroyedTransition,
+      latest_destroying_state_change: {
+        event_type: "workspace.state_changed",
+        old_state: "ready",
+        new_state: "destroying",
+        occurred_at: "2026-09-06T12:20:00Z",
+      },
+      latest_workflow_terminal_state_change: null,
+    }),
+    false,
+    "ready -> destroying -> destroyed has no workflow terminal boundary",
+  );
+});
+
 test("resolveWorkflowTiming preserves explicit duration without a terminal finish", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const item = {
@@ -640,6 +701,14 @@ test("resolveWorkflowTiming uses the retained terminal event after recovery", as
         new_state: "destroyed",
         occurred_at: "2026-09-06T12:30:00Z",
         event_order: 43,
+      },
+      latest_destroying_state_change: {
+        id: "event_destroying",
+        event_type: "workspace.state_changed",
+        old_state: "completed",
+        new_state: "destroying",
+        occurred_at: "2026-09-06T12:25:00Z",
+        event_order: 42,
       },
       latest_workflow_terminal_state_change: {
         ...terminalEvent,
@@ -1452,7 +1521,7 @@ test("resolveWorkflowTiming rejects completed lifecycle timing contradicted by t
   );
 });
 
-test("resolveWorkflowTiming infers destroyed timing without a retained completed transition", async () => {
+test("resolveWorkflowTiming infers destroyed timing from a corroborated completed cleanup", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const lifecycle = [
     {
@@ -1484,6 +1553,24 @@ test("resolveWorkflowTiming infers destroyed timing without a retained completed
     finished_at: null,
     duration_seconds: null,
     lifecycle,
+    latest_state_change: {
+      event_type: "workspace.state_changed",
+      old_state: "destroying",
+      new_state: "destroyed",
+      occurred_at: "2026-09-06T12:21:00Z",
+    },
+    latest_destroying_state_change: {
+      event_type: "workspace.state_changed",
+      old_state: "completed",
+      new_state: "destroying",
+      occurred_at: "2026-09-06T12:20:00Z",
+    },
+    latest_workflow_terminal_state_change: {
+      event_type: "workspace.state_changed",
+      old_state: "running",
+      new_state: "completed",
+      occurred_at: "2026-09-06T12:15:00Z",
+    },
   };
 
   assert.deepEqual(resolveWorkflowTiming(item), {
@@ -2319,6 +2406,11 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
           "running",
           terminalStatus,
           "2026-09-06T12:05:00Z",
+        ),
+        latest_destroying_state_change: stateChanged(
+          terminalStatus,
+          "destroying",
+          "2026-09-06T12:10:00Z",
         ),
         latest_state_change: stateChanged(
           "destroying",

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1139,6 +1139,73 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
     }),
     { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
   );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "destroying",
+      last_event: stateChanged("running", "destroying", "2026-09-06T12:05:00Z"),
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "a direct pre-terminal destroy must not infer workflow timing",
+  );
+  for (const terminalStatus of ["failed", "cancelled"]) {
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        ...item,
+        status: "destroying",
+        latest_workflow_terminal_state_change: stateChanged(
+          "running",
+          terminalStatus,
+          "2026-09-06T12:05:00Z",
+        ),
+        latest_state_change: stateChanged(
+          terminalStatus,
+          "destroying",
+          "2026-09-06T12:20:00Z",
+        ),
+        last_event: stateChanged(
+          terminalStatus,
+          "destroying",
+          "2026-09-06T12:20:00Z",
+        ),
+      }),
+      { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+      `destroying cleanup must preserve the earlier ${terminalStatus} transition`,
+    );
+  }
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "destroying",
+      lifecycle: [
+        ...item.lifecycle,
+        {
+          stage: "completed",
+          started_at: "2026-09-06T12:05:00Z",
+          ended_at: "2026-09-06T12:20:00Z",
+          duration_seconds: 900,
+          status: "completed",
+        },
+      ],
+      latest_workflow_terminal_state_change: stateChanged(
+        "running",
+        "completed",
+        "2026-09-06T12:05:00Z",
+      ),
+      latest_state_change: stateChanged(
+        "completed",
+        "destroying",
+        "2026-09-06T12:20:00Z",
+      ),
+      last_event: stateChanged(
+        "completed",
+        "destroying",
+        "2026-09-06T12:20:00Z",
+      ),
+    }),
+    { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+    "destroying cleanup must preserve an earlier completed transition",
+  );
   for (const terminalStatus of ["failed", "cancelled"]) {
     assert.deepEqual(
       resolveWorkflowTiming({

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -478,6 +478,26 @@ test("resolveWorkflowTiming preserves explicit duration without a terminal finis
   );
 });
 
+test("resolveWorkflowTiming preserves duration when an unused finished_at differs", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const item = {
+    status: "completed",
+    recovery: null,
+    workflow_finished_at: "2026-09-06T12:12:00Z",
+    duration_seconds: 600,
+    lifecycle: [],
+  };
+
+  assert.deepEqual(
+    resolveWorkflowTiming({ ...item, finished_at: "2026-09-06T12:10:00Z" }),
+    { finishedAt: "2026-09-06T12:12:00Z", durationSeconds: 600 },
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({ ...item, finished_at: "not-a-timestamp" }),
+    { finishedAt: "2026-09-06T12:12:00Z", durationSeconds: 600 },
+  );
+});
+
 test("resolveWorkflowTiming rejects tied latest lifecycle stages in either array order", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const requested = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -753,6 +753,47 @@ test("resolveWorkflowTiming rejects lifecycle timing that contradicts stage stat
       `${contradictoryStage.status} timing must invalidate lifecycle fallback`,
     );
   }
+
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      status: "failed",
+      recovery: null,
+      workflow_finished_at: null,
+      finished_at: null,
+      duration_seconds: null,
+      lifecycle: [
+        {
+          stage: "requested",
+          started_at: "2026-09-06T12:00:00Z",
+          ended_at: "2026-09-06T12:01:00Z",
+          duration_seconds: 60,
+          status: "completed",
+        },
+        {
+          stage: "running",
+          started_at: "2026-09-06T12:01:00Z",
+          ended_at: null,
+          duration_seconds: null,
+          status: "active",
+        },
+        {
+          stage: "validating",
+          started_at: "2026-09-06T12:05:00Z",
+          ended_at: "2026-09-06T12:10:00Z",
+          duration_seconds: 300,
+          status: "completed",
+        },
+      ],
+      last_event: {
+        event_type: "workspace.state_changed",
+        old_state: "validating",
+        new_state: "failed",
+        occurred_at: "2026-09-06T12:10:00Z",
+      },
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "an unended active stage must invalidate a later corroborated terminal boundary",
+  );
 });
 
 test("resolveWorkflowTiming rejects stage durations that contradict their timestamps", async () => {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -826,6 +826,47 @@ test("resolveWorkflowTiming rejects stage durations that contradict their timest
     finishedAt: "2026-09-06T12:10:00.999Z",
     durationSeconds: 600,
   });
+  const submillisecondItem = {
+    ...item,
+    lifecycle: [
+      {
+        ...item.lifecycle[0],
+        started_at: "2026-09-06T12:00:00.000900Z",
+        ended_at: "2026-09-06T12:00:01.000800Z",
+        duration_seconds: 0,
+      },
+      {
+        ...item.lifecycle[1],
+        started_at: "2026-09-06T12:00:01.000800Z",
+        ended_at: "2026-09-06T12:00:01.000800Z",
+      },
+    ],
+  };
+  assert.deepEqual(
+    resolveWorkflowTiming(submillisecondItem),
+    {
+      finishedAt: "2026-09-06T12:00:01.000800Z",
+      durationSeconds: 0,
+    },
+    "duration validation must retain Core's microsecond precision",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...submillisecondItem,
+      lifecycle: [
+        {
+          ...submillisecondItem.lifecycle[0],
+          duration_seconds: 1,
+        },
+        submillisecondItem.lifecycle[1],
+      ],
+    }),
+    {
+      finishedAt: "2026-09-06T12:00:01.000800Z",
+      durationSeconds: null,
+    },
+    "microsecond precision must not accept the millisecond-truncated interval",
+  );
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1041,6 +1041,38 @@ test("resolveWorkflowTiming orders latest lifecycle stages at full recorded prec
   });
 });
 
+test("resolveWorkflowTiming rejects a sub-millisecond gap before completed", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const item = {
+    status: "completed",
+    recovery: null,
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [
+      {
+        stage: "requested",
+        started_at: "2026-09-06T12:00:00.000000Z",
+        ended_at: "2026-09-06T12:00:01.000100Z",
+        duration_seconds: 1,
+        status: "completed",
+      },
+      {
+        stage: "completed",
+        started_at: "2026-09-06T12:00:01.000800Z",
+        ended_at: "2026-09-06T12:00:01.000800Z",
+        duration_seconds: 0,
+        status: "completed",
+      },
+    ],
+  };
+
+  assert.deepEqual(resolveWorkflowTiming(item), {
+    finishedAt: null,
+    durationSeconds: null,
+  });
+});
+
 test("resolveWorkflowTiming rejects sub-millisecond gaps between lifecycle stages", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const item = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -542,6 +542,52 @@ test("hasTerminalWorkflowTiming requires a workflow terminal cleanup chain for d
   );
 });
 
+test("hasTerminalWorkflowTiming requires a workflow terminal boundary before cleanup failure", async () => {
+  const { hasTerminalWorkflowTiming } = await import("./agent-format.ts");
+  const cleanupFailure = {
+    event_type: "workspace.state_changed",
+    old_state: "destroying",
+    new_state: "failed",
+    occurred_at: "2026-09-06T12:30:00Z",
+  };
+
+  assert.equal(
+    hasTerminalWorkflowTiming({
+      status: "failed",
+      latest_state_change: cleanupFailure,
+      latest_destroying_state_change: {
+        event_type: "workspace.state_changed",
+        old_state: "ready",
+        new_state: "destroying",
+        occurred_at: "2026-09-06T12:20:00Z",
+      },
+      latest_workflow_terminal_state_change: null,
+    }),
+    false,
+    "ready -> destroying -> failed has no workflow terminal boundary",
+  );
+  assert.equal(
+    hasTerminalWorkflowTiming({
+      status: "failed",
+      latest_state_change: cleanupFailure,
+      latest_destroying_state_change: {
+        event_type: "workspace.state_changed",
+        old_state: "ready",
+        new_state: "destroying",
+        occurred_at: "2026-09-06T12:20:00Z",
+      },
+      latest_workflow_terminal_state_change: {
+        event_type: "workspace.state_changed",
+        old_state: "running",
+        new_state: "failed",
+        occurred_at: "2026-09-06T12:08:00Z",
+      },
+    }),
+    false,
+    "a direct cleanup failure must not reuse an older workflow terminal transition",
+  );
+});
+
 test("resolveWorkflowTiming preserves explicit duration without a terminal finish", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const item = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -2456,6 +2456,28 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
     }),
     { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
   );
+  for (const terminalStatus of ["failed", "cancelled"]) {
+    const ordinaryOrderedTerminalEvent = {
+      ...stateChanged("running", terminalStatus, "2026-09-06T12:05:00Z"),
+      id: `event_direct_${terminalStatus}`,
+      event_order: 7,
+    };
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        ...item,
+        status: terminalStatus,
+        lifecycle: [
+          item.lifecycle[0],
+          { ...item.lifecycle[1], ended_event_order: 7 },
+        ],
+        latest_state_change: ordinaryOrderedTerminalEvent,
+        latest_workflow_terminal_state_change: ordinaryOrderedTerminalEvent,
+        last_event: ordinaryOrderedTerminalEvent,
+      }),
+      { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+      `an ordinary ordered ${terminalStatus} boundary must retain lifecycle duration`,
+    );
+  }
   // Regression for PR #964 review thread PRRT_kwDOSJAM6s6huEEr: Core orders
   // running -> blocked -> running -> failed transitions that can share one
   // timestamp. The collapsed lifecycle retains the first running boundary, so
@@ -2469,6 +2491,10 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,
+      lifecycle: [
+        item.lifecycle[0],
+        { ...item.lifecycle[1], ended_event_order: 5 },
+      ],
       latest_state_change: tiedOrderedTerminalEvent,
       latest_workflow_terminal_state_change: tiedOrderedTerminalEvent,
       last_event: tiedOrderedTerminalEvent,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -705,6 +705,12 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
     new_state: newState,
     occurred_at: occurredAt,
   });
+  const terminalRuntimeReleased = {
+    event_type: "workspace.terminal_runtime_released",
+    old_state: null,
+    new_state: null,
+    occurred_at: "2026-09-06T12:06:00Z",
+  };
 
   assert.deepEqual(resolveWorkflowTiming({ ...item, last_event: null }), {
     finishedAt: null,
@@ -746,6 +752,45 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
       last_event: stateChanged("running", "failed", "2026-09-06T12:05:00Z"),
     }),
     { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      latest_state_change: stateChanged(
+        "running",
+        "failed",
+        "2026-09-06T12:05:00Z",
+      ),
+      last_event: terminalRuntimeReleased,
+    }),
+    { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+    "terminal cleanup must not hide an earlier direct terminal transition",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "cancelled",
+      latest_state_change: stateChanged(
+        "running",
+        "cancelled",
+        "2026-09-06T12:05:00Z",
+      ),
+      last_event: terminalRuntimeReleased,
+    }),
+    { finishedAt: "2026-09-06T12:05:00Z", durationSeconds: 300 },
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      latest_state_change: stateChanged(
+        "blocked",
+        "failed",
+        "2026-09-06T12:05:00Z",
+      ),
+      last_event: terminalRuntimeReleased,
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "a cleanup event must not bypass the direct-transition requirement",
   );
   assert.deepEqual(
     resolveWorkflowTiming({

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -565,6 +565,20 @@ test("resolveWorkflowTiming uses the retained terminal event after recovery", as
   assert.deepEqual(
     resolveWorkflowTiming({
       ...item,
+      status: "failed",
+      latest_state_change: {
+        event_type: "workspace.state_changed",
+        old_state: "destroying",
+        new_state: "failed",
+        occurred_at: "2026-09-06T12:30:00Z",
+      },
+    }),
+    { finishedAt: "2026-09-06T12:20:00Z", durationSeconds: null },
+    "cleanup failure must preserve the recovered completed workflow finish",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
       status: "destroyed",
       recovery: { started_at: "2026-09-06T12:21:00Z" },
       latest_state_change: {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -537,6 +537,57 @@ test("resolveWorkflowTiming preserves duration when an unused finished_at differ
   );
 });
 
+test("resolveWorkflowTiming compares explicit and lifecycle finishes at full recorded precision", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const lifecycle = [
+    {
+      stage: "requested",
+      started_at: "2026-09-06T12:00:00.500600Z",
+      ended_at: "2026-09-06T12:00:01.500600Z",
+      duration_seconds: 1,
+      status: "completed",
+    },
+    {
+      stage: "completed",
+      started_at: "2026-09-06T12:00:01.500600Z",
+      ended_at: "2026-09-06T12:00:01.500600Z",
+      duration_seconds: 0,
+      status: "completed",
+    },
+  ];
+
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      status: "completed",
+      recovery: null,
+      workflow_finished_at: "2026-09-06T12:00:01.500400Z",
+      finished_at: null,
+      duration_seconds: null,
+      lifecycle,
+    }),
+    {
+      finishedAt: "2026-09-06T12:00:01.500400Z",
+      durationSeconds: null,
+    },
+    "a millisecond-truncated match must not attach a contradictory lifecycle duration",
+  );
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      status: "completed",
+      recovery: null,
+      workflow_finished_at: "2026-09-06T12:00:01.5006000+00:00",
+      finished_at: null,
+      duration_seconds: null,
+      lifecycle,
+    }),
+    {
+      finishedAt: "2026-09-06T12:00:01.5006000+00:00",
+      durationSeconds: 1,
+    },
+    "equivalent timezone and fractional forms must retain lifecycle duration",
+  );
+});
+
 test("resolveWorkflowTiming skips malformed explicit finish candidates", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
 

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -576,6 +576,44 @@ test("hasTerminalWorkflowTiming honors explicit workflow finishes for destroyed 
   );
 });
 
+test("hasTerminalWorkflowTiming honors explicit workflow finishes while cleanup is destroying", async () => {
+  const { hasTerminalWorkflowTiming } = await import("./agent-format.ts");
+
+  for (const timing of [
+    { workflow_finished_at: "2026-09-06T12:08:00Z" },
+    { finished_at: "2026-09-06T12:08:00Z" },
+  ]) {
+    assert.equal(
+      hasTerminalWorkflowTiming({
+        status: "destroying",
+        latest_state_change: null,
+        latest_destroying_state_change: null,
+        latest_workflow_terminal_state_change: null,
+        ...timing,
+      }),
+      true,
+      "a documented workflow finish must remain terminal during cleanup",
+    );
+  }
+
+  for (const timing of [
+    {},
+    { workflow_finished_at: "not-a-timestamp", finished_at: null },
+  ]) {
+    assert.equal(
+      hasTerminalWorkflowTiming({
+        status: "destroying",
+        latest_state_change: null,
+        latest_destroying_state_change: null,
+        latest_workflow_terminal_state_change: null,
+        ...timing,
+      }),
+      false,
+      "cleanup without a valid explicit finish must not appear terminal",
+    );
+  }
+});
+
 test("hasTerminalWorkflowTiming requires a workflow terminal boundary before cleanup failure", async () => {
   const { hasTerminalWorkflowTiming } = await import("./agent-format.ts");
   const cleanupFailure = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -614,6 +614,33 @@ test("hasTerminalWorkflowTiming honors explicit workflow finishes while cleanup 
   }
 });
 
+test("hasTerminalWorkflowTiming honors explicit workflow finishes after cleanup failure", async () => {
+  const { hasTerminalWorkflowTiming } = await import("./agent-format.ts");
+  const cleanupFailure = {
+    event_type: "workspace.state_changed",
+    old_state: "destroying",
+    new_state: "failed",
+    occurred_at: "2026-09-06T12:30:00Z",
+  };
+
+  for (const timing of [
+    { workflow_finished_at: "2026-09-06T12:08:00Z" },
+    { finished_at: "2026-09-06T12:08:00Z" },
+  ]) {
+    assert.equal(
+      hasTerminalWorkflowTiming({
+        status: "failed",
+        latest_state_change: cleanupFailure,
+        latest_destroying_state_change: null,
+        latest_workflow_terminal_state_change: null,
+        ...timing,
+      }),
+      true,
+      "a documented workflow finish must replace optional cleanup provenance",
+    );
+  }
+});
+
 test("hasTerminalWorkflowTiming requires a workflow terminal boundary before cleanup failure", async () => {
   const { hasTerminalWorkflowTiming } = await import("./agent-format.ts");
   const cleanupFailure = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1892,14 +1892,16 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
       { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
       `a resumed running -> ${terminalStatus} transition must use the retained finish`,
     );
-    for (const [cleanupStatus, cleanupEvent] of [
+    for (const [cleanupStatus, cleanupEvent, destroyingEvent] of [
       [
         "destroying",
+        stateChanged(terminalStatus, "destroying", "2026-09-06T12:20:00Z"),
         stateChanged(terminalStatus, "destroying", "2026-09-06T12:20:00Z"),
       ],
       [
         "destroyed",
         stateChanged("destroying", "destroyed", "2026-09-06T12:30:00Z"),
+        stateChanged(terminalStatus, "destroying", "2026-09-06T12:20:00Z"),
       ],
     ]) {
       assert.deepEqual(
@@ -1907,6 +1909,7 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
           ...item,
           status: cleanupStatus,
           latest_state_change: cleanupEvent,
+          latest_destroying_state_change: destroyingEvent,
           latest_workflow_terminal_state_change: terminalEvent,
           last_event: cleanupEvent,
         }),
@@ -1949,14 +1952,16 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
     { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
     "a resumed post-PR pause must use the retained completion finish",
   );
-  for (const [cleanupStatus, cleanupEvent] of [
+  for (const [cleanupStatus, cleanupEvent, destroyingEvent] of [
     [
       "destroying",
+      stateChanged("completed", "destroying", "2026-09-06T12:20:00Z"),
       stateChanged("completed", "destroying", "2026-09-06T12:20:00Z"),
     ],
     [
       "destroyed",
       stateChanged("destroying", "destroyed", "2026-09-06T12:30:00Z"),
+      stateChanged("completed", "destroying", "2026-09-06T12:20:00Z"),
     ],
   ]) {
     assert.deepEqual(
@@ -1965,6 +1970,7 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
         status: cleanupStatus,
         lifecycle: postPrLifecycle,
         latest_state_change: cleanupEvent,
+        latest_destroying_state_change: destroyingEvent,
         latest_workflow_terminal_state_change: postPrTerminalEvent,
         last_event: cleanupEvent,
       }),
@@ -1989,6 +1995,31 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
     { finishedAt: null, durationSeconds: null },
     "an earlier cleanup transition must not corroborate a later retained finish",
   );
+  // Regression for PR #964 review thread PRRT_kwDOSJAM6s6hswvx: cleanup
+  // completion alone cannot prove that its destroying cycle started from the
+  // retained pause-resume terminal state.
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      status: "destroyed",
+      latest_state_change: stateChanged(
+        "destroying",
+        "destroyed",
+        "2026-09-06T12:30:00Z",
+      ),
+      latest_destroying_state_change: stateChanged(
+        "ready",
+        "destroying",
+        "2026-09-06T12:20:00Z",
+      ),
+      latest_workflow_terminal_state_change: {
+        ...stateChanged("running", "failed", "2026-09-06T12:10:00Z"),
+        id: "event_resumed_before_unrelated_destroy",
+      },
+    }),
+    { finishedAt: null, durationSeconds: null },
+    "a later direct destroy must not surface an earlier resumed finish",
+  );
   const tiedTerminalEvent = {
     ...stateChanged("running", "failed", "2026-09-06T12:10:00Z"),
     id: "event_resumed_before_tied_cleanup",
@@ -2000,6 +2031,10 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
       status: "destroyed",
       latest_state_change: {
         ...stateChanged("destroying", "destroyed", "2026-09-06T12:10:00Z"),
+        event_order: 42,
+      },
+      latest_destroying_state_change: {
+        ...stateChanged("failed", "destroying", "2026-09-06T12:10:00Z"),
         event_order: 41,
       },
       latest_workflow_terminal_state_change: tiedTerminalEvent,

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1573,6 +1573,51 @@ test("resolveWorkflowTiming orders latest lifecycle stages at full recorded prec
   });
 });
 
+test("resolveWorkflowTiming sorts duration stages at full recorded precision", async () => {
+  const { resolveWorkflowTiming } = await import("./agent-format.ts");
+  const requested = {
+    stage: "requested",
+    started_at: "2026-09-06T12:00:00.000100Z",
+    ended_at: "2026-09-06T12:00:00.000800Z",
+    duration_seconds: 0,
+    status: "completed",
+  };
+  const running = {
+    stage: "running",
+    started_at: "2026-09-06T12:00:00.000800Z",
+    ended_at: "2026-09-06T12:00:01.000800Z",
+    duration_seconds: 1,
+    status: "completed",
+  };
+  const completed = {
+    stage: "completed",
+    started_at: "2026-09-06T12:00:01.000800Z",
+    ended_at: "2026-09-06T12:00:01.000800Z",
+    duration_seconds: 0,
+    status: "completed",
+  };
+  const timingFor = (lifecycle) =>
+    resolveWorkflowTiming({
+      status: "completed",
+      recovery: null,
+      workflow_finished_at: null,
+      finished_at: null,
+      duration_seconds: null,
+      lifecycle,
+    });
+
+  const canonicalTiming = timingFor([requested, running, completed]);
+  assert.deepEqual(canonicalTiming, {
+    finishedAt: "2026-09-06T12:00:01.000800Z",
+    durationSeconds: 1,
+  });
+  assert.deepEqual(
+    timingFor([running, requested, completed]),
+    canonicalTiming,
+    "sub-millisecond stage order must not depend on lifecycle array order",
+  );
+});
+
 test("resolveWorkflowTiming rejects a sub-millisecond gap before completed", async () => {
   const { resolveWorkflowTiming } = await import("./agent-format.ts");
   const item = {

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1918,6 +1918,52 @@ test("resolveWorkflowTiming requires terminal evidence after the latest represen
       );
     }
   }
+  // Regression for PR #964 review thread PRRT_kwDOSJAM6s6hsx00: cleanup can
+  // fail after the retained transition records a resumed workflow failure.
+  const resumedFailure = {
+    ...stateChanged("running", "failed", "2026-09-06T12:10:00Z"),
+    id: "event_resumed_before_cleanup_failure",
+  };
+  assert.deepEqual(
+    resolveWorkflowTiming({
+      ...item,
+      latest_state_change: stateChanged(
+        "destroying",
+        "failed",
+        "2026-09-06T12:30:00Z",
+      ),
+      latest_destroying_state_change: stateChanged(
+        "failed",
+        "destroying",
+        "2026-09-06T12:20:00Z",
+      ),
+      latest_workflow_terminal_state_change: resumedFailure,
+    }),
+    { finishedAt: "2026-09-06T12:10:00Z", durationSeconds: null },
+    "a cleanup failure must retain the resumed workflow failure timestamp",
+  );
+  for (const [destroyingEvent, reason] of [
+    [undefined, "missing cleanup-entry provenance"],
+    [
+      stateChanged("failed", "destroying", "2026-09-06T12:09:00Z"),
+      "cleanup that predates the retained failure",
+    ],
+  ]) {
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        ...item,
+        latest_state_change: stateChanged(
+          "destroying",
+          "failed",
+          "2026-09-06T12:30:00Z",
+        ),
+        latest_destroying_state_change: destroyingEvent,
+        latest_workflow_terminal_state_change: resumedFailure,
+      }),
+      { finishedAt: null, durationSeconds: null },
+      `${reason} must not corroborate a retained workflow finish`,
+    );
+  }
   const postPrTerminalEvent = {
     ...stateChanged("monitoring_pr", "completed", "2026-09-06T12:10:00Z"),
     id: "event_resumed_post_pr_completed",

--- a/apps/console/lib/agent-format.test.mjs
+++ b/apps/console/lib/agent-format.test.mjs
@@ -1027,6 +1027,35 @@ test("resolveWorkflowTiming rejects lifecycle timing that contradicts stage stat
     );
   }
 
+  for (const malformedStage of [
+    {
+      stage: "requested",
+      started_at: "2026-09-06T12:00:00Z",
+      ended_at: "2026-09-06T12:10:00Z",
+      duration_seconds: 600,
+    },
+    {
+      stage: "requested",
+      started_at: "2026-09-06T12:00:00Z",
+      ended_at: "2026-09-06T12:10:00Z",
+      duration_seconds: 600,
+      status: "future_status",
+    },
+  ]) {
+    assert.deepEqual(
+      resolveWorkflowTiming({
+        status: "completed",
+        recovery: null,
+        workflow_finished_at: null,
+        finished_at: null,
+        duration_seconds: null,
+        lifecycle: [malformedStage, completedStage],
+      }),
+      { finishedAt: null, durationSeconds: null },
+      "missing or unknown stage status must invalidate lifecycle fallback",
+    );
+  }
+
   assert.deepEqual(
     resolveWorkflowTiming({
       status: "failed",

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -524,7 +524,9 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
 }
 
 function recordedDurationSeconds(value: number | null | undefined): number | null {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : null;
 }
 
 function recordedIntervalDurationSeconds(
@@ -768,7 +770,7 @@ export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflow
   if (!hasTerminalWorkflowTiming(item)) {
     return {
       finishedAt: resolvedFinishedAt,
-      durationSeconds: item.duration_seconds ?? null,
+      durationSeconds: recordedDurationSeconds(item.duration_seconds),
     };
   }
 

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -377,11 +377,23 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
   }
 
   const finishedMs = recordedMilliseconds(terminalEvent.occurred_at);
+  const recoveryComparison =
+    recoveryStartedAt == null
+      ? null
+      : compareRecordedInstants(terminalEvent.occurred_at, recoveryStartedAt);
+  // Both overview fields are selected from the backend's event_order-sorted
+  // history. A matching latest-state ID therefore proves which transition won
+  // when recovery and its terminal transition share a recorded instant.
+  const orderedAfterSameInstantRecovery =
+    recoveryComparison === 0 &&
+    typeof terminalEvent.id === "string" &&
+    terminalEvent.id.length > 0 &&
+    item.latest_state_change?.id === terminalEvent.id;
   if (
     finishedMs == null ||
     (!isDirectPauseExit &&
-      (recoveryStartedAt == null ||
-        compareRecordedInstants(terminalEvent.occurred_at, recoveryStartedAt) !== 1))
+      recoveryComparison !== 1 &&
+      !orderedAfterSameInstantRecovery)
   ) {
     return null;
   }

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -740,14 +740,19 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     ) {
       return null;
     }
-    // Current Core events carry a workspace-local order, but lifecycle stages
-    // retain only timestamps. When an ordered terminal event ties the retained
-    // stage end, that stage may have been closed by an earlier same-tick pause
-    // before re-entry and terminal exit. The event still proves the finish;
-    // without the lifecycle boundary's order it cannot prove the duration.
+    // Compare Core's workspace-local order with the event that first closed
+    // this collapsed stage. A later same-tick terminal event proves the finish
+    // but also proves an omitted re-entry, so the retained interval cannot
+    // prove duration. Legacy payloads without the boundary order stay
+    // conservative when the terminal event is ordered.
+    const terminalEventOrder = terminalEvent.event_order;
+    const lifecycleBoundaryOrder = latestEntered.stage.ended_event_order;
     if (
-      typeof terminalEvent.event_order === "number" &&
-      Number.isSafeInteger(terminalEvent.event_order)
+      typeof terminalEventOrder === "number" &&
+      Number.isSafeInteger(terminalEventOrder) &&
+      (typeof lifecycleBoundaryOrder !== "number" ||
+        !Number.isSafeInteger(lifecycleBoundaryOrder) ||
+        lifecycleBoundaryOrder !== terminalEventOrder)
     ) {
       return { finishedAt, finishedMs, durationSeconds: null };
     }

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -386,14 +386,22 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
     recoveryStartedAt == null
       ? null
       : compareRecordedInstants(terminalEvent.occurred_at, recoveryStartedAt);
-  // Both overview fields are selected from the backend's event_order-sorted
-  // history. A matching latest-state ID therefore proves which transition won
-  // when recovery and its terminal transition share a recorded instant.
+  const terminalEventOrder = terminalEvent.event_order;
+  const recoveryStartedEventOrder = item.recovery?.started_event_order;
+  const explicitEventOrderProof =
+    typeof terminalEventOrder === "number" &&
+    Number.isSafeInteger(terminalEventOrder) &&
+    typeof recoveryStartedEventOrder === "number" &&
+    Number.isSafeInteger(recoveryStartedEventOrder) &&
+    terminalEventOrder > recoveryStartedEventOrder;
+  // Event order remains authoritative after cleanup replaces latest_state_change.
+  // Retain the matching-ID proof for legacy payloads without order metadata.
   const orderedAfterSameInstantRecovery =
     recoveryComparison === 0 &&
-    typeof terminalEvent.id === "string" &&
-    terminalEvent.id.length > 0 &&
-    item.latest_state_change?.id === terminalEvent.id;
+    (explicitEventOrderProof ||
+      (typeof terminalEvent.id === "string" &&
+        terminalEvent.id.length > 0 &&
+        item.latest_state_change?.id === terminalEvent.id));
   if (
     finishedMs == null ||
     (!isDirectPauseExit &&

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -216,6 +216,8 @@ type RetainedTerminalEvent = NonNullable<
   WorkspaceOverview["latest_workflow_terminal_state_change"]
 >;
 
+type RetainedStateChangeEvent = NonNullable<WorkspaceOverview["latest_state_change"]>;
+
 function terminalEventMatchesWorkflowStatus(
   item: WorkspaceOverview,
   terminalEvent: RetainedTerminalEvent,
@@ -368,6 +370,26 @@ function recordedMilliseconds(value: string | null | undefined): number | null {
   return Number.isFinite(milliseconds) ? milliseconds : null;
 }
 
+function eventStrictlyFollows(
+  later: RetainedStateChangeEvent,
+  earlier: RetainedStateChangeEvent,
+): boolean {
+  const recordedOrder = compareRecordedInstants(later.occurred_at, earlier.occurred_at);
+  if (recordedOrder == null || recordedOrder === -1) {
+    return false;
+  }
+  const laterEventOrder = later.event_order;
+  const earlierEventOrder = earlier.event_order;
+  const hasEventOrderProof =
+    typeof laterEventOrder === "number" &&
+    Number.isSafeInteger(laterEventOrder) &&
+    typeof earlierEventOrder === "number" &&
+    Number.isSafeInteger(earlierEventOrder);
+  return hasEventOrderProof
+    ? laterEventOrder > earlierEventOrder
+    : recordedOrder === 1;
+}
+
 function retainedTerminalEventTiming(item: WorkspaceOverview): {
   finishedAt: string;
   finishedMs: number;
@@ -393,35 +415,29 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
         )
       : null;
   const latestStateChange = item.latest_state_change;
-  const cleanupOrder =
-    latestStateChange != null && terminalEvent != null
-      ? compareRecordedInstants(
-          latestStateChange.occurred_at,
-          terminalEvent.occurred_at,
-        )
-      : null;
-  const cleanupEventOrder = latestStateChange?.event_order;
+  const destroyingStateChange =
+    item.status === "destroying"
+      ? latestStateChange
+      : item.status === "destroyed"
+        ? item.latest_destroying_state_change
+        : null;
   const terminalEventOrder = terminalEvent?.event_order;
-  const hasCleanupEventOrderProof =
-    typeof cleanupEventOrder === "number" &&
-    Number.isSafeInteger(cleanupEventOrder) &&
-    typeof terminalEventOrder === "number" &&
-    Number.isSafeInteger(terminalEventOrder);
-  const cleanupFollowsTerminalEvent =
-    cleanupOrder != null &&
-    cleanupOrder !== -1 &&
-    (hasCleanupEventOrderProof
-      ? cleanupEventOrder > terminalEventOrder
-      : cleanupOrder === 1);
+  const cleanupEnteredFromTerminal =
+    terminalEvent != null &&
+    destroyingStateChange?.event_type === "workspace.state_changed" &&
+    destroyingStateChange.old_state === terminalEvent.new_state &&
+    destroyingStateChange.new_state === "destroying" &&
+    eventStrictlyFollows(destroyingStateChange, terminalEvent);
   const subsequentCleanupCorroboratesTerminal =
     terminalEvent != null &&
+    cleanupEnteredFromTerminal &&
     latestStateChange?.event_type === "workspace.state_changed" &&
     latestStateChange.new_state === item.status &&
-    ((latestStateChange.old_state === terminalEvent.new_state &&
-      latestStateChange.new_state === "destroying") ||
-      (latestStateChange.old_state === "destroying" &&
-        latestStateChange.new_state === "destroyed")) &&
-    cleanupFollowsTerminalEvent;
+    (item.status === "destroying" ||
+      (item.status === "destroyed" &&
+        destroyingStateChange != null &&
+        latestStateChange.old_state === "destroying" &&
+        eventStrictlyFollows(latestStateChange, destroyingStateChange)));
   const isRetainedResumeExit =
     recoveryStartedAt == null &&
     terminalEvent != null &&
@@ -445,7 +461,7 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
   // terminal exit from either pause is authoritative without that boundary.
   // After a pause resumes, the lifecycle retains the first interval for the
   // re-entered stage. The matching current state transition, or a subsequent
-  // cleanup transition that follows it, can prove the later finish, but not a
+  // cleanup chain that entered from it, can prove the later finish, but not a
   // duration that spans the omitted pause.
   if (
     (recoveryStartedAt == null &&

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -478,6 +478,20 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       entered.push({ stage, startedAt: stage.started_at, startedMs, endedMs });
     }
   }
+  const chronologicallyEntered = [...entered].sort((left, right) => {
+    const instantOrder = compareRecordedInstants(left.startedAt, right.startedAt);
+    return instantOrder === 0
+      ? lifecycleStageOrder(left.stage.stage) - lifecycleStageOrder(right.stage.stage)
+      : (instantOrder ?? 0);
+  });
+  let previousStageOrder = -1;
+  for (const entry of chronologicallyEntered) {
+    const stageOrder = lifecycleStageOrder(entry.stage.stage);
+    if (stageOrder < 0 || stageOrder <= previousStageOrder) {
+      return null;
+    }
+    previousStageOrder = stageOrder;
+  }
   let latestEntered = entered.reduce<TimedLifecycleStage | null>(
     (latest, entry) =>
       latest == null || compareRecordedInstants(entry.startedAt, latest.startedAt) === 1

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -337,17 +337,25 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       item.latest_state_change ??
       item.last_event;
     const terminalEventMs = recordedMilliseconds(terminalEvent?.occurred_at);
+    const cleanupFailureConfirmsCancelledBoundary =
+      item.status === "failed" &&
+      terminalEvent?.new_state === "cancelled" &&
+      item.latest_state_change?.event_type === "workspace.state_changed" &&
+      item.latest_state_change.old_state === "destroying" &&
+      item.latest_state_change.new_state === "failed";
     const eventMatchesTerminalStatus =
       terminalEvent?.new_state === item.status ||
       (item.status === "destroyed" &&
         (terminalEvent?.new_state === "failed" ||
-          terminalEvent?.new_state === "cancelled"));
+          terminalEvent?.new_state === "cancelled")) ||
+      cleanupFailureConfirmsCancelledBoundary;
     // Pauses such as blocked/recovering are absent from lifecycle summaries.
     // For terminal paths without a completed stage, only trust that boundary
     // when a retained workflow state-change corroborates the actual terminal
-    // transition. A destroyed workspace may retain the failed/cancelled
-    // boundary that preceded its later cleanup transitions. `last_event`
-    // remains a compatibility fallback for older overview payloads.
+    // transition. Cleanup may retain an earlier failed/cancelled boundary
+    // after successful destruction, or after cancellation cleanup itself
+    // fails. `last_event` remains a compatibility fallback for older overview
+    // payloads.
     if (
       terminalEvent?.event_type !== "workspace.state_changed" ||
       terminalEvent.old_state !== latestEntered.stage.stage ||

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -347,7 +347,9 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     if (
       (stage.started_at != null && startedMs == null) ||
       (stage.ended_at != null && endedMs == null) ||
-      (startedMs != null && endedMs != null && endedMs < startedMs)
+      (stage.started_at != null &&
+        stage.ended_at != null &&
+        compareRecordedInstants(stage.ended_at, stage.started_at) === -1)
     ) {
       return null;
     }

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -269,6 +269,25 @@ function recordedDurationSeconds(value: number | null | undefined): number | nul
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
 }
 
+function recordedIntervalDurationSeconds(
+  startedAt: string,
+  startedMs: number,
+  endedAt: string,
+  endedMs: number,
+): number {
+  const submillisecondMicroseconds = (value: string): number => {
+    const fractionalSeconds = RFC3339_DATE_TIME.exec(value)?.[7] ?? "";
+    return Number(fractionalSeconds.slice(4, 7).padEnd(3, "0"));
+  };
+  const elapsedMilliseconds = endedMs - startedMs;
+  const elapsedWholeSeconds = Math.floor(elapsedMilliseconds / 1000);
+  const elapsedMicroseconds =
+    (elapsedMilliseconds - elapsedWholeSeconds * 1000) * 1000 +
+    submillisecondMicroseconds(endedAt) -
+    submillisecondMicroseconds(startedAt);
+  return elapsedWholeSeconds + Math.floor(elapsedMicroseconds / 1_000_000);
+}
+
 function lifecycleWorkflowTiming(item: WorkspaceOverview): {
   finishedAt: string;
   finishedMs: number;
@@ -391,9 +410,14 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
   for (const entry of durationStages) {
     const stageDuration = recordedDurationSeconds(entry.stage.duration_seconds);
     const intervalDurationSeconds =
-      entry.endedMs == null
+      entry.stage.ended_at == null || entry.endedMs == null
         ? null
-        : Math.floor((entry.endedMs - entry.startedMs) / 1000);
+        : recordedIntervalDurationSeconds(
+            entry.startedAt,
+            entry.startedMs,
+            entry.stage.ended_at,
+            entry.endedMs,
+          );
     if (
       entry.endedMs == null ||
       entry.endedMs > finishedMs ||

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -213,19 +213,32 @@ const TERMINAL_WORKFLOW_STATUSES = new Set<WorkspaceOverview["status"]>([
 
 /**
  * True when workflow timing should be presented as terminal. Destroy cleanup
- * is post-terminal only when the overview retained the preceding workflow
- * terminal transition; direct pre-terminal destroys remain conservative.
+ * is post-terminal only when its latest state transition entered cleanup from
+ * the retained workflow terminal transition. Retry history can retain an older
+ * terminal event, so its presence alone does not prove the current attempt
+ * finished before a direct destroy.
  */
 export function hasTerminalWorkflowTiming(
   item: Pick<
     WorkspaceOverview,
-    "status" | "latest_workflow_terminal_state_change"
+    | "status"
+    | "latest_state_change"
+    | "latest_workflow_terminal_state_change"
   >,
 ): boolean {
+  const terminalTransition = item.latest_workflow_terminal_state_change;
+  const cleanupTransition = item.latest_state_change;
   return (
     TERMINAL_WORKFLOW_STATUSES.has(item.status) ||
     (item.status === "destroying" &&
-      item.latest_workflow_terminal_state_change != null)
+      terminalTransition?.event_type === "workspace.state_changed" &&
+      cleanupTransition?.event_type === "workspace.state_changed" &&
+      cleanupTransition.new_state === "destroying" &&
+      cleanupTransition.old_state === terminalTransition.new_state &&
+      terminalTransition.new_state !== "destroyed" &&
+      TERMINAL_WORKFLOW_STATUSES.has(
+        terminalTransition.new_state as WorkspaceOverview["status"],
+      ))
   );
 }
 

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -399,19 +399,22 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
   let finishedAt = latestEntered.stage.ended_at;
   let finishedMs = latestEntered.endedMs;
   if (latestEntered.stage.stage === "completed") {
-    const previousEndMs = entered.reduce<number | null>(
+    const previousEndAt = entered.reduce<string | null>(
       (latest, entry) =>
         entry.stage.stage !== "completed" &&
-        entry.endedMs != null &&
-        (latest == null || entry.endedMs > latest)
-          ? entry.endedMs
+        entry.stage.ended_at != null &&
+        (latest == null || compareRecordedInstants(entry.stage.ended_at, latest) === 1)
+          ? entry.stage.ended_at
           : latest,
       null,
     );
     // The completed stage starts at workflow end but may itself end much later
     // during cleanup. Require the preceding lifecycle boundary to corroborate
     // that start so a collapsed retry history cannot invent a fresh finish.
-    if (previousEndMs !== latestEntered.startedMs) {
+    if (
+      previousEndAt == null ||
+      compareRecordedInstants(previousEndAt, latestEntered.startedAt) !== 0
+    ) {
       return null;
     }
     finishedAt = latestEntered.startedAt;

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -301,6 +301,7 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     // when the latest state-change corroborates the actual terminal transition.
     if (
       terminalEvent?.event_type !== "workspace.state_changed" ||
+      terminalEvent.old_state !== latestEntered.stage.stage ||
       terminalEvent.new_state !== item.status ||
       terminalEventMs !== finishedMs
     ) {

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -291,10 +291,13 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       return null;
     }
     if (
-      stage.started_at == null &&
-      (stage.ended_at != null ||
-        stage.duration_seconds != null ||
-        (stage.status !== "pending" && stage.status !== "terminal_skipped"))
+      ((stage.status === "pending" || stage.status === "terminal_skipped") &&
+        stage.started_at != null) ||
+      (stage.status === "active" && stage.ended_at != null) ||
+      (stage.started_at == null &&
+        (stage.ended_at != null ||
+          stage.duration_seconds != null ||
+          (stage.status !== "pending" && stage.status !== "terminal_skipped")))
     ) {
       return null;
     }

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -536,21 +536,17 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
   let finishedAt = latestEntered.stage.ended_at;
   let finishedMs = latestEntered.endedMs;
   if (latestEntered.stage.stage === "completed") {
-    const previousEndAt = entered.reduce<string | null>(
-      (latest, entry) =>
-        entry.stage.stage !== "completed" &&
-        entry.stage.ended_at != null &&
-        (latest == null || compareRecordedInstants(entry.stage.ended_at, latest) === 1)
-          ? entry.stage.ended_at
-          : latest,
-      null,
-    );
+    const previousEntered = chronologicallyEntered[chronologicallyEntered.length - 2];
     // The completed stage starts at workflow end but may itself end much later
-    // during cleanup. Require the preceding lifecycle boundary to corroborate
-    // that start so a collapsed retry history cannot invent a fresh finish.
+    // during cleanup. Require the immediately preceding entered stage to
+    // corroborate that start so an overlapping or collapsed retry history
+    // cannot invent a fresh finish.
     if (
-      previousEndAt == null ||
-      compareRecordedInstants(previousEndAt, latestEntered.startedAt) !== 0
+      previousEntered?.stage.ended_at == null ||
+      compareRecordedInstants(
+        previousEntered.stage.ended_at,
+        latestEntered.startedAt,
+      ) !== 0
     ) {
       return null;
     }

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -211,6 +211,30 @@ const TERMINAL_WORKFLOW_STATUSES = new Set<WorkspaceOverview["status"]>([
   "destroyed",
 ]);
 
+type RetainedTerminalEvent = NonNullable<
+  WorkspaceOverview["latest_workflow_terminal_state_change"]
+>;
+
+function terminalEventMatchesWorkflowStatus(
+  item: WorkspaceOverview,
+  terminalEvent: RetainedTerminalEvent,
+): boolean {
+  const cleanupFailureConfirmsCancelledBoundary =
+    item.status === "failed" &&
+    terminalEvent.new_state === "cancelled" &&
+    item.latest_state_change?.event_type === "workspace.state_changed" &&
+    item.latest_state_change.old_state === "destroying" &&
+    item.latest_state_change.new_state === "failed";
+  return (
+    terminalEvent.new_state === item.status ||
+    ((item.status === "destroying" || item.status === "destroyed") &&
+      (terminalEvent.new_state === "completed" ||
+        terminalEvent.new_state === "failed" ||
+        terminalEvent.new_state === "cancelled")) ||
+    cleanupFailureConfirmsCancelledBoundary
+  );
+}
+
 /**
  * True when workflow timing should be presented as terminal. Destroy cleanup
  * is post-terminal only when its latest state transition entered cleanup from
@@ -318,6 +342,35 @@ function recordedMilliseconds(value: string | null | undefined): number | null {
   }
   const milliseconds = Date.parse(value);
   return Number.isFinite(milliseconds) ? milliseconds : null;
+}
+
+function retainedTerminalEventTiming(item: WorkspaceOverview): {
+  finishedAt: string;
+  finishedMs: number;
+} | null {
+  // Recovery makes the collapsed lifecycle ambiguous. Its dedicated terminal
+  // event is still authoritative only when it belongs to the latest recovery.
+  const recoveryStartedAt = item.recovery?.started_at;
+  const terminalEvent = item.latest_workflow_terminal_state_change;
+  if (
+    recoveryStartedAt == null ||
+    terminalEvent?.event_type !== "workspace.state_changed" ||
+    (terminalEvent.new_state !== "completed" &&
+      terminalEvent.new_state !== "failed" &&
+      terminalEvent.new_state !== "cancelled") ||
+    !terminalEventMatchesWorkflowStatus(item, terminalEvent)
+  ) {
+    return null;
+  }
+
+  const finishedMs = recordedMilliseconds(terminalEvent.occurred_at);
+  if (
+    finishedMs == null ||
+    compareRecordedInstants(terminalEvent.occurred_at, recoveryStartedAt) !== 1
+  ) {
+    return null;
+  }
+  return { finishedAt: terminalEvent.occurred_at, finishedMs };
 }
 
 function recordedDurationSeconds(value: number | null | undefined): number | null {
@@ -428,19 +481,6 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       item.latest_workflow_terminal_state_change ??
       item.latest_state_change ??
       item.last_event;
-    const cleanupFailureConfirmsCancelledBoundary =
-      item.status === "failed" &&
-      terminalEvent?.new_state === "cancelled" &&
-      item.latest_state_change?.event_type === "workspace.state_changed" &&
-      item.latest_state_change.old_state === "destroying" &&
-      item.latest_state_change.new_state === "failed";
-    const eventMatchesTerminalStatus =
-      terminalEvent?.new_state === item.status ||
-      ((item.status === "destroying" || item.status === "destroyed") &&
-        (terminalEvent?.new_state === "completed" ||
-          terminalEvent?.new_state === "failed" ||
-          terminalEvent?.new_state === "cancelled")) ||
-      cleanupFailureConfirmsCancelledBoundary;
     // Pauses such as blocked/recovering are absent from lifecycle summaries.
     // For terminal paths without a completed stage, only trust that boundary
     // when a retained workflow state-change corroborates the actual terminal
@@ -451,7 +491,7 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     if (
       terminalEvent?.event_type !== "workspace.state_changed" ||
       terminalEvent.old_state !== latestEntered.stage.stage ||
-      !eventMatchesTerminalStatus ||
+      !terminalEventMatchesWorkflowStatus(item, terminalEvent) ||
       compareRecordedInstants(terminalEvent.occurred_at, finishedAt) !== 0
     ) {
       return null;
@@ -514,8 +554,9 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
 /**
  * Resolve the workflow timing displayed by console surfaces. Terminal local
  * overviews and evidenced post-terminal cleanup may derive timing from one
- * complete lifecycle interval; active workspaces retain their explicit timing
- * fields and never infer a finish.
+ * complete lifecycle interval. Recovered terminal overviews may retain only
+ * their terminal event, which supplies a finish but not a duration. Active
+ * workspaces retain their explicit timing fields and never infer a finish.
  */
 export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflowTiming {
   const resolvedFinishedAt = resolveWorkflowFinishedAt(item);
@@ -529,8 +570,17 @@ export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflow
   const explicitFinishedMs = recordedMilliseconds(resolvedFinishedAt);
 
   const lifecycleTiming = lifecycleWorkflowTiming(item);
-  const finishedAt = resolvedFinishedAt ?? lifecycleTiming?.finishedAt ?? null;
-  const finishedMs = explicitFinishedMs ?? lifecycleTiming?.finishedMs ?? null;
+  const retainedTerminalTiming = retainedTerminalEventTiming(item);
+  const finishedAt =
+    resolvedFinishedAt ??
+    lifecycleTiming?.finishedAt ??
+    retainedTerminalTiming?.finishedAt ??
+    null;
+  const finishedMs =
+    explicitFinishedMs ??
+    lifecycleTiming?.finishedMs ??
+    retainedTerminalTiming?.finishedMs ??
+    null;
   if (finishedAt == null || finishedMs == null) {
     return {
       finishedAt: null,

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -556,11 +556,12 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     }
     finishedAt = latestEntered.startedAt;
     finishedMs = latestEntered.startedMs;
-    // A completed status can corroborate legacy payloads that predate retained
-    // state-change fields. Every other current status must retain the transition
-    // into completed, including the supported completed -> cleanup failure path.
+    // A completed or destroyed status can corroborate legacy payloads that
+    // predate retained state-change fields. Other current statuses must retain
+    // the transition into completed, including the supported completed ->
+    // cleanup failure path. Any retained state transition must still agree.
     const requiresCompletedTransition =
-      item.status !== "completed" ||
+      (item.status !== "completed" && item.status !== "destroyed") ||
       terminalEvent?.event_type === "workspace.state_changed";
     if (
       requiresCompletedTransition &&

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -353,12 +353,20 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
   finishedAt: string;
   finishedMs: number;
 } | null {
-  // Recovery makes the collapsed lifecycle ambiguous. Its dedicated terminal
-  // event is still authoritative only when it belongs to the latest recovery.
   const recoveryStartedAt = item.recovery?.started_at;
   const terminalEvent = item.latest_workflow_terminal_state_change;
+  const isDirectPauseExit =
+    recoveryStartedAt == null &&
+    (terminalEvent?.old_state === "blocked" ||
+      terminalEvent?.old_state === "recovering") &&
+    (terminalEvent.new_state === "failed" ||
+      terminalEvent.new_state === "cancelled");
+  // Recovery makes the collapsed lifecycle ambiguous, so its dedicated
+  // terminal event must belong to the latest recovery. Blocked and recovering
+  // are themselves omitted from that lifecycle and recovery summary; a direct
+  // terminal exit from either pause is authoritative without that boundary.
   if (
-    recoveryStartedAt == null ||
+    (recoveryStartedAt == null && !isDirectPauseExit) ||
     terminalEvent?.event_type !== "workspace.state_changed" ||
     (terminalEvent.new_state !== "completed" &&
       terminalEvent.new_state !== "failed" &&
@@ -371,7 +379,9 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
   const finishedMs = recordedMilliseconds(terminalEvent.occurred_at);
   if (
     finishedMs == null ||
-    compareRecordedInstants(terminalEvent.occurred_at, recoveryStartedAt) !== 1
+    (!isDirectPauseExit &&
+      (recoveryStartedAt == null ||
+        compareRecordedInstants(terminalEvent.occurred_at, recoveryStartedAt) !== 1))
   ) {
     return null;
   }

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -431,11 +431,11 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     .sort((left, right) => left.startedMs - right.startedMs);
   // A contiguous tail can corroborate the finish without representing the
   // whole workflow. Only `requested` supplies the authoritative start needed
-  // to report the summed stages as workflow duration.
-  if (durationStages[0]?.stage.stage !== "requested") {
+  // to calculate workflow duration.
+  const [workflowStart] = durationStages;
+  if (workflowStart?.stage.stage !== "requested") {
     return { finishedAt, finishedMs, durationSeconds: null };
   }
-  let durationSeconds = 0;
   let previousEndMs: number | null = null;
   for (const entry of durationStages) {
     const stageDuration = recordedDurationSeconds(entry.stage.duration_seconds);
@@ -457,12 +457,17 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     ) {
       return { finishedAt, finishedMs, durationSeconds: null };
     }
-    durationSeconds += stageDuration;
     previousEndMs = entry.endedMs;
   }
   if (previousEndMs !== finishedMs) {
     return { finishedAt, finishedMs, durationSeconds: null };
   }
+  const durationSeconds = recordedIntervalDurationSeconds(
+    workflowStart.startedAt,
+    workflowStart.startedMs,
+    finishedAt,
+    finishedMs,
+  );
   return { finishedAt, finishedMs, durationSeconds };
 }
 

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -321,6 +321,12 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
         entry.startedMs <= finishedMs,
     )
     .sort((left, right) => left.startedMs - right.startedMs);
+  // A contiguous tail can corroborate the finish without representing the
+  // whole workflow. Only `requested` supplies the authoritative start needed
+  // to report the summed stages as workflow duration.
+  if (durationStages[0]?.stage.stage !== "requested") {
+    return { finishedAt, finishedMs, durationSeconds: null };
+  }
   let durationSeconds = 0;
   let previousEndMs: number | null = null;
   for (const entry of durationStages) {

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -197,6 +197,171 @@ export function distinctFinishedAt(workspace: WorkflowTimingFields): string | nu
   return finishedAt;
 }
 
+const TERMINAL_WORKFLOW_STATUSES = new Set<WorkspaceOverview["status"]>([
+  "completed",
+  "failed",
+  "cancelled",
+  "destroyed",
+]);
+
+export type ResolvedWorkflowTiming = {
+  finishedAt: string | null;
+  durationSeconds: number | null;
+};
+
+type TimedLifecycleStage = {
+  stage: WorkspaceOverview["lifecycle"][number];
+  startedAt: string;
+  startedMs: number;
+  endedMs: number | null;
+};
+
+function recordedMilliseconds(value: string | null | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const milliseconds = Date.parse(value);
+  return Number.isFinite(milliseconds) ? milliseconds : null;
+}
+
+function recordedDurationSeconds(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function lifecycleWorkflowTiming(item: WorkspaceOverview): {
+  finishedAt: string;
+  finishedMs: number;
+  durationSeconds: number | null;
+} | null {
+  // Lifecycle summaries collapse repeated visits to a stage. Once a retry or
+  // reverse transition exists, they cannot identify the current workflow end.
+  if (item.recovery != null) {
+    return null;
+  }
+  const entered: TimedLifecycleStage[] = [];
+  for (const stage of item.lifecycle) {
+    const startedMs = recordedMilliseconds(stage.started_at);
+    const endedMs = recordedMilliseconds(stage.ended_at);
+    if (
+      (stage.started_at != null && startedMs == null) ||
+      (stage.ended_at != null && endedMs == null)
+    ) {
+      return null;
+    }
+    if (
+      stage.started_at == null &&
+      (stage.ended_at != null ||
+        stage.duration_seconds != null ||
+        (stage.status !== "pending" && stage.status !== "terminal_skipped"))
+    ) {
+      return null;
+    }
+    if (stage.started_at != null && startedMs != null) {
+      entered.push({ stage, startedAt: stage.started_at, startedMs, endedMs });
+    }
+  }
+  const latestEntered = entered.reduce<TimedLifecycleStage | null>(
+    (latest, entry) => (latest == null || entry.startedMs > latest.startedMs ? entry : latest),
+    null,
+  );
+  if (latestEntered == null) {
+    return null;
+  }
+
+  let finishedAt = latestEntered.stage.ended_at;
+  let finishedMs = latestEntered.endedMs;
+  if (latestEntered.stage.stage === "completed") {
+    const previousEndMs = entered.reduce<number | null>(
+      (latest, entry) =>
+        entry.stage.stage !== "completed" &&
+        entry.endedMs != null &&
+        (latest == null || entry.endedMs > latest)
+          ? entry.endedMs
+          : latest,
+      null,
+    );
+    // The completed stage starts at workflow end but may itself end much later
+    // during cleanup. Require the preceding lifecycle boundary to corroborate
+    // that start so a collapsed retry history cannot invent a fresh finish.
+    if (previousEndMs !== latestEntered.startedMs) {
+      return null;
+    }
+    finishedAt = latestEntered.startedAt;
+    finishedMs = latestEntered.startedMs;
+  }
+  if (finishedAt == null || finishedMs == null) {
+    return null;
+  }
+
+  const durationStages = entered
+    .filter(
+      (entry) =>
+        entry.stage.stage !== "completed" &&
+        entry.startedMs <= finishedMs,
+    )
+    .sort((left, right) => left.startedMs - right.startedMs);
+  let durationSeconds = 0;
+  let previousEndMs: number | null = null;
+  for (const entry of durationStages) {
+    const stageDuration = recordedDurationSeconds(entry.stage.duration_seconds);
+    if (
+      entry.endedMs == null ||
+      entry.endedMs > finishedMs ||
+      stageDuration == null ||
+      (previousEndMs != null && previousEndMs !== entry.startedMs)
+    ) {
+      return { finishedAt, finishedMs, durationSeconds: null };
+    }
+    durationSeconds += stageDuration;
+    previousEndMs = entry.endedMs;
+  }
+  if (previousEndMs !== finishedMs) {
+    return { finishedAt, finishedMs, durationSeconds: null };
+  }
+  return { finishedAt, finishedMs, durationSeconds };
+}
+
+/**
+ * Resolve the workflow timing displayed by console surfaces. Terminal local
+ * overviews may derive timing from one complete lifecycle interval; active
+ * workspaces retain their explicit timing fields and never infer a finish.
+ */
+export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflowTiming {
+  const resolvedFinishedAt = resolveWorkflowFinishedAt(item);
+  if (!TERMINAL_WORKFLOW_STATUSES.has(item.status)) {
+    return {
+      finishedAt: resolvedFinishedAt,
+      durationSeconds: item.duration_seconds ?? null,
+    };
+  }
+
+  const explicitFinishedMs = recordedMilliseconds(resolvedFinishedAt);
+  if (resolvedFinishedAt != null && explicitFinishedMs == null) {
+    return { finishedAt: null, durationSeconds: null };
+  }
+
+  const lifecycleTiming = lifecycleWorkflowTiming(item);
+  const finishedAt = resolvedFinishedAt ?? lifecycleTiming?.finishedAt ?? null;
+  const finishedMs = explicitFinishedMs ?? lifecycleTiming?.finishedMs ?? null;
+  if (finishedAt == null || finishedMs == null) {
+    return { finishedAt: null, durationSeconds: null };
+  }
+
+  const explicitDurationPresent = item.duration_seconds != null;
+  const explicitDuration = recordedDurationSeconds(item.duration_seconds);
+  let durationSeconds: number | null = null;
+  if (explicitDurationPresent) {
+    const fallbackFinishedMs = recordedMilliseconds(item.finished_at);
+    const durationMatchesFinish =
+      item.finished_at == null || fallbackFinishedMs === finishedMs;
+    durationSeconds = explicitDuration != null && durationMatchesFinish ? explicitDuration : null;
+  } else if (lifecycleTiming?.finishedMs === finishedMs) {
+    durationSeconds = lifecycleTiming.durationSeconds;
+  }
+
+  return { finishedAt, durationSeconds };
+}
+
 type PresentationModelFields = RequestedModelWorkspace & ConfirmedModelWorkspace;
 
 /**

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -285,6 +285,7 @@ export function hasTerminalWorkflowTiming(
   const retainedCleanupEntry = item.latest_destroying_state_change;
   const cleanupFailureHasTerminalBoundary =
     !isCleanupFailure ||
+    hasExplicitWorkflowFinish ||
     (terminalTransition?.event_type === "workspace.state_changed" &&
       TERMINAL_WORKFLOW_STATUSES.has(
         terminalTransition.new_state as WorkspaceOverview["status"],

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -287,6 +287,13 @@ const LIFECYCLE_STAGE_STATUSES = new Set([
   "terminal_skipped",
 ]);
 
+const RESUMED_TERMINAL_SOURCE_STAGES = new Set([
+  "running",
+  "validating",
+  "pushing",
+  "monitoring_pr",
+]);
+
 function lifecycleStageOrder(stage: string): number {
   return lifecycleStages.findIndex((candidate) => candidate === stage);
 }
@@ -373,12 +380,45 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
       terminalEvent?.old_state === "recovering") &&
     (terminalEvent.new_state === "failed" ||
       terminalEvent.new_state === "cancelled");
+  const retainedSourceStages = item.lifecycle.filter(
+    (stage) => stage.stage === terminalEvent?.old_state,
+  );
+  const retainedSourceStage =
+    retainedSourceStages.length === 1 ? retainedSourceStages[0] : null;
+  const retainedSourceIntervalOrder =
+    retainedSourceStage?.started_at != null && retainedSourceStage.ended_at != null
+      ? compareRecordedInstants(
+          retainedSourceStage.ended_at,
+          retainedSourceStage.started_at,
+        )
+      : null;
+  const isRetainedResumeExit =
+    recoveryStartedAt == null &&
+    terminalEvent != null &&
+    typeof terminalEvent.id === "string" &&
+    terminalEvent.id.length > 0 &&
+    item.latest_state_change?.id === terminalEvent.id &&
+    terminalEvent.old_state != null &&
+    RESUMED_TERMINAL_SOURCE_STAGES.has(terminalEvent.old_state) &&
+    retainedSourceStage?.status === "completed" &&
+    retainedSourceStage.ended_at != null &&
+    retainedSourceIntervalOrder != null &&
+    retainedSourceIntervalOrder !== -1 &&
+    compareRecordedInstants(
+      terminalEvent.occurred_at,
+      retainedSourceStage.ended_at,
+    ) === 1;
   // Recovery makes the collapsed lifecycle ambiguous, so its dedicated
   // terminal event must belong to the latest recovery. Blocked and recovering
   // are themselves omitted from that lifecycle and recovery summary; a direct
   // terminal exit from either pause is authoritative without that boundary.
+  // After a pause resumes, the lifecycle retains the first interval for the
+  // re-entered stage; the matching current state transition can prove the later
+  // finish, but not a duration that spans the omitted pause.
   if (
-    (recoveryStartedAt == null && !isDirectPauseExit) ||
+    (recoveryStartedAt == null &&
+      !isDirectPauseExit &&
+      !isRetainedResumeExit) ||
     terminalEvent?.event_type !== "workspace.state_changed" ||
     (terminalEvent.new_state !== "completed" &&
       terminalEvent.new_state !== "failed" &&
@@ -412,6 +452,7 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
   if (
     finishedMs == null ||
     (!isDirectPauseExit &&
+      !isRetainedResumeExit &&
       recoveryComparison !== 1 &&
       !orderedAfterSameInstantRecovery)
   ) {

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -383,10 +383,15 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
   let previousEndMs: number | null = null;
   for (const entry of durationStages) {
     const stageDuration = recordedDurationSeconds(entry.stage.duration_seconds);
+    const intervalDurationSeconds =
+      entry.endedMs == null
+        ? null
+        : Math.floor((entry.endedMs - entry.startedMs) / 1000);
     if (
       entry.endedMs == null ||
       entry.endedMs > finishedMs ||
       stageDuration == null ||
+      stageDuration !== intervalDurationSeconds ||
       (previousEndMs != null && previousEndMs !== entry.startedMs)
     ) {
       return { finishedAt, finishedMs, durationSeconds: null };

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -373,10 +373,7 @@ export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflow
   const explicitDuration = recordedDurationSeconds(item.duration_seconds);
   let durationSeconds: number | null = null;
   if (explicitDurationPresent) {
-    const fallbackFinishedMs = recordedMilliseconds(item.finished_at);
-    const durationMatchesFinish =
-      item.finished_at == null || fallbackFinishedMs === finishedMs;
-    durationSeconds = explicitDuration != null && durationMatchesFinish ? explicitDuration : null;
+    durationSeconds = explicitDuration;
   } else if (lifecycleTiming?.finishedMs === finishedMs) {
     durationSeconds = lifecycleTiming.durationSeconds;
   }

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -272,10 +272,28 @@ export function hasTerminalWorkflowTiming(
 ): boolean {
   const terminalTransition = item.latest_workflow_terminal_state_change;
   const cleanupTransition = item.latest_state_change;
+  const isCleanupFailure =
+    item.status === "failed" &&
+    cleanupTransition?.event_type === "workspace.state_changed" &&
+    cleanupTransition.old_state === "destroying" &&
+    cleanupTransition.new_state === "failed";
+  const retainedCleanupEntry = item.latest_destroying_state_change;
+  const cleanupFailureHasTerminalBoundary =
+    !isCleanupFailure ||
+    (terminalTransition?.event_type === "workspace.state_changed" &&
+      TERMINAL_WORKFLOW_STATUSES.has(
+        terminalTransition.new_state as WorkspaceOverview["status"],
+      ) &&
+      // Legacy payloads can omit this field; current Core payloads must match it.
+      (retainedCleanupEntry == null ||
+        (retainedCleanupEntry.event_type === "workspace.state_changed" &&
+          retainedCleanupEntry.new_state === "destroying" &&
+          cleanupEntryMatchesRetainedTerminal(
+            retainedCleanupEntry,
+            terminalTransition,
+          ))));
   const cleanupEntryTransition =
-    item.status === "destroyed"
-      ? item.latest_destroying_state_change
-      : cleanupTransition;
+    item.status === "destroyed" ? retainedCleanupEntry : cleanupTransition;
   const cleanupExitMatchesStatus =
     item.status === "destroying" ||
     (item.status === "destroyed" &&
@@ -283,7 +301,8 @@ export function hasTerminalWorkflowTiming(
       cleanupTransition.old_state === "destroying" &&
       cleanupTransition.new_state === "destroyed");
   return (
-    TERMINAL_WORKFLOW_STATUSES.has(item.status) ||
+    (TERMINAL_WORKFLOW_STATUSES.has(item.status) &&
+      cleanupFailureHasTerminalBoundary) ||
     ((item.status === "destroying" || item.status === "destroyed") &&
       terminalTransition?.event_type === "workspace.state_changed" &&
       cleanupEntryTransition?.event_type === "workspace.state_changed" &&

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -293,7 +293,7 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     if (
       ((stage.status === "pending" || stage.status === "terminal_skipped") &&
         stage.started_at != null) ||
-      (stage.status === "active" && stage.ended_at != null) ||
+      stage.status === "active" ||
       (stage.started_at == null &&
         (stage.ended_at != null ||
           stage.duration_seconds != null ||

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -412,7 +412,6 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       item.latest_workflow_terminal_state_change ??
       item.latest_state_change ??
       item.last_event;
-    const terminalEventMs = recordedMilliseconds(terminalEvent?.occurred_at);
     const cleanupFailureConfirmsCancelledBoundary =
       item.status === "failed" &&
       terminalEvent?.new_state === "cancelled" &&
@@ -437,7 +436,7 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       terminalEvent?.event_type !== "workspace.state_changed" ||
       terminalEvent.old_state !== latestEntered.stage.stage ||
       !eventMatchesTerminalStatus ||
-      terminalEventMs !== finishedMs
+      compareRecordedInstants(terminalEvent.occurred_at, finishedAt) !== 0
     ) {
       return null;
     }

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -360,7 +360,10 @@ export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflow
   const finishedAt = resolvedFinishedAt ?? lifecycleTiming?.finishedAt ?? null;
   const finishedMs = explicitFinishedMs ?? lifecycleTiming?.finishedMs ?? null;
   if (finishedAt == null || finishedMs == null) {
-    return { finishedAt: null, durationSeconds: null };
+    return {
+      finishedAt: null,
+      durationSeconds: recordedDurationSeconds(item.duration_seconds),
+    };
   }
 
   const explicitDurationPresent = item.duration_seconds != null;

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -353,7 +353,10 @@ export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflow
 
   const explicitFinishedMs = recordedMilliseconds(resolvedFinishedAt);
   if (resolvedFinishedAt != null && explicitFinishedMs == null) {
-    return { finishedAt: null, durationSeconds: null };
+    return {
+      finishedAt: null,
+      durationSeconds: recordedDurationSeconds(item.duration_seconds),
+    };
   }
 
   const lifecycleTiming = lifecycleWorkflowTiming(item);

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -281,7 +281,8 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     const endedMs = recordedMilliseconds(stage.ended_at);
     if (
       (stage.started_at != null && startedMs == null) ||
-      (stage.ended_at != null && endedMs == null)
+      (stage.ended_at != null && endedMs == null) ||
+      (startedMs != null && endedMs != null && endedMs < startedMs)
     ) {
       return null;
     }

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -258,7 +258,7 @@ function terminalEventMatchesWorkflowStatus(
  * is post-terminal only when its retained cleanup entry came from the retained
  * workflow terminal transition and a destroyed workspace retains the matching
  * cleanup exit. A valid explicit workflow finish also proves that a hosted or
- * legacy destroyed row reached a workflow terminal boundary when those optional
+ * legacy cleanup row reached a workflow terminal boundary when those optional
  * Core event projections are absent. Retry history can retain an older terminal
  * event, so its presence alone does not prove the current attempt finished
  * before a direct destroy.
@@ -308,7 +308,8 @@ export function hasTerminalWorkflowTiming(
   return (
     (TERMINAL_WORKFLOW_STATUSES.has(item.status) &&
       cleanupFailureHasTerminalBoundary) ||
-    (item.status === "destroyed" && hasExplicitWorkflowFinish) ||
+    ((item.status === "destroying" || item.status === "destroyed") &&
+      hasExplicitWorkflowFinish) ||
     ((item.status === "destroying" || item.status === "destroyed") &&
       terminalTransition?.event_type === "workspace.state_changed" &&
       cleanupEntryTransition?.event_type === "workspace.state_changed" &&

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -287,15 +287,7 @@ function submillisecondFraction(value: string): string {
   return fractionalSeconds.slice(4).replace(/0+$/, "");
 }
 
-function compareRecordedInstants(left: string, right: string): number | null {
-  const leftMs = recordedMilliseconds(left);
-  const rightMs = recordedMilliseconds(right);
-  if (leftMs == null || rightMs == null) {
-    return null;
-  }
-  if (leftMs !== rightMs) {
-    return leftMs < rightMs ? -1 : 1;
-  }
+function compareSubmillisecondFractions(left: string, right: string): number {
   const leftFraction = submillisecondFraction(left);
   const rightFraction = submillisecondFraction(right);
   const precision = Math.max(leftFraction.length, rightFraction.length);
@@ -306,6 +298,18 @@ function compareRecordedInstants(left: string, right: string): number | null {
     : normalizedLeft < normalizedRight
       ? -1
       : 1;
+}
+
+function compareRecordedInstants(left: string, right: string): number | null {
+  const leftMs = recordedMilliseconds(left);
+  const rightMs = recordedMilliseconds(right);
+  if (leftMs == null || rightMs == null) {
+    return null;
+  }
+  if (leftMs !== rightMs) {
+    return leftMs < rightMs ? -1 : 1;
+  }
+  return compareSubmillisecondFractions(left, right);
 }
 
 function recordedMilliseconds(value: string | null | undefined): number | null {
@@ -384,17 +388,16 @@ function recordedIntervalDurationSeconds(
   endedAt: string,
   endedMs: number,
 ): number {
-  const submillisecondMicroseconds = (value: string): number => {
-    const fractionalSeconds = RFC3339_DATE_TIME.exec(value)?.[7] ?? "";
-    return Number(fractionalSeconds.slice(4, 7).padEnd(3, "0"));
-  };
   const elapsedMilliseconds = endedMs - startedMs;
   const elapsedWholeSeconds = Math.floor(elapsedMilliseconds / 1000);
-  const elapsedMicroseconds =
-    (elapsedMilliseconds - elapsedWholeSeconds * 1000) * 1000 +
-    submillisecondMicroseconds(endedAt) -
-    submillisecondMicroseconds(startedAt);
-  return elapsedWholeSeconds + Math.floor(elapsedMicroseconds / 1_000_000);
+  const elapsedMillisecondRemainder =
+    elapsedMilliseconds - elapsedWholeSeconds * 1000;
+  // Date.parse retains milliseconds. The remaining fractional digits can
+  // lower the floored duration only at an exact millisecond-second boundary.
+  return elapsedMillisecondRemainder === 0 &&
+    compareSubmillisecondFractions(endedAt, startedAt) === -1
+    ? elapsedWholeSeconds - 1
+    : elapsedWholeSeconds;
 }
 
 function lifecycleWorkflowTiming(item: WorkspaceOverview): {

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -740,6 +740,17 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     ) {
       return null;
     }
+    // Current Core events carry a workspace-local order, but lifecycle stages
+    // retain only timestamps. When an ordered terminal event ties the retained
+    // stage end, that stage may have been closed by an earlier same-tick pause
+    // before re-entry and terminal exit. The event still proves the finish;
+    // without the lifecycle boundary's order it cannot prove the duration.
+    if (
+      typeof terminalEvent.event_order === "number" &&
+      Number.isSafeInteger(terminalEvent.event_order)
+    ) {
+      return { finishedAt, finishedMs, durationSeconds: null };
+    }
   }
 
   const durationStages = entered

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -293,6 +293,20 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
   if (finishedAt == null || finishedMs == null) {
     return null;
   }
+  if (latestEntered.stage.stage !== "completed") {
+    const terminalEvent = item.last_event;
+    const terminalEventMs = recordedMilliseconds(terminalEvent?.occurred_at);
+    // Pauses such as blocked/recovering are absent from lifecycle summaries.
+    // For terminal paths without a completed stage, only trust that boundary
+    // when the latest state-change corroborates the actual terminal transition.
+    if (
+      terminalEvent?.event_type !== "workspace.state_changed" ||
+      terminalEvent.new_state !== item.status ||
+      terminalEventMs !== finishedMs
+    ) {
+      return null;
+    }
+  }
 
   const durationStages = entered
     .filter(

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -180,9 +180,13 @@ function sameRecordedInstant(left: string, right: string): boolean {
   if (left === right) {
     return true;
   }
-  const leftMs = Date.parse(left);
-  const rightMs = Date.parse(right);
-  return Number.isFinite(leftMs) && leftMs === rightMs;
+  const leftMs = recordedMilliseconds(left);
+  const rightMs = recordedMilliseconds(right);
+  return (
+    leftMs != null &&
+    leftMs === rightMs &&
+    submillisecondFraction(left) === submillisecondFraction(right)
+  );
 }
 
 /**
@@ -227,6 +231,11 @@ type TimedLifecycleStage = {
 
 const RFC3339_DATE_TIME =
   /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(\.\d+)?([Zz]|[+-](\d{2}):(\d{2}))$/;
+
+function submillisecondFraction(value: string): string {
+  const fractionalSeconds = RFC3339_DATE_TIME.exec(value)?.[7] ?? "";
+  return fractionalSeconds.slice(4).replace(/0+$/, "");
+}
 
 function recordedMilliseconds(value: string | null | undefined): number | null {
   if (!value) {
@@ -467,7 +476,10 @@ export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflow
   let durationSeconds: number | null = null;
   if (explicitDurationPresent) {
     durationSeconds = explicitDuration;
-  } else if (lifecycleTiming?.finishedMs === finishedMs) {
+  } else if (
+    lifecycleTiming != null &&
+    sameRecordedInstant(lifecycleTiming.finishedAt, finishedAt)
+  ) {
     durationSeconds = lifecycleTiming.durationSeconds;
   }
 

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -218,6 +218,21 @@ type RetainedTerminalEvent = NonNullable<
 
 type RetainedStateChangeEvent = NonNullable<WorkspaceOverview["latest_state_change"]>;
 
+// Core omits destroying -> failed cleanup failures from the retained workflow
+// terminal field. With a retained completed/cancelled terminal, a later cleanup
+// entry from failed can therefore only be a destroy retry of that workflow.
+function cleanupEntryMatchesRetainedTerminal(
+  cleanupEvent: RetainedStateChangeEvent,
+  terminalEvent: RetainedTerminalEvent,
+): boolean {
+  return (
+    cleanupEvent.old_state === terminalEvent.new_state ||
+    (cleanupEvent.old_state === "failed" &&
+      (terminalEvent.new_state === "completed" ||
+        terminalEvent.new_state === "cancelled"))
+  );
+}
+
 function terminalEventMatchesWorkflowStatus(
   item: WorkspaceOverview,
   terminalEvent: RetainedTerminalEvent,
@@ -262,7 +277,7 @@ export function hasTerminalWorkflowTiming(
       terminalTransition?.event_type === "workspace.state_changed" &&
       cleanupTransition?.event_type === "workspace.state_changed" &&
       cleanupTransition.new_state === "destroying" &&
-      cleanupTransition.old_state === terminalTransition.new_state &&
+      cleanupEntryMatchesRetainedTerminal(cleanupTransition, terminalTransition) &&
       terminalTransition.new_state !== "destroyed" &&
       TERMINAL_WORKFLOW_STATUSES.has(
         terminalTransition.new_state as WorkspaceOverview["status"],
@@ -425,7 +440,7 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
   const cleanupEnteredFromTerminal =
     terminalEvent != null &&
     destroyingStateChange?.event_type === "workspace.state_changed" &&
-    destroyingStateChange.old_state === terminalEvent.new_state &&
+    cleanupEntryMatchesRetainedTerminal(destroyingStateChange, terminalEvent) &&
     destroyingStateChange.new_state === "destroying" &&
     eventStrictlyFollows(destroyingStateChange, terminalEvent);
   const subsequentCleanupCorroboratesTerminal =

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -191,7 +191,7 @@ function sameRecordedInstant(left: string, right: string): boolean {
  */
 export function distinctFinishedAt(workspace: WorkflowTimingFields): string | null {
   const finishedAt = workspace.finished_at;
-  if (recordedMilliseconds(finishedAt) == null) {
+  if (finishedAt == null || recordedMilliseconds(finishedAt) == null) {
     return null;
   }
   const workflowFinishedAt = resolveWorkflowFinishedAt(workspace);

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -221,8 +221,40 @@ type TimedLifecycleStage = {
   endedMs: number | null;
 };
 
+const RFC3339_DATE_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(\.\d+)?([Zz]|[+-](\d{2}):(\d{2}))$/;
+
 function recordedMilliseconds(value: string | null | undefined): number | null {
   if (!value) {
+    return null;
+  }
+  const match = RFC3339_DATE_TIME.exec(value);
+  if (!match) {
+    return null;
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const dateTime = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  if (
+    dateTime.getUTCFullYear() !== year ||
+    dateTime.getUTCMonth() !== month - 1 ||
+    dateTime.getUTCDate() !== day ||
+    dateTime.getUTCHours() !== hour ||
+    dateTime.getUTCMinutes() !== minute ||
+    dateTime.getUTCSeconds() !== second
+  ) {
+    return null;
+  }
+  const timezone = match[8];
+  if (
+    timezone !== "Z" &&
+    timezone !== "z" &&
+    (Number(match[9]) > 23 || Number(match[10]) > 59)
+  ) {
     return null;
   }
   const milliseconds = Date.parse(value);

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -260,13 +260,14 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       entered.push({ stage, startedAt: stage.started_at, startedMs, endedMs });
     }
   }
-  const latestEntered = entered.reduce<TimedLifecycleStage | null>(
-    (latest, entry) => (latest == null || entry.startedMs > latest.startedMs ? entry : latest),
-    null,
+  const latestStartedMs = Math.max(...entered.map((entry) => entry.startedMs));
+  const latestCandidates = entered.filter(
+    (entry) => entry.startedMs === latestStartedMs,
   );
-  if (latestEntered == null) {
+  if (latestCandidates.length !== 1) {
     return null;
   }
+  const [latestEntered] = latestCandidates;
 
   let finishedAt = latestEntered.stage.ended_at;
   let finishedMs = latestEntered.endedMs;

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -686,6 +686,7 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     item.last_event;
   let finishedAt = latestEntered.stage.ended_at;
   let finishedMs = latestEntered.endedMs;
+  let lifecycleBoundaryStage = latestEntered.stage;
   if (latestEntered.stage.stage === "completed") {
     const previousEntered = chronologicallyEntered[chronologicallyEntered.length - 2];
     // The completed stage starts at workflow end but may itself end much later
@@ -701,6 +702,7 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     ) {
       return null;
     }
+    lifecycleBoundaryStage = previousEntered.stage;
     finishedAt = latestEntered.startedAt;
     finishedMs = latestEntered.startedMs;
     // A completed or destroyed status can corroborate legacy payloads that
@@ -740,22 +742,22 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     ) {
       return null;
     }
-    // Compare Core's workspace-local order with the event that first closed
-    // this collapsed stage. A later same-tick terminal event proves the finish
-    // but also proves an omitted re-entry, so the retained interval cannot
-    // prove duration. Legacy payloads without the boundary order stay
-    // conservative when the terminal event is ordered.
-    const terminalEventOrder = terminalEvent.event_order;
-    const lifecycleBoundaryOrder = latestEntered.stage.ended_event_order;
-    if (
-      typeof terminalEventOrder === "number" &&
-      Number.isSafeInteger(terminalEventOrder) &&
-      (typeof lifecycleBoundaryOrder !== "number" ||
-        !Number.isSafeInteger(lifecycleBoundaryOrder) ||
-        lifecycleBoundaryOrder !== terminalEventOrder)
-    ) {
-      return { finishedAt, finishedMs, durationSeconds: null };
-    }
+  }
+  // Compare Core's workspace-local order with the event that first closed
+  // the terminal source stage. A later same-tick terminal event proves the
+  // finish but also proves an omitted re-entry, so the retained interval
+  // cannot prove duration. Legacy payloads without the boundary order stay
+  // conservative when the terminal event is ordered.
+  const terminalEventOrder = terminalEvent?.event_order;
+  const lifecycleBoundaryOrder = lifecycleBoundaryStage.ended_event_order;
+  if (
+    typeof terminalEventOrder === "number" &&
+    Number.isSafeInteger(terminalEventOrder) &&
+    (typeof lifecycleBoundaryOrder !== "number" ||
+      !Number.isSafeInteger(lifecycleBoundaryOrder) ||
+      lifecycleBoundaryOrder !== terminalEventOrder)
+  ) {
+    return { finishedAt, finishedMs, durationSeconds: null };
   }
 
   const durationStages = entered

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -180,13 +180,7 @@ function sameRecordedInstant(left: string, right: string): boolean {
   if (left === right) {
     return true;
   }
-  const leftMs = recordedMilliseconds(left);
-  const rightMs = recordedMilliseconds(right);
-  return (
-    leftMs != null &&
-    leftMs === rightMs &&
-    submillisecondFraction(left) === submillisecondFraction(right)
-  );
+  return compareRecordedInstants(left, right) === 0;
 }
 
 /**
@@ -235,6 +229,27 @@ const RFC3339_DATE_TIME =
 function submillisecondFraction(value: string): string {
   const fractionalSeconds = RFC3339_DATE_TIME.exec(value)?.[7] ?? "";
   return fractionalSeconds.slice(4).replace(/0+$/, "");
+}
+
+function compareRecordedInstants(left: string, right: string): number | null {
+  const leftMs = recordedMilliseconds(left);
+  const rightMs = recordedMilliseconds(right);
+  if (leftMs == null || rightMs == null) {
+    return null;
+  }
+  if (leftMs !== rightMs) {
+    return leftMs < rightMs ? -1 : 1;
+  }
+  const leftFraction = submillisecondFraction(left);
+  const rightFraction = submillisecondFraction(right);
+  const precision = Math.max(leftFraction.length, rightFraction.length);
+  const normalizedLeft = leftFraction.padEnd(precision, "0");
+  const normalizedRight = rightFraction.padEnd(precision, "0");
+  return normalizedLeft === normalizedRight
+    ? 0
+    : normalizedLeft < normalizedRight
+      ? -1
+      : 1;
 }
 
 function recordedMilliseconds(value: string | null | undefined): number | null {
@@ -333,14 +348,20 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       entered.push({ stage, startedAt: stage.started_at, startedMs, endedMs });
     }
   }
-  const latestStartedMs = Math.max(...entered.map((entry) => entry.startedMs));
-  const latestCandidates = entered.filter(
-    (entry) => entry.startedMs === latestStartedMs,
+  const latestEntered = entered.reduce<TimedLifecycleStage | null>(
+    (latest, entry) =>
+      latest == null || compareRecordedInstants(entry.startedAt, latest.startedAt) === 1
+        ? entry
+        : latest,
+    null,
   );
-  if (latestCandidates.length !== 1) {
+  if (
+    latestEntered == null ||
+    entered.filter((entry) => sameRecordedInstant(entry.startedAt, latestEntered.startedAt))
+      .length !== 1
+  ) {
     return null;
   }
-  const [latestEntered] = latestCandidates;
 
   let finishedAt = latestEntered.stage.ended_at;
   let finishedMs = latestEntered.endedMs;

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceOverview } from "@/lib/types";
+import { lifecycleStages } from "./format.ts";
 
 type AgentLabelWorkspace = Pick<
   WorkspaceOverview,
@@ -279,6 +280,10 @@ type TimedLifecycleStage = {
   endedMs: number | null;
 };
 
+function lifecycleStageOrder(stage: string): number {
+  return lifecycleStages.findIndex((candidate) => candidate === stage);
+}
+
 const RFC3339_DATE_TIME =
   /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(\.\d+)?([Zz]|[+-](\d{2}):(\d{2}))$/;
 
@@ -460,19 +465,35 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       entered.push({ stage, startedAt: stage.started_at, startedMs, endedMs });
     }
   }
-  const latestEntered = entered.reduce<TimedLifecycleStage | null>(
+  let latestEntered = entered.reduce<TimedLifecycleStage | null>(
     (latest, entry) =>
       latest == null || compareRecordedInstants(entry.startedAt, latest.startedAt) === 1
         ? entry
         : latest,
     null,
   );
-  if (
-    latestEntered == null ||
-    entered.filter((entry) => sameRecordedInstant(entry.startedAt, latestEntered.startedAt))
-      .length !== 1
-  ) {
+  if (latestEntered == null) {
     return null;
+  }
+  const latestStartedAt = latestEntered.startedAt;
+  const latestCandidates = entered.filter((entry) =>
+    sameRecordedInstant(entry.startedAt, latestStartedAt),
+  );
+  if (latestCandidates.length > 1) {
+    const stageOrders = latestCandidates.map((entry) =>
+      lifecycleStageOrder(entry.stage.stage),
+    );
+    if (
+      stageOrders.some((stageOrder) => stageOrder < 0) ||
+      new Set(stageOrders).size !== stageOrders.length
+    ) {
+      return null;
+    }
+    latestEntered = latestCandidates.reduce((latest, entry) =>
+      lifecycleStageOrder(entry.stage.stage) > lifecycleStageOrder(latest.stage.stage)
+        ? entry
+        : latest,
+    );
   }
 
   let finishedAt = latestEntered.stage.ended_at;

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -331,17 +331,26 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     return null;
   }
   if (latestEntered.stage.stage !== "completed") {
-    const terminalEvent = item.latest_state_change ?? item.last_event;
+    const terminalEvent =
+      item.latest_workflow_terminal_state_change ??
+      item.latest_state_change ??
+      item.last_event;
     const terminalEventMs = recordedMilliseconds(terminalEvent?.occurred_at);
+    const eventMatchesTerminalStatus =
+      terminalEvent?.new_state === item.status ||
+      (item.status === "destroyed" &&
+        (terminalEvent?.new_state === "failed" ||
+          terminalEvent?.new_state === "cancelled"));
     // Pauses such as blocked/recovering are absent from lifecycle summaries.
     // For terminal paths without a completed stage, only trust that boundary
-    // when the latest state-change corroborates the actual terminal transition.
-    // `last_event` remains a compatibility fallback because cleanup can append
-    // a newer non-state audit event after that transition.
+    // when a retained workflow state-change corroborates the actual terminal
+    // transition. A destroyed workspace may retain the failed/cancelled
+    // boundary that preceded its later cleanup transitions. `last_event`
+    // remains a compatibility fallback for older overview payloads.
     if (
       terminalEvent?.event_type !== "workspace.state_changed" ||
       terminalEvent.old_state !== latestEntered.stage.stage ||
-      terminalEvent.new_state !== item.status ||
+      !eventMatchesTerminalStatus ||
       terminalEventMs !== finishedMs
     ) {
       return null;

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -193,7 +193,7 @@ function sameRecordedInstant(left: string, right: string): boolean {
  */
 export function distinctFinishedAt(workspace: WorkflowTimingFields): string | null {
   const finishedAt = workspace.finished_at;
-  if (!finishedAt) {
+  if (recordedMilliseconds(finishedAt) == null) {
     return null;
   }
   const workflowFinishedAt = resolveWorkflowFinishedAt(workspace);

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -280,6 +280,13 @@ type TimedLifecycleStage = {
   endedMs: number | null;
 };
 
+const LIFECYCLE_STAGE_STATUSES = new Set([
+  "pending",
+  "active",
+  "completed",
+  "terminal_skipped",
+]);
+
 function lifecycleStageOrder(stage: string): number {
   return lifecycleStages.findIndex((candidate) => candidate === stage);
 }
@@ -448,6 +455,9 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
   const entered: TimedLifecycleStage[] = [];
   const seenStages = new Set<string>();
   for (const stage of item.lifecycle) {
+    if (!LIFECYCLE_STAGE_STATUSES.has(stage.status)) {
+      return null;
+    }
     if (seenStages.has(stage.stage)) {
       return null;
     }

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -469,7 +469,7 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
   if (workflowStart?.stage.stage !== "requested") {
     return { finishedAt, finishedMs, durationSeconds: null };
   }
-  let previousEndMs: number | null = null;
+  let previousEndAt: string | null = null;
   for (const entry of durationStages) {
     const stageDuration = recordedDurationSeconds(entry.stage.duration_seconds);
     const intervalDurationSeconds =
@@ -486,13 +486,17 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       entry.endedMs > finishedMs ||
       stageDuration == null ||
       stageDuration !== intervalDurationSeconds ||
-      (previousEndMs != null && previousEndMs !== entry.startedMs)
+      (previousEndAt != null &&
+        compareRecordedInstants(previousEndAt, entry.startedAt) !== 0)
     ) {
       return { finishedAt, finishedMs, durationSeconds: null };
     }
-    previousEndMs = entry.endedMs;
+    previousEndAt = entry.stage.ended_at;
   }
-  if (previousEndMs !== finishedMs) {
+  if (
+    previousEndAt == null ||
+    compareRecordedInstants(previousEndAt, finishedAt) !== 0
+  ) {
     return { finishedAt, finishedMs, durationSeconds: null };
   }
   const durationSeconds = recordedIntervalDurationSeconds(

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -219,9 +219,10 @@ function terminalEventMatchesWorkflowStatus(
   item: WorkspaceOverview,
   terminalEvent: RetainedTerminalEvent,
 ): boolean {
-  const cleanupFailureConfirmsCancelledBoundary =
+  const cleanupFailureConfirmsEarlierTerminalBoundary =
     item.status === "failed" &&
-    terminalEvent.new_state === "cancelled" &&
+    (terminalEvent.new_state === "completed" ||
+      terminalEvent.new_state === "cancelled") &&
     item.latest_state_change?.event_type === "workspace.state_changed" &&
     item.latest_state_change.old_state === "destroying" &&
     item.latest_state_change.new_state === "failed";
@@ -231,7 +232,7 @@ function terminalEventMatchesWorkflowStatus(
       (terminalEvent.new_state === "completed" ||
         terminalEvent.new_state === "failed" ||
         terminalEvent.new_state === "cancelled")) ||
-    cleanupFailureConfirmsCancelledBoundary
+    cleanupFailureConfirmsEarlierTerminalBoundary
   );
 }
 

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -257,9 +257,11 @@ function terminalEventMatchesWorkflowStatus(
  * True when workflow timing should be presented as terminal. Destroy cleanup
  * is post-terminal only when its retained cleanup entry came from the retained
  * workflow terminal transition and a destroyed workspace retains the matching
- * cleanup exit. Retry history can retain an older terminal event, so its
- * presence alone does not prove the current attempt finished before a direct
- * destroy.
+ * cleanup exit. A valid explicit workflow finish also proves that a hosted or
+ * legacy destroyed row reached a workflow terminal boundary when those optional
+ * Core event projections are absent. Retry history can retain an older terminal
+ * event, so its presence alone does not prove the current attempt finished
+ * before a direct destroy.
  */
 export function hasTerminalWorkflowTiming(
   item: Pick<
@@ -268,10 +270,13 @@ export function hasTerminalWorkflowTiming(
     | "latest_destroying_state_change"
     | "latest_state_change"
     | "latest_workflow_terminal_state_change"
+    | "workflow_finished_at"
+    | "finished_at"
   >,
 ): boolean {
   const terminalTransition = item.latest_workflow_terminal_state_change;
   const cleanupTransition = item.latest_state_change;
+  const hasExplicitWorkflowFinish = resolveWorkflowFinishedAt(item) != null;
   const isCleanupFailure =
     item.status === "failed" &&
     cleanupTransition?.event_type === "workspace.state_changed" &&
@@ -303,6 +308,7 @@ export function hasTerminalWorkflowTiming(
   return (
     (TERMINAL_WORKFLOW_STATUSES.has(item.status) &&
       cleanupFailureHasTerminalBoundary) ||
+    (item.status === "destroyed" && hasExplicitWorkflowFinish) ||
     ((item.status === "destroying" || item.status === "destroyed") &&
       terminalTransition?.event_type === "workspace.state_changed" &&
       cleanupEntryTransition?.event_type === "workspace.state_changed" &&

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -211,6 +211,24 @@ const TERMINAL_WORKFLOW_STATUSES = new Set<WorkspaceOverview["status"]>([
   "destroyed",
 ]);
 
+/**
+ * True when workflow timing should be presented as terminal. Destroy cleanup
+ * is post-terminal only when the overview retained the preceding workflow
+ * terminal transition; direct pre-terminal destroys remain conservative.
+ */
+export function hasTerminalWorkflowTiming(
+  item: Pick<
+    WorkspaceOverview,
+    "status" | "latest_workflow_terminal_state_change"
+  >,
+): boolean {
+  return (
+    TERMINAL_WORKFLOW_STATUSES.has(item.status) ||
+    (item.status === "destroying" &&
+      item.latest_workflow_terminal_state_change != null)
+  );
+}
+
 export type ResolvedWorkflowTiming = {
   finishedAt: string | null;
   durationSeconds: number | null;
@@ -401,8 +419,9 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
       item.latest_state_change.new_state === "failed";
     const eventMatchesTerminalStatus =
       terminalEvent?.new_state === item.status ||
-      (item.status === "destroyed" &&
-        (terminalEvent?.new_state === "failed" ||
+      ((item.status === "destroying" || item.status === "destroyed") &&
+        (terminalEvent?.new_state === "completed" ||
+          terminalEvent?.new_state === "failed" ||
           terminalEvent?.new_state === "cancelled")) ||
       cleanupFailureConfirmsCancelledBoundary;
     // Pauses such as blocked/recovering are absent from lifecycle summaries.
@@ -473,12 +492,13 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
 
 /**
  * Resolve the workflow timing displayed by console surfaces. Terminal local
- * overviews may derive timing from one complete lifecycle interval; active
- * workspaces retain their explicit timing fields and never infer a finish.
+ * overviews and evidenced post-terminal cleanup may derive timing from one
+ * complete lifecycle interval; active workspaces retain their explicit timing
+ * fields and never infer a finish.
  */
 export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflowTiming {
   const resolvedFinishedAt = resolveWorkflowFinishedAt(item);
-  if (!TERMINAL_WORKFLOW_STATUSES.has(item.status)) {
+  if (!hasTerminalWorkflowTiming(item)) {
     return {
       finishedAt: resolvedFinishedAt,
       durationSeconds: item.duration_seconds ?? null,

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -418,7 +418,7 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
   const destroyingStateChange =
     item.status === "destroying"
       ? latestStateChange
-      : item.status === "destroyed"
+      : item.status === "destroyed" || item.status === "failed"
         ? item.latest_destroying_state_change
         : null;
   const terminalEventOrder = terminalEvent?.event_order;
@@ -434,7 +434,7 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
     latestStateChange?.event_type === "workspace.state_changed" &&
     latestStateChange.new_state === item.status &&
     (item.status === "destroying" ||
-      (item.status === "destroyed" &&
+      ((item.status === "destroyed" || item.status === "failed") &&
         destroyingStateChange != null &&
         latestStateChange.old_state === "destroying" &&
         eventStrictlyFollows(latestStateChange, destroyingStateChange)));

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -209,7 +209,6 @@ const TERMINAL_WORKFLOW_STATUSES = new Set<WorkspaceOverview["status"]>([
   "completed",
   "failed",
   "cancelled",
-  "destroyed",
 ]);
 
 type RetainedTerminalEvent = NonNullable<
@@ -256,28 +255,44 @@ function terminalEventMatchesWorkflowStatus(
 
 /**
  * True when workflow timing should be presented as terminal. Destroy cleanup
- * is post-terminal only when its latest state transition entered cleanup from
- * the retained workflow terminal transition. Retry history can retain an older
- * terminal event, so its presence alone does not prove the current attempt
- * finished before a direct destroy.
+ * is post-terminal only when its retained cleanup entry came from the retained
+ * workflow terminal transition and a destroyed workspace retains the matching
+ * cleanup exit. Retry history can retain an older terminal event, so its
+ * presence alone does not prove the current attempt finished before a direct
+ * destroy.
  */
 export function hasTerminalWorkflowTiming(
   item: Pick<
     WorkspaceOverview,
     | "status"
+    | "latest_destroying_state_change"
     | "latest_state_change"
     | "latest_workflow_terminal_state_change"
   >,
 ): boolean {
   const terminalTransition = item.latest_workflow_terminal_state_change;
   const cleanupTransition = item.latest_state_change;
+  const cleanupEntryTransition =
+    item.status === "destroyed"
+      ? item.latest_destroying_state_change
+      : cleanupTransition;
+  const cleanupExitMatchesStatus =
+    item.status === "destroying" ||
+    (item.status === "destroyed" &&
+      cleanupTransition?.event_type === "workspace.state_changed" &&
+      cleanupTransition.old_state === "destroying" &&
+      cleanupTransition.new_state === "destroyed");
   return (
     TERMINAL_WORKFLOW_STATUSES.has(item.status) ||
-    (item.status === "destroying" &&
+    ((item.status === "destroying" || item.status === "destroyed") &&
       terminalTransition?.event_type === "workspace.state_changed" &&
-      cleanupTransition?.event_type === "workspace.state_changed" &&
-      cleanupTransition.new_state === "destroying" &&
-      cleanupEntryMatchesRetainedTerminal(cleanupTransition, terminalTransition) &&
+      cleanupEntryTransition?.event_type === "workspace.state_changed" &&
+      cleanupEntryTransition.new_state === "destroying" &&
+      cleanupEntryMatchesRetainedTerminal(
+        cleanupEntryTransition,
+        terminalTransition,
+      ) &&
+      cleanupExitMatchesStatus &&
       terminalTransition.new_state !== "destroyed" &&
       TERMINAL_WORKFLOW_STATUSES.has(
         terminalTransition.new_state as WorkspaceOverview["status"],

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -392,12 +392,43 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
           retainedSourceStage.started_at,
         )
       : null;
+  const latestStateChange = item.latest_state_change;
+  const cleanupOrder =
+    latestStateChange != null && terminalEvent != null
+      ? compareRecordedInstants(
+          latestStateChange.occurred_at,
+          terminalEvent.occurred_at,
+        )
+      : null;
+  const cleanupEventOrder = latestStateChange?.event_order;
+  const terminalEventOrder = terminalEvent?.event_order;
+  const hasCleanupEventOrderProof =
+    typeof cleanupEventOrder === "number" &&
+    Number.isSafeInteger(cleanupEventOrder) &&
+    typeof terminalEventOrder === "number" &&
+    Number.isSafeInteger(terminalEventOrder);
+  const cleanupFollowsTerminalEvent =
+    cleanupOrder != null &&
+    cleanupOrder !== -1 &&
+    (hasCleanupEventOrderProof
+      ? cleanupEventOrder > terminalEventOrder
+      : cleanupOrder === 1);
+  const subsequentCleanupCorroboratesTerminal =
+    terminalEvent != null &&
+    latestStateChange?.event_type === "workspace.state_changed" &&
+    latestStateChange.new_state === item.status &&
+    ((latestStateChange.old_state === terminalEvent.new_state &&
+      latestStateChange.new_state === "destroying") ||
+      (latestStateChange.old_state === "destroying" &&
+        latestStateChange.new_state === "destroyed")) &&
+    cleanupFollowsTerminalEvent;
   const isRetainedResumeExit =
     recoveryStartedAt == null &&
     terminalEvent != null &&
     typeof terminalEvent.id === "string" &&
     terminalEvent.id.length > 0 &&
-    item.latest_state_change?.id === terminalEvent.id &&
+    (latestStateChange?.id === terminalEvent.id ||
+      subsequentCleanupCorroboratesTerminal) &&
     terminalEvent.old_state != null &&
     RESUMED_TERMINAL_SOURCE_STAGES.has(terminalEvent.old_state) &&
     retainedSourceStage?.status === "completed" &&
@@ -413,8 +444,9 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
   // are themselves omitted from that lifecycle and recovery summary; a direct
   // terminal exit from either pause is authoritative without that boundary.
   // After a pause resumes, the lifecycle retains the first interval for the
-  // re-entered stage; the matching current state transition can prove the later
-  // finish, but not a duration that spans the omitted pause.
+  // re-entered stage. The matching current state transition, or a subsequent
+  // cleanup transition that follows it, can prove the later finish, but not a
+  // duration that spans the omitted pause.
   if (
     (recoveryStartedAt == null &&
       !isDirectPauseExit &&
@@ -433,7 +465,6 @@ function retainedTerminalEventTiming(item: WorkspaceOverview): {
     recoveryStartedAt == null
       ? null
       : compareRecordedInstants(terminalEvent.occurred_at, recoveryStartedAt);
-  const terminalEventOrder = terminalEvent.event_order;
   const recoveryStartedEventOrder = item.recovery?.started_event_order;
   const explicitEventOrderProof =
     typeof terminalEventOrder === "number" &&

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -189,6 +189,7 @@ function sameRecordedInstant(left: string, right: string): boolean {
  * Separate "Finished" timestamp. `finished_at` is already the documented
  * fallback for Workflow finished, so omit it when that fact would repeat the
  * same instant (cloud rows that only send `finished_at`, or equivalent ISO forms).
+ * Also omit malformed values when no valid workflow finish exists.
  */
 export function distinctFinishedAt(workspace: WorkflowTimingFields): string | null {
   const finishedAt = workspace.finished_at;
@@ -196,7 +197,10 @@ export function distinctFinishedAt(workspace: WorkflowTimingFields): string | nu
     return null;
   }
   const workflowFinishedAt = resolveWorkflowFinishedAt(workspace);
-  if (workflowFinishedAt && sameRecordedInstant(finishedAt, workflowFinishedAt)) {
+  if (!workflowFinishedAt) {
+    return null;
+  }
+  if (sameRecordedInstant(finishedAt, workflowFinishedAt)) {
     return null;
   }
   return finishedAt;

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -157,14 +157,19 @@ type WorkflowTimingFields = {
 };
 
 /**
- * Workflow completion timestamp: prefer explicit workflow_finished_at, then the
- * documented workflow timing field finished_at. Native runtime finish stays
- * separate via native_runtime_finished_at.
+ * Valid workflow completion timestamp: prefer explicit workflow_finished_at,
+ * then the documented workflow timing field finished_at. Native runtime finish
+ * stays separate via native_runtime_finished_at.
  */
 export function resolveWorkflowFinishedAt(
   workspace: WorkflowTimingFields,
 ): string | null {
-  return workspace.workflow_finished_at ?? workspace.finished_at ?? null;
+  for (const candidate of [workspace.workflow_finished_at, workspace.finished_at]) {
+    if (candidate != null && recordedMilliseconds(candidate) != null) {
+      return candidate;
+    }
+  }
+  return null;
 }
 
 /**
@@ -352,12 +357,6 @@ export function resolveWorkflowTiming(item: WorkspaceOverview): ResolvedWorkflow
   }
 
   const explicitFinishedMs = recordedMilliseconds(resolvedFinishedAt);
-  if (resolvedFinishedAt != null && explicitFinishedMs == null) {
-    return {
-      finishedAt: null,
-      durationSeconds: recordedDurationSeconds(item.duration_seconds),
-    };
-  }
 
   const lifecycleTiming = lifecycleWorkflowTiming(item);
   const finishedAt = resolvedFinishedAt ?? lifecycleTiming?.finishedAt ?? null;

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -331,11 +331,13 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     return null;
   }
   if (latestEntered.stage.stage !== "completed") {
-    const terminalEvent = item.last_event;
+    const terminalEvent = item.latest_state_change ?? item.last_event;
     const terminalEventMs = recordedMilliseconds(terminalEvent?.occurred_at);
     // Pauses such as blocked/recovering are absent from lifecycle summaries.
     // For terminal paths without a completed stage, only trust that boundary
     // when the latest state-change corroborates the actual terminal transition.
+    // `last_event` remains a compatibility fallback because cleanup can append
+    // a newer non-state audit event after that transition.
     if (
       terminalEvent?.event_type !== "workspace.state_changed" ||
       terminalEvent.old_state !== latestEntered.stage.stage ||

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -600,7 +600,12 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
         entry.stage.stage !== "completed" &&
         entry.startedMs <= finishedMs,
     )
-    .sort((left, right) => left.startedMs - right.startedMs);
+    .sort((left, right) => {
+      const instantOrder = compareRecordedInstants(left.startedAt, right.startedAt);
+      return instantOrder === 0
+        ? lifecycleStageOrder(left.stage.stage) - lifecycleStageOrder(right.stage.stage)
+        : (instantOrder ?? 0);
+    });
   // A contiguous tail can corroborate the finish without representing the
   // whole workflow. Only `requested` supplies the authoritative start needed
   // to calculate workflow duration.

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -446,7 +446,12 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     return null;
   }
   const entered: TimedLifecycleStage[] = [];
+  const seenStages = new Set<string>();
   for (const stage of item.lifecycle) {
+    if (seenStages.has(stage.stage)) {
+      return null;
+    }
+    seenStages.add(stage.stage);
     const startedMs = recordedMilliseconds(stage.started_at);
     const endedMs = recordedMilliseconds(stage.ended_at);
     if (

--- a/apps/console/lib/agent-format.ts
+++ b/apps/console/lib/agent-format.ts
@@ -533,6 +533,10 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     );
   }
 
+  const terminalEvent =
+    item.latest_workflow_terminal_state_change ??
+    item.latest_state_change ??
+    item.last_event;
   let finishedAt = latestEntered.stage.ended_at;
   let finishedMs = latestEntered.endedMs;
   if (latestEntered.stage.stage === "completed") {
@@ -552,15 +556,27 @@ function lifecycleWorkflowTiming(item: WorkspaceOverview): {
     }
     finishedAt = latestEntered.startedAt;
     finishedMs = latestEntered.startedMs;
+    // A completed status can corroborate legacy payloads that predate retained
+    // state-change fields. Every other current status must retain the transition
+    // into completed, including the supported completed -> cleanup failure path.
+    const requiresCompletedTransition =
+      item.status !== "completed" ||
+      terminalEvent?.event_type === "workspace.state_changed";
+    if (
+      requiresCompletedTransition &&
+      (terminalEvent?.event_type !== "workspace.state_changed" ||
+        terminalEvent.old_state !== previousEntered.stage.stage ||
+        terminalEvent.new_state !== "completed" ||
+        !terminalEventMatchesWorkflowStatus(item, terminalEvent) ||
+        compareRecordedInstants(terminalEvent.occurred_at, finishedAt) !== 0)
+    ) {
+      return null;
+    }
   }
   if (finishedAt == null || finishedMs == null) {
     return null;
   }
   if (latestEntered.stage.stage !== "completed") {
-    const terminalEvent =
-      item.latest_workflow_terminal_state_change ??
-      item.latest_state_change ??
-      item.last_event;
     // Pauses such as blocked/recovering are absent from lifecycle summaries.
     // For terminal paths without a completed stage, only trust that boundary
     // when a retained workflow state-change corroborates the actual terminal

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -117,13 +117,18 @@ test("workspace summary does not embed effort in the Agent fact", () => {
   assert.doesNotMatch(summarySource, /formatAgentLabel\(/);
 });
 
-test("task details modal shows duration when duration_seconds is recorded", () => {
+test("task details modal uses resolved workflow timing", () => {
   const modalSource = extractFunctionSource("TaskDetailsModal");
 
   assert.match(
     modalSource,
-    /recordedDurationLabel\(workspace\.duration_seconds\)/,
-    "Expected TaskDetailsModal to read duration_seconds from the hosted overview",
+    /resolveWorkflowTiming\(workspace\)/,
+    "Expected TaskDetailsModal to share the card workflow timing resolver",
+  );
+  assert.match(
+    modalSource,
+    /recordedDurationLabel\(workflowTiming\.durationSeconds\)/,
+    "Expected TaskDetailsModal to format resolved explicit or lifecycle duration",
   );
   assert.match(
     modalSource,

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -145,7 +145,7 @@ test("workspace summary uses resolved workflow timing", () => {
 
   assert.match(
     summarySource,
-    /resolveWorkflowTiming\(workflowTimingInput\)/,
+    /resolveWorkflowTiming\(overview\)/,
     "Expected WorkspaceSummary to share the card workflow timing resolver",
   );
   assert.match(summarySource, /workflowFinishedAt = workflowTiming\.finishedAt/);

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -137,6 +137,25 @@ test("task details modal uses resolved workflow timing", () => {
   );
 });
 
+test("workspace summary uses resolved workflow timing", () => {
+  // Regression for PR #964 review thread PRRT_kwDOSJAM6s6hlFuW: local terminal
+  // cards infer timing from one complete lifecycle interval, and the inspector
+  // must use the same resolver rather than dropping back to explicit fields.
+  const summarySource = extractFunctionSource("WorkspaceSummary");
+
+  assert.match(
+    summarySource,
+    /resolveWorkflowTiming\(workflowTimingInput\)/,
+    "Expected WorkspaceSummary to share the card workflow timing resolver",
+  );
+  assert.match(summarySource, /workflowFinishedAt = workflowTiming\.finishedAt/);
+  assert.match(
+    summarySource,
+    /workflowTiming\.durationSeconds != null \? \([\s\S]*?compactDuration\(workflowTiming\.durationSeconds\)/,
+    "Expected WorkspaceSummary to render resolved explicit or lifecycle duration",
+  );
+});
+
 test("task details modal locks body scroll in a layout effect", () => {
   const modalSource = extractFunctionSource("TaskDetailsModal");
   const scrollLockEffect = modalSource.match(

--- a/apps/console/lib/console-dashboard-summary.test.mjs
+++ b/apps/console/lib/console-dashboard-summary.test.mjs
@@ -340,9 +340,9 @@ test("confirmed KPI lower bounds stay qualified while exact values win", () => {
     { value: monitoring.value, suffix: monitoring.suffix },
     { value: 0, suffix: " confirmed" },
   );
-  assert.match(active.hint, /project total is incomplete/);
+  assert.match(active.hint, /exact metric count is incomplete/);
   assert.match(completed.hint, /last 24h/);
-  assert.match(completed.hint, /project total is incomplete/);
+  assert.match(completed.hint, /exact metric count is incomplete/);
   assert.equal(lowerBounds.counts.active, null);
 
   const exactPayload = summaryWithCountEvidence({ confirmed: { active: 1, executing: 1 } });
@@ -372,6 +372,28 @@ test("confirmed KPI lower bounds stay qualified while exact values win", () => {
     },
     { value: 0, suffix: undefined },
   );
+});
+
+test("confirmed KPI hints describe metric gaps when every workflow status is known", () => {
+  const summary = parseDashboardSummary(
+    summaryWithCountEvidence({ total: 1, known: 1, unknown: 0, confirmed: { active: 1 } }),
+  );
+  assert.ok(summary);
+  summary.coverage.notes = ["terminal_timestamp_unavailable", "attention_evidence_unavailable"];
+
+  const kpis = fleetKpisFromDashboardSummary({
+    summary,
+    summaryStale: false,
+    saturation: null,
+    saturationStale: false,
+    showCapacity: false,
+    includeSummary: true,
+  });
+  for (const id of ["active", "completed"]) {
+    const hint = kpis.find((item) => item.id === id).hint;
+    assert.match(hint, /exact metric count is incomplete/);
+    assert.doesNotMatch(hint, /project total is incomplete/);
+  }
 });
 
 test("missing count evidence keeps null KPIs as honest dashes", () => {

--- a/apps/console/lib/console-dashboard-summary.test.mjs
+++ b/apps/console/lib/console-dashboard-summary.test.mjs
@@ -316,6 +316,14 @@ test("parseDashboardSummary rejects every exact and confirmed count mismatch", (
   }
 });
 
+test("parseDashboardSummary rejects exact counts while any workflow status is unknown", () => {
+  for (const key of countKeys) {
+    const payload = summaryWithCountEvidence();
+    payload.counts[key] = payload.count_evidence.confirmed_counts[key];
+    assert.equal(parseDashboardSummary(payload), null, `unproven exact count at ${key}`);
+  }
+});
+
 test("confirmed KPI lower bounds stay qualified while exact values win", () => {
   const lowerBounds = parseDashboardSummary(
     summaryWithCountEvidence({ confirmed: { active: 1, executing: 1 } }),
@@ -345,7 +353,12 @@ test("confirmed KPI lower bounds stay qualified while exact values win", () => {
   assert.match(completed.hint, /exact metric count is incomplete/);
   assert.equal(lowerBounds.counts.active, null);
 
-  const exactPayload = summaryWithCountEvidence({ confirmed: { active: 1, executing: 1 } });
+  const exactPayload = summaryWithCountEvidence({
+    total: 1,
+    known: 1,
+    unknown: 0,
+    confirmed: { active: 1, executing: 1 },
+  });
   exactPayload.counts.active = 1;
   exactPayload.counts.monitoring_pr = 0;
   const exactSummary = parseDashboardSummary(exactPayload);

--- a/apps/console/lib/console-dashboard-summary.test.mjs
+++ b/apps/console/lib/console-dashboard-summary.test.mjs
@@ -324,6 +324,17 @@ test("parseDashboardSummary rejects exact counts while any workflow status is un
   }
 });
 
+test("parseDashboardSummary rejects a positive exact lower bound with one unknown status", () => {
+  const payload = summaryWithCountEvidence({
+    total: 30,
+    known: 29,
+    unknown: 1,
+    confirmed: { active: 8, executing: 8 },
+  });
+  payload.counts.active = 8;
+  assert.equal(parseDashboardSummary(payload), null);
+});
+
 test("confirmed KPI lower bounds stay qualified while exact values win", () => {
   const lowerBounds = parseDashboardSummary(
     summaryWithCountEvidence({ confirmed: { active: 1, executing: 1 } }),

--- a/apps/console/lib/console-dashboard-summary.test.mjs
+++ b/apps/console/lib/console-dashboard-summary.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  fleetKpisFromDashboardSummary,
   formatDashboardCoverageNotice,
   parseDashboardSummary,
 } from "./console-dashboard-summary.ts";
@@ -16,6 +17,30 @@ const fixture = JSON.parse(
 
 function validSummary(overrides = {}) {
   return structuredClone({ ...fixture, ...overrides });
+}
+
+const countKeys = Object.keys(fixture.counts);
+
+function zeroConfirmedCounts() {
+  return Object.fromEntries(countKeys.map((key) => [key, 0]));
+}
+
+function summaryWithCountEvidence({
+  total = 29,
+  known = 24,
+  unknown = 5,
+  confirmed = {},
+} = {}) {
+  return validSummary({
+    coverage: { status: "partial", notes: ["workflow_status_incomplete"] },
+    counts: Object.fromEntries(countKeys.map((key) => [key, null])),
+    count_evidence: {
+      total_workspaces: total,
+      status_known_workspaces: known,
+      status_unknown_workspaces: unknown,
+      confirmed_counts: { ...zeroConfirmedCounts(), ...confirmed },
+    },
+  });
 }
 
 for (const level of [null, "window", "coverage", "counts", "overlap"]) {
@@ -164,6 +189,235 @@ test("formatDashboardCoverageNotice surfaces partial and unknown notes", () => {
   assert.equal(formatDashboardCoverageNotice({ status: "complete", notes: [] }), null);
   assert.equal(formatDashboardCoverageNotice(null), null);
   assert.equal(formatDashboardCoverageNotice(undefined), null);
+});
+
+test("parseDashboardSummary accepts absent, null, and valid count evidence", () => {
+  const legacy = parseDashboardSummary(validSummary());
+  assert.ok(legacy);
+  assert.equal("count_evidence" in legacy, false);
+
+  const explicitNull = parseDashboardSummary(validSummary({ count_evidence: null }));
+  assert.ok(explicitNull);
+  assert.equal(explicitNull.count_evidence, null);
+
+  const allZero = parseDashboardSummary(summaryWithCountEvidence());
+  assert.ok(allZero);
+  assert.equal(allZero.count_evidence.total_workspaces, 29);
+  assert.equal(allZero.count_evidence.status_known_workspaces, 24);
+  assert.equal(allZero.count_evidence.status_unknown_workspaces, 5);
+  assert.equal(allZero.count_evidence.confirmed_counts.active, 0);
+
+  const oneRunning = parseDashboardSummary(
+    summaryWithCountEvidence({
+      total: 30,
+      known: 25,
+      unknown: 5,
+      confirmed: { active: 1, executing: 1 },
+    }),
+  );
+  assert.ok(oneRunning);
+  assert.equal(oneRunning.counts.active, null);
+  assert.equal(oneRunning.count_evidence.confirmed_counts.active, 1);
+  assert.equal(oneRunning.count_evidence.confirmed_counts.executing, 1);
+});
+
+test("parseDashboardSummary rejects malformed count evidence objects", () => {
+  for (const level of ["count_evidence", "confirmed_counts"]) {
+    const payload = summaryWithCountEvidence();
+    const target = level === "count_evidence"
+      ? payload.count_evidence
+      : payload.count_evidence.confirmed_counts;
+    target.unpublished_field = 0;
+    assert.equal(parseDashboardSummary(payload), null, `unknown key at ${level}`);
+  }
+
+  for (const [level, key] of [
+    ["count_evidence", "total_workspaces"],
+    ["count_evidence", "status_known_workspaces"],
+    ["count_evidence", "status_unknown_workspaces"],
+    ["count_evidence", "confirmed_counts"],
+    ...countKeys.map((key) => ["confirmed_counts", key]),
+  ]) {
+    const payload = summaryWithCountEvidence();
+    const target = level === "count_evidence"
+      ? payload.count_evidence
+      : payload.count_evidence.confirmed_counts;
+    delete target[key];
+    assert.equal(parseDashboardSummary(payload), null, `missing ${level}.${key}`);
+  }
+});
+
+test("parseDashboardSummary rejects non-strict count evidence integers", () => {
+  for (const path of [
+    ["total_workspaces"],
+    ["status_known_workspaces"],
+    ["status_unknown_workspaces"],
+    ["confirmed_counts", "active"],
+  ]) {
+    for (const invalid of ["1", true, -1, 1.5]) {
+      const payload = summaryWithCountEvidence();
+      const target = path.length === 1
+        ? payload.count_evidence
+        : payload.count_evidence.confirmed_counts;
+      target[path.at(-1)] = invalid;
+      assert.equal(parseDashboardSummary(payload), null, `${path.join(".")}=${invalid}`);
+    }
+  }
+});
+
+test("parseDashboardSummary rejects count evidence contradictions", () => {
+  assert.equal(
+    parseDashboardSummary(summaryWithCountEvidence({ total: 30, known: 24, unknown: 5 })),
+    null,
+  );
+  assert.equal(
+    parseDashboardSummary(summaryWithCountEvidence({ confirmed: { active: 25 } })),
+    null,
+  );
+  assert.equal(
+    parseDashboardSummary(summaryWithCountEvidence({
+      confirmed: {
+        active: 20,
+        completed_last_window: 10,
+        cancelled_last_window: 10,
+        failed_last_window: 10,
+      },
+    })),
+    null,
+    "disjoint active and terminal statuses cannot exceed the known population",
+  );
+  const completeWithUnknownStatus = summaryWithCountEvidence({ total: 1, known: 0, unknown: 1 });
+  completeWithUnknownStatus.coverage = { status: "complete", notes: [] };
+  completeWithUnknownStatus.counts = zeroConfirmedCounts();
+  assert.equal(parseDashboardSummary(completeWithUnknownStatus), null);
+  for (const confirmed of [
+    { active: 1, executing: 2 },
+    { active: 1, monitoring_pr: 2, awaiting_human: 0 },
+    { active: 1, queued: 2 },
+    { active: 2, monitoring_pr: 1, awaiting_human: 2 },
+    { active: 2, executing: 2, awaiting_operator: 1 },
+    { active: 2, executing: 2, retrying: 1 },
+    { active: 3, executing: 1, monitoring_pr: 1, awaiting_operator: 1, retrying: 1 },
+    { active: 1, executing: 1, queued: 1 },
+  ]) {
+    assert.equal(
+      parseDashboardSummary(summaryWithCountEvidence({ confirmed })),
+      null,
+      `relationship contradiction ${JSON.stringify(confirmed)}`,
+    );
+  }
+});
+
+test("parseDashboardSummary rejects every exact and confirmed count mismatch", () => {
+  for (const key of countKeys) {
+    const payload = summaryWithCountEvidence();
+    payload.counts[key] = 1;
+    assert.equal(parseDashboardSummary(payload), null, `mismatch at ${key}`);
+  }
+});
+
+test("confirmed KPI lower bounds stay qualified while exact values win", () => {
+  const lowerBounds = parseDashboardSummary(
+    summaryWithCountEvidence({ confirmed: { active: 1, executing: 1 } }),
+  );
+  assert.ok(lowerBounds);
+  const lowerBoundKpis = fleetKpisFromDashboardSummary({
+    summary: lowerBounds,
+    summaryStale: true,
+    saturation: null,
+    saturationStale: false,
+    showCapacity: false,
+    includeSummary: true,
+  });
+  const active = lowerBoundKpis.find((item) => item.id === "active");
+  const monitoring = lowerBoundKpis.find((item) => item.id === "monitoring_pr");
+  const completed = lowerBoundKpis.find((item) => item.id === "completed");
+  assert.deepEqual(
+    { value: active.value, suffix: active.suffix, stale: active.stale },
+    { value: 1, suffix: " confirmed", stale: true },
+  );
+  assert.deepEqual(
+    { value: monitoring.value, suffix: monitoring.suffix },
+    { value: 0, suffix: " confirmed" },
+  );
+  assert.match(active.hint, /project total is incomplete/);
+  assert.match(completed.hint, /last 24h/);
+  assert.match(completed.hint, /project total is incomplete/);
+  assert.equal(lowerBounds.counts.active, null);
+
+  const exactPayload = summaryWithCountEvidence({ confirmed: { active: 1, executing: 1 } });
+  exactPayload.counts.active = 1;
+  exactPayload.counts.monitoring_pr = 0;
+  const exactSummary = parseDashboardSummary(exactPayload);
+  assert.ok(exactSummary);
+  const exactKpis = fleetKpisFromDashboardSummary({
+    summary: exactSummary,
+    summaryStale: false,
+    saturation: null,
+    saturationStale: false,
+    showCapacity: false,
+    includeSummary: true,
+  });
+  assert.deepEqual(
+    {
+      value: exactKpis.find((item) => item.id === "active").value,
+      suffix: exactKpis.find((item) => item.id === "active").suffix,
+    },
+    { value: 1, suffix: undefined },
+  );
+  assert.deepEqual(
+    {
+      value: exactKpis.find((item) => item.id === "monitoring_pr").value,
+      suffix: exactKpis.find((item) => item.id === "monitoring_pr").suffix,
+    },
+    { value: 0, suffix: undefined },
+  );
+});
+
+test("missing count evidence keeps null KPIs as honest dashes", () => {
+  const summary = parseDashboardSummary(
+    validSummary({
+      coverage: { status: "partial", notes: ["queued_count_unavailable"] },
+      counts: { ...fixture.counts, queued: null },
+    }),
+  );
+  assert.ok(summary);
+  const queued = fleetKpisFromDashboardSummary({
+    summary,
+    summaryStale: false,
+    saturation: null,
+    saturationStale: false,
+    showCapacity: false,
+    includeSummary: true,
+  }).find((item) => item.id === "queued");
+  assert.deepEqual(
+    { value: queued.value, suffix: queued.suffix, hint: queued.hint },
+    { value: "—", suffix: undefined, hint: undefined },
+  );
+});
+
+test("coverage notice quantifies statuses without hiding other evidence gaps", () => {
+  const parsed = parseDashboardSummary(
+    summaryWithCountEvidence({ total: 1, known: 1, unknown: 0 }),
+  );
+  assert.ok(parsed);
+  parsed.coverage.notes = ["terminal_timestamp_unavailable", "attention_evidence_unavailable"];
+  assert.equal(
+    formatDashboardCoverageNotice(parsed.coverage, parsed.count_evidence),
+    "partial coverage — 1 of 1 workflow statuses known; 0 unknown; terminal timestamp unavailable; attention evidence unavailable",
+  );
+  assert.equal(
+    formatDashboardCoverageNotice(
+      { status: "unknown", notes: ["provider_lag"] },
+      {
+        total_workspaces: 29,
+        status_known_workspaces: 24,
+        status_unknown_workspaces: 5,
+        confirmed_counts: zeroConfirmedCounts(),
+      },
+    ),
+    "coverage unknown — 24 of 29 workflow statuses known; 5 unknown; provider lag",
+  );
 });
 
 test("parseDashboardSummary rejects impossible calendar timestamps", () => {

--- a/apps/console/lib/console-dashboard-summary.ts
+++ b/apps/console/lib/console-dashboard-summary.ts
@@ -1,6 +1,8 @@
 import { capacityUtilizationPct } from "./format.ts";
 import type {
   ConsoleBackendKind,
+  ConsoleDashboardCountEvidence,
+  ConsoleDashboardCounts,
   ConsoleDashboardSummary,
   ResourceSaturationSummary,
 } from "./types.ts";
@@ -11,6 +13,19 @@ function expectedSummaryScope(backendKind: ConsoleBackendKind): "local" | "tenan
 }
 
 const DASH = "—";
+const DASHBOARD_COUNT_KEYS = [
+  "active",
+  "executing",
+  "monitoring_pr",
+  "awaiting_operator",
+  "awaiting_human",
+  "retrying",
+  "queued",
+  "completed_last_window",
+  "cancelled_last_window",
+  "failed_last_window",
+] as const;
+type DashboardCountKey = (typeof DASHBOARD_COUNT_KEYS)[number];
 
 /**
  * OpenAPI `format: date-time` / RFC 3339 profile: full date-time with `T`/`t`
@@ -80,12 +95,64 @@ export type SummaryFleetKpi = {
   stale?: boolean;
 };
 
-function displayCount(value: number | null | undefined): string | number {
-  // Null ≠ zero: incomplete/unknown counts render as an em dash.
-  if (value == null) {
-    return DASH;
+function countRelationshipsAreValid(counts: Record<DashboardCountKey, number | null>): boolean {
+  const {
+    active,
+    executing,
+    monitoring_pr: monitoringPr,
+    awaiting_operator: awaitingOperator,
+    awaiting_human: awaitingHuman,
+    retrying,
+    queued,
+  } = counts;
+  for (const subset of [executing, monitoringPr, queued, awaitingOperator, retrying]) {
+    if (active != null && subset != null && subset > active) {
+      return false;
+    }
   }
-  return value;
+  if (awaitingHuman != null && monitoringPr != null && awaitingHuman > monitoringPr) {
+    return false;
+  }
+  for (const disjointCount of [awaitingOperator, retrying]) {
+    if (
+      active != null &&
+      executing != null &&
+      disjointCount != null &&
+      disjointCount + executing > active
+    ) {
+      return false;
+    }
+  }
+  if (active != null) {
+    const disjointParts = [executing, monitoringPr, queued, awaitingOperator, retrying].filter(
+      (value): value is number => value != null,
+    );
+    if (disjointParts.length >= 2 && disjointParts.reduce((sum, value) => sum + value, 0) > active) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const CONFIRMED_COUNT_HINT = "confirmed lower bound; project total is incomplete";
+
+function displayCount(
+  exact: number | null | undefined,
+  confirmed: number | null | undefined,
+  baseHint?: string,
+): Pick<SummaryFleetKpi, "value" | "suffix" | "hint"> {
+  if (exact != null) {
+    return { value: exact, hint: baseHint };
+  }
+  if (confirmed != null) {
+    return {
+      value: confirmed,
+      suffix: " confirmed",
+      hint: baseHint ? `${baseHint} · ${CONFIRMED_COUNT_HINT}` : CONFIRMED_COUNT_HINT,
+    };
+  }
+  // Null ≠ zero: incomplete/unknown counts without evidence render as an em dash.
+  return { value: DASH };
 }
 
 const COVERAGE_NOTE_LABELS: Record<string, string> = {
@@ -111,6 +178,7 @@ function formatCoverageNote(note: string): string {
  */
 export function formatDashboardCoverageNotice(
   coverage: { status: string; notes?: readonly string[] | null } | null | undefined,
+  countEvidence?: ConsoleDashboardCountEvidence | null,
 ): string | null {
   if (!coverage || (coverage.status !== "partial" && coverage.status !== "unknown")) {
     return null;
@@ -118,6 +186,11 @@ export function formatDashboardCoverageNotice(
   const notes = (coverage.notes ?? [])
     .map((note) => formatCoverageNote(note))
     .filter((note) => note.length > 0);
+  if (countEvidence) {
+    notes.unshift(
+      `${countEvidence.status_known_workspaces} of ${countEvidence.total_workspaces} workflow statuses known; ${countEvidence.status_unknown_workspaces} unknown`,
+    );
+  }
   const headline = coverage.status === "partial" ? "partial coverage" : "coverage unknown";
   if (notes.length === 0) {
     return `${headline} — some counts are incomplete`;
@@ -143,8 +216,11 @@ export function fleetKpisFromDashboardSummary(options: {
     includeSummary,
   } = options;
   const counts = summary?.counts ?? null;
+  const confirmedCounts = summary?.count_evidence?.confirmed_counts ?? null;
   const windowHint = summary ? `last ${summary.window.since_hours}h` : undefined;
   const capacity = showCapacity && saturation ? capacityUtilizationPct(saturation) : null;
+  const displayedNumber = (key: DashboardCountKey): number | null =>
+    counts?.[key] ?? confirmedCounts?.[key] ?? null;
 
   // Contract: unsupported/omitted fleet_summary must omit the widget, not render dash shells.
   // Available-but-null summary still emits counters as — (loading / first-load failure).
@@ -153,77 +229,86 @@ export function fleetKpisFromDashboardSummary(options: {
         {
           id: "active",
           label: "Active",
-          value: displayCount(counts?.active),
+          ...displayCount(counts?.active, confirmedCounts?.active),
           stale: summaryStale,
         },
         {
           id: "running",
           label: "Running",
-          value: displayCount(counts?.executing),
-          tone: counts?.executing ? "info" : undefined,
+          ...displayCount(counts?.executing, confirmedCounts?.executing),
+          tone: displayedNumber("executing") ? "info" : undefined,
           stale: summaryStale,
         },
         {
           id: "monitoring_pr",
           label: "Monitoring PR",
-          value: displayCount(counts?.monitoring_pr),
-          tone: counts?.monitoring_pr ? "info" : undefined,
+          ...displayCount(counts?.monitoring_pr, confirmedCounts?.monitoring_pr),
+          tone: displayedNumber("monitoring_pr") ? "info" : undefined,
           stale: summaryStale,
         },
         {
           id: "blocked",
           label: "Awaiting operator",
-          value: displayCount(counts?.awaiting_operator),
-          tone: counts?.awaiting_operator ? "warn" : undefined,
+          ...displayCount(counts?.awaiting_operator, confirmedCounts?.awaiting_operator),
+          tone: displayedNumber("awaiting_operator") ? "warn" : undefined,
           stale: summaryStale,
         },
         {
           id: "recovering",
           label: "Auto-retrying",
-          value: displayCount(counts?.retrying),
-          tone: counts?.retrying ? "info" : undefined,
+          ...displayCount(counts?.retrying, confirmedCounts?.retrying),
+          tone: displayedNumber("retrying") ? "info" : undefined,
           stale: summaryStale,
         },
         {
           id: "awaiting_human",
           label: "Awaiting human",
-          value: displayCount(counts?.awaiting_human),
-          tone: counts?.awaiting_human ? "warn" : undefined,
+          ...displayCount(counts?.awaiting_human, confirmedCounts?.awaiting_human),
+          tone: displayedNumber("awaiting_human") ? "warn" : undefined,
           stale: summaryStale,
         },
         {
           id: "queued",
           label: "Queued",
-          value: displayCount(counts?.queued),
-          tone: counts?.queued ? "warn" : undefined,
-          hint:
-            counts?.queued != null && counts.queued > 0
-              ? "awaiting capacity"
-              : undefined,
+          ...displayCount(
+            counts?.queued,
+            confirmedCounts?.queued,
+            displayedNumber("queued") ? "awaiting capacity" : undefined,
+          ),
+          tone: displayedNumber("queued") ? "warn" : undefined,
           stale: summaryStale,
         },
         {
           id: "completed",
           label: "Completed",
-          value: displayCount(counts?.completed_last_window),
-          tone: counts?.completed_last_window ? "good" : undefined,
-          hint: counts?.completed_last_window != null ? windowHint : undefined,
+          ...displayCount(
+            counts?.completed_last_window,
+            confirmedCounts?.completed_last_window,
+            windowHint,
+          ),
+          tone: displayedNumber("completed_last_window") ? "good" : undefined,
           stale: summaryStale,
         },
         {
           id: "cancelled",
           label: "Cancelled",
-          value: displayCount(counts?.cancelled_last_window),
-          tone: counts?.cancelled_last_window ? "warn" : undefined,
-          hint: counts?.cancelled_last_window != null ? windowHint : undefined,
+          ...displayCount(
+            counts?.cancelled_last_window,
+            confirmedCounts?.cancelled_last_window,
+            windowHint,
+          ),
+          tone: displayedNumber("cancelled_last_window") ? "warn" : undefined,
           stale: summaryStale,
         },
         {
           id: "failed",
           label: "Failed",
-          value: displayCount(counts?.failed_last_window),
-          tone: counts?.failed_last_window ? "bad" : undefined,
-          hint: counts?.failed_last_window != null ? windowHint : undefined,
+          ...displayCount(
+            counts?.failed_last_window,
+            confirmedCounts?.failed_last_window,
+            windowHint,
+          ),
+          tone: displayedNumber("failed_last_window") ? "bad" : undefined,
           stale: summaryStale,
         },
       ]
@@ -260,7 +345,7 @@ export function parseDashboardSummary(
   const record = payload as Record<string, unknown>;
   if (!hasOnlyKeys(record, [
     "schema_version", "scope", "generated_at", "as_of", "last_success_at",
-    "window", "coverage", "counts", "overlap",
+    "window", "coverage", "counts", "count_evidence", "overlap",
   ])) {
     return null;
   }
@@ -351,23 +436,11 @@ export function parseDashboardSummary(
     return null;
   }
   const counts = record.counts as Record<string, unknown>;
-  const requiredCountKeys = [
-    "active",
-    "executing",
-    "monitoring_pr",
-    "awaiting_operator",
-    "awaiting_human",
-    "retrying",
-    "queued",
-    "completed_last_window",
-    "cancelled_last_window",
-    "failed_last_window",
-  ] as const;
-  if (!hasOnlyKeys(counts, requiredCountKeys)) {
+  if (!hasOnlyKeys(counts, DASHBOARD_COUNT_KEYS)) {
     return null;
   }
   let anyCountNull = false;
-  for (const key of requiredCountKeys) {
+  for (const key of DASHBOARD_COUNT_KEYS) {
     if (!(key in counts)) {
       return null;
     }
@@ -384,27 +457,6 @@ export function parseDashboardSummary(
   // Reject complete + null so hosted snapshots cannot replace last-good KPIs
   // with dashes under a purported complete result.
   if (anyCountNull && coverage.status === "complete") {
-    return null;
-  }
-  // Immediately after the per-value loop: reject contradictory domain subsets
-  // among related non-null counts so malformed hosted snapshots fail closed and
-  // the console retains the last-good KPI snapshot.
-  const active = counts.active as number | null;
-  const executing = counts.executing as number | null;
-  const monitoringPr = counts.monitoring_pr as number | null;
-  const awaitingHuman = counts.awaiting_human as number | null;
-  const awaitingOperator = counts.awaiting_operator as number | null;
-  const retrying = counts.retrying as number | null;
-  const queued = counts.queued as number | null;
-  if (active != null && executing != null && executing > active) {
-    return null;
-  }
-  // monitoring_pr is a non-terminal status bucket ⊆ active.
-  if (active != null && monitoringPr != null && monitoringPr > active) {
-    return null;
-  }
-  // queued (requested) is a non-terminal status bucket ⊆ active.
-  if (active != null && queued != null && queued > active) {
     return null;
   }
   if (!record.overlap || typeof record.overlap !== "object" || Array.isArray(record.overlap)) {
@@ -425,57 +477,76 @@ export function parseDashboardSummary(
       return null;
     }
   }
-  if (
-    awaitingHuman != null &&
-    monitoringPr != null &&
-    awaitingHuman > monitoringPr
-  ) {
+  const exactCounts = counts as unknown as ConsoleDashboardCounts;
+  if (!countRelationshipsAreValid(exactCounts)) {
     return null;
   }
-  if (awaitingOperator != null) {
-    if (active != null && awaitingOperator > active) {
+
+  if ("count_evidence" in record && record.count_evidence !== null) {
+    if (
+      !record.count_evidence ||
+      typeof record.count_evidence !== "object" ||
+      Array.isArray(record.count_evidence)
+    ) {
       return null;
     }
-    if (active != null && executing != null && awaitingOperator + executing > active) {
+    const evidence = record.count_evidence as Record<string, unknown>;
+    const evidenceKeys = [
+      "total_workspaces",
+      "status_known_workspaces",
+      "status_unknown_workspaces",
+      "confirmed_counts",
+    ] as const;
+    if (!hasOnlyKeys(evidence, evidenceKeys) || !evidenceKeys.every((key) => key in evidence)) {
       return null;
     }
-  }
-  if (retrying != null) {
-    if (active != null && retrying > active) {
+    if (
+      !isNonNegativeInteger(evidence.total_workspaces) ||
+      !isNonNegativeInteger(evidence.status_known_workspaces) ||
+      !isNonNegativeInteger(evidence.status_unknown_workspaces) ||
+      evidence.status_known_workspaces + evidence.status_unknown_workspaces !==
+        evidence.total_workspaces
+    ) {
       return null;
     }
-    if (active != null && executing != null && retrying + executing > active) {
+    if (
+      !evidence.confirmed_counts ||
+      typeof evidence.confirmed_counts !== "object" ||
+      Array.isArray(evidence.confirmed_counts)
+    ) {
       return null;
     }
-  }
-  // Combined disjoint active status buckets: pairwise subset checks miss cases
-  // like active=3 with executing=monitoring_pr=awaiting_operator=retrying=1.
-  // executing, monitoring_pr, and queued are always distinct statuses;
-  // awaiting_operator / retrying are always in active ∉ executing under v1.
-  if (active != null) {
-    let disjointActiveSum = 0;
-    let partCount = 0;
-    if (executing != null) {
-      disjointActiveSum += executing;
-      partCount += 1;
+    const confirmed = evidence.confirmed_counts as Record<string, unknown>;
+    if (
+      !hasOnlyKeys(confirmed, DASHBOARD_COUNT_KEYS) ||
+      !DASHBOARD_COUNT_KEYS.every(
+        (key) =>
+          key in confirmed &&
+          isNonNegativeInteger(confirmed[key]) &&
+          confirmed[key] <= (evidence.status_known_workspaces as number),
+      )
+    ) {
+      return null;
     }
-    if (monitoringPr != null) {
-      disjointActiveSum += monitoringPr;
-      partCount += 1;
+    const confirmedCounts = confirmed as Record<DashboardCountKey, number>;
+    if (
+      confirmedCounts.active +
+        confirmedCounts.completed_last_window +
+        confirmedCounts.cancelled_last_window +
+        confirmedCounts.failed_last_window >
+      evidence.status_known_workspaces
+    ) {
+      return null;
     }
-    if (queued != null) {
-      disjointActiveSum += queued;
-      partCount += 1;
+    if (!countRelationshipsAreValid(confirmedCounts)) {
+      return null;
     }
-    if (awaitingOperator != null) {
-      disjointActiveSum += awaitingOperator;
-      partCount += 1;
+    for (const key of DASHBOARD_COUNT_KEYS) {
+      if (exactCounts[key] != null && exactCounts[key] !== confirmedCounts[key]) {
+        return null;
+      }
     }
-    if (retrying != null) {
-      disjointActiveSum += retrying;
-      partCount += 1;
-    }
-    if (partCount >= 2 && disjointActiveSum > active) {
+    if (coverage.status === "complete" && evidence.status_unknown_workspaces !== 0) {
       return null;
     }
   }

--- a/apps/console/lib/console-dashboard-summary.ts
+++ b/apps/console/lib/console-dashboard-summary.ts
@@ -549,6 +549,12 @@ export function parseDashboardSummary(
     if (coverage.status === "complete" && evidence.status_unknown_workspaces !== 0) {
       return null;
     }
+    if (
+      evidence.status_unknown_workspaces > 0 &&
+      DASHBOARD_COUNT_KEYS.some((key) => exactCounts[key] !== null)
+    ) {
+      return null;
+    }
   }
   return {
     ...(payload as ConsoleDashboardSummary),

--- a/apps/console/lib/console-dashboard-summary.ts
+++ b/apps/console/lib/console-dashboard-summary.ts
@@ -134,7 +134,7 @@ function countRelationshipsAreValid(counts: Record<DashboardCountKey, number | n
   return true;
 }
 
-const CONFIRMED_COUNT_HINT = "confirmed lower bound; project total is incomplete";
+const CONFIRMED_COUNT_HINT = "confirmed lower bound; exact metric count is incomplete";
 
 function displayCount(
   exact: number | null | undefined,

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -232,6 +232,8 @@ export interface WorkspaceOverview {
   last_event: WorkspaceEvent | null;
   /** Latest state transition, retained when a newer non-state audit event exists. */
   latest_state_change?: WorkspaceEvent | null;
+  /** Latest completed/failed/cancelled transition, retained across destroy cleanup. */
+  latest_workflow_terminal_state_change?: WorkspaceEvent | null;
   pr_url: string | null;
   pr_number?: number | null;
   failure_reason: string | null;

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -83,6 +83,7 @@ export interface WorkspaceRecoverySummary {
   action: string | null;
   recovery_mode: string | null;
   started_at: string;
+  started_event_order?: number | null;
   current_operation: WorkspaceRecoveryCurrentOperation | null;
   summary: string;
   payload: Record<string, unknown> | null;
@@ -182,6 +183,7 @@ export interface WorkspaceEvent {
   new_state: string | null;
   reason_code: string | null;
   payload: Record<string, unknown> | null;
+  event_order?: number | null;
   occurred_at: string;
 }
 

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -230,6 +230,8 @@ export interface WorkspaceOverview {
   current_phase: string;
   active_operation: string | null;
   last_event: WorkspaceEvent | null;
+  /** Latest state transition, retained when a newer non-state audit event exists. */
+  latest_state_change?: WorkspaceEvent | null;
   pr_url: string | null;
   pr_number?: number | null;
   failure_reason: string | null;

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -39,6 +39,7 @@ export interface WorkspaceLifecycleStage {
   stage: string;
   started_at: string | null;
   ended_at: string | null;
+  ended_event_order?: number | null;
   duration_seconds: number | null;
   status: WorkspaceLifecycleStageStatus;
 }

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -234,6 +234,8 @@ export interface WorkspaceOverview {
   last_event: WorkspaceEvent | null;
   /** Latest state transition, retained when a newer non-state audit event exists. */
   latest_state_change?: WorkspaceEvent | null;
+  /** Latest transition into destroying, retained after cleanup reaches destroyed. */
+  latest_destroying_state_change?: WorkspaceEvent | null;
   /** Latest completed/failed/cancelled transition, retained across destroy cleanup. */
   latest_workflow_terminal_state_change?: WorkspaceEvent | null;
   pr_url: string | null;

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -991,6 +991,26 @@ export interface ConsoleDashboardCounts {
   failed_last_window: number | null;
 }
 
+export interface ConsoleDashboardConfirmedCounts {
+  active: number;
+  executing: number;
+  monitoring_pr: number;
+  awaiting_operator: number;
+  awaiting_human: number;
+  retrying: number;
+  queued: number;
+  completed_last_window: number;
+  cancelled_last_window: number;
+  failed_last_window: number;
+}
+
+export interface ConsoleDashboardCountEvidence {
+  total_workspaces: number;
+  status_known_workspaces: number;
+  status_unknown_workspaces: number;
+  confirmed_counts: ConsoleDashboardConfirmedCounts;
+}
+
 export interface ConsoleDashboardSummary {
   schema_version: number;
   scope: ConsoleSummaryScope;
@@ -1008,6 +1028,7 @@ export interface ConsoleDashboardSummary {
     notes: string[];
   };
   counts: ConsoleDashboardCounts;
+  count_evidence?: ConsoleDashboardCountEvidence | null;
   overlap: {
     awaiting_human_subset_of_monitoring_pr: true;
     awaiting_operator_in_active_not_executing: true;

--- a/apps/console/tests/dashboard-inspector.spec.ts
+++ b/apps/console/tests/dashboard-inspector.spec.ts
@@ -12,6 +12,14 @@ async function clickWorkspaceTitle(page: Page, workspaceId: string) {
   await page.mouse.click(titleBox.x + titleBox.width / 2, titleBox.y + titleBox.height / 2);
 }
 
+async function expectInsideViewport(locator: ReturnType<Page["locator"]>, width: number) {
+  await expect(locator).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, `expected a box at ${width}px`).not.toBeNull();
+  expect(box!.x, `left edge at ${width}px`).toBeGreaterThanOrEqual(-1);
+  expect(box!.x + box!.width, `right edge at ${width}px`).toBeLessThanOrEqual(width + 1);
+}
+
 // Since we don't have a real API running in the CI for this test, we need to mock it.
 test.describe("Dashboard Workspace Inspector", () => {
   test.beforeEach(async ({ page }) => {
@@ -320,6 +328,140 @@ test.describe("Dashboard Workspace Inspector", () => {
     const overlay = page.locator(".fixed.inset-0.z-40").first();
     await expect(overlay).toBeVisible();
     await expect(inspectorDrawer).toHaveClass(/w-full/);
+  });
+
+  test("long workspace summary stays inside the inspector at supported widths", async ({ page }) => {
+    const workspaceId = "ws_layout_overflow";
+    const longToken = "pathological-unbroken-workspace-value-".repeat(18);
+    const layoutWorkspace = {
+      workspace_id: workspaceId,
+      task_id: `task_${workspaceId}`,
+      task_key: `AWF-${longToken}`,
+      title: `Inspector layout ${longToken}`,
+      task_prompt: "Verify the workspace inspector layout.",
+      repo_url: `https://github.com/example/${longToken}.git`,
+      base_branch: `base/${longToken}`,
+      branch_name: `awf/${longToken}`,
+      agent: "codex",
+      agent_model: `gpt-${longToken}`,
+      agent_effort: "high",
+      agent_model_source: "task_policy",
+      agent_effort_source: "default",
+      requested_model: `requested-${longToken}`,
+      requested_model_source: "task_policy",
+      confirmed_execution_model: `confirmed-${longToken}`,
+      confirmed_execution_model_source: "execution_evidence",
+      status: "running",
+      subphase: null,
+      current_phase: "running",
+      active_operation: null,
+      created_at: "2026-09-11T12:00:00Z",
+      updated_at: "2026-09-11T12:05:00Z",
+      last_activity_at: "2026-09-11T12:05:00Z",
+      lifecycle: [],
+      llm_usage: null,
+      recovery: null,
+      coordination_warnings: [],
+      is_stale_running: false,
+      pr_url: "https://github.com/example/repo/pull/963",
+      pr_number: 963,
+    };
+
+    await page.route("/api/awf/workspaces/overview*", async (route) => {
+      await fulfillJson(route, { items: [layoutWorkspace], next_cursor: null, has_more: false });
+    });
+    await page.route(/\/api\/awf\/workspaces\/ws_layout_overflow(?:\/.*)?(?:\?.*)?$/, async (route) => {
+      const path = new URL(route.request().url()).pathname;
+      if (path === `/api/awf/workspaces/${workspaceId}`) {
+        await fulfillJson(route, { ...layoutWorkspace, id: workspaceId, version: 1 });
+      } else if (path.endsWith("/runtime")) {
+        await fulfillJson(route, { status: "running" });
+      } else if (path.endsWith("/stream")) {
+        await route.fulfill({
+          status: 200,
+          headers: { "content-type": "text/event-stream; charset=utf-8" },
+          body: `data: ${JSON.stringify({ type: "connected", workspace_id: workspaceId })}\n\n`,
+        });
+      } else {
+        await fulfillJson(route, { items: [], next_cursor: null, has_more: false });
+      }
+    });
+
+    await page.goto(`/?workspaceId=${workspaceId}`);
+    const inspector = page.locator(".fixed.inset-y-0.right-0").first();
+    await expect(inspector).toHaveClass(/translate-x-0/);
+    await inspector.evaluate(async (element) => {
+      await Promise.all(element.getAnimations().map((animation) => animation.finished));
+    });
+    const summary = inspector
+      .locator("section")
+      .filter({ has: page.getByRole("heading", { name: "Workspace", exact: true }) })
+      .first();
+    await expect(summary).toBeVisible();
+
+    const viewports = [
+      { width: 320, columns: 1 },
+      { width: 375, columns: 1 },
+      { width: 390, columns: 1 },
+      { width: 430, columns: 1 },
+      { width: 768, columns: 2 },
+      { width: 1280, columns: 4 },
+      { width: 1720, columns: 4 },
+    ];
+    for (const viewport of viewports) {
+      await page.setViewportSize({ width: viewport.width, height: 1000 });
+      await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+
+      const overflowingDescendants = await summary.evaluate((element) => {
+        const bounds = element.getBoundingClientRect();
+        return Array.from(element.querySelectorAll<HTMLElement>("*"))
+          .filter((descendant) => {
+            const style = getComputedStyle(descendant);
+            const box = descendant.getBoundingClientRect();
+            return (
+              style.display !== "none" &&
+              style.visibility !== "hidden" &&
+              box.width > 1 &&
+              box.height > 1 &&
+              (box.left < bounds.left - 1 || box.right > bounds.right + 1)
+            );
+          })
+          .map((descendant) => ({
+            tag: descendant.tagName,
+            className: descendant.className,
+            left: descendant.getBoundingClientRect().left,
+            right: descendant.getBoundingClientRect().right,
+            summaryLeft: bounds.left,
+            summaryRight: bounds.right,
+          }));
+      });
+      expect(overflowingDescendants, `summary descendants at ${viewport.width}px`).toEqual([]);
+
+      const status = summary.getByText("running", { exact: true }).first();
+      const pullRequest = summary.getByRole("link", { name: "PR #963", exact: true });
+      const reload = inspector.getByRole("button", { name: "Reload workspace", exact: true });
+      const close = inspector.getByRole("button", { name: "Close inspector", exact: true });
+      for (const reachable of [status, pullRequest, reload, close]) {
+        await expectInsideViewport(reachable, viewport.width);
+      }
+
+      const factColumns = await Promise.all(
+        ["Workspace", "Task key", "Agent", "Requested model"].map(async (label) => {
+          const fact = summary.locator(".label-caps", { hasText: label }).first().locator("..");
+          const box = await fact.boundingBox();
+          expect(box, `${label} fact at ${viewport.width}px`).not.toBeNull();
+          return Math.round(box!.x);
+        }),
+      );
+      expect(new Set(factColumns).size, `fact columns at ${viewport.width}px`).toBe(
+        viewport.columns,
+      );
+    }
+
+    await inspector.getByRole("button", { name: "Reload workspace", exact: true }).click();
+    await expect(summary.getByText("running", { exact: true }).first()).toBeVisible();
+    await inspector.getByRole("button", { name: "Close inspector", exact: true }).click();
+    await expect(inspector).toHaveClass(/translate-x-full/);
   });
 });
 

--- a/apps/console/tests/dashboard-overview-performance.spec.ts
+++ b/apps/console/tests/dashboard-overview-performance.spec.ts
@@ -1738,8 +1738,12 @@ test("height restore keeps the viewport covered across a virtual-window boundary
 
   await page.goto("/");
   await waitForConsoleReady(page);
+  const loadMore = page.getByRole("button", { name: "Load more workspaces" });
   for (const loaded of [PAGE_SIZE * 2, PAGE_SIZE * 3]) {
-    await page.getByRole("button", { name: "Load more workspaces" }).click();
+    // This setup needs one button-driven page at a time. Playwright's locator
+    // click can scroll the footer into the near-bottom autoload threshold and
+    // race that request with the button handler.
+    await loadMore.evaluate((button: HTMLButtonElement) => button.click());
     await expect(page.getByTestId("workspace-history-scope")).toContainText(`${loaded} loaded`);
   }
 

--- a/apps/console/tests/dashboard-overview-performance.spec.ts
+++ b/apps/console/tests/dashboard-overview-performance.spec.ts
@@ -567,17 +567,30 @@ test("filtered continuation backfills unchanged first-page membership", async ({
   const statusGroup = page.getByRole("group", { name: "Status" });
   await statusGroup.getByRole("button", { name: /Status all/ }).click();
   await statusGroup.getByLabel("completed").check();
-  await page.getByRole("button", { name: "Load more workspaces" }).click();
-  await expect.poll(() => completedRequests).toContain("completed-page-2");
+  const loadMore = page.getByRole("button", { name: "Load more workspaces" });
+  // This regression exercises filtered cursor backfill. Dispatch setup loads
+  // without Playwright scrolling the footer into the independent near-bottom
+  // loader, which can otherwise advance the stale cursor before membership
+  // changes and leave an extra retained row in the test fixture.
+  const requestHistoryWithoutScrolling = async (expectedCursor: string) => {
+    await expect(async () => {
+      if (!completedRequests.includes(expectedCursor)) {
+        await loadMore.evaluate((button: HTMLButtonElement) => button.click());
+      }
+      expect(completedRequests).toContain(expectedCursor);
+    }).toPass({ intervals: [100, 250, 500], timeout: 5_000 });
+  };
+  await requestHistoryWithoutScrolling("completed-page-2");
+  await expect(page.getByText(`1–${PAGE_SIZE} of ${PAGE_SIZE * 2} loaded`, { exact: true }))
+    .toBeVisible();
 
   // Membership can change after the latest page-one poll. The continuation
   // itself must be armed to replay the loaded range; waiting for another poll
   // would leave a window where the stale page-three cursor skips this row.
   membershipGrew = true;
   const firstPageRequests = completedRequests.filter((cursor) => cursor === null).length;
-  await page.getByRole("button", { name: "Load more workspaces" }).click();
+  await requestHistoryWithoutScrolling("shifted-completed-page-3");
 
-  await expect.poll(() => completedRequests).toContain("shifted-completed-page-3");
   expect(completedRequests.filter((cursor) => cursor === null)).toHaveLength(firstPageRequests);
   await expect(page.getByText(new RegExp(`of ${PAGE_SIZE * 3} loaded$`))).toBeVisible();
   await page.getByPlaceholder("Search workspaces").fill("Newly matching off-page workspace");

--- a/apps/console/tests/dashboard-overview-performance.spec.ts
+++ b/apps/console/tests/dashboard-overview-performance.spec.ts
@@ -304,6 +304,126 @@ test("scroll loads one history page and refresh preserves the bounded loaded win
   await expect(page.getByText("1 selected for logs", { exact: true })).toBeVisible();
 });
 
+// Regression for PR #965 review thread PRRT_kwDOSJAM6s6hp4wm: a list shrink
+// can clamp the DOM scroll position before the virtual page is repaired. The
+// repair must happen in the layout effect so an empty window is never painted.
+test("membership shrink repairs an at-top virtual window before paint", async ({ page }) => {
+  await mockAwfConsoleApi(page);
+  await installLargeFleetOverview(page);
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+  await page.getByRole("button", { name: "Load more workspaces" })
+    .evaluate((button: HTMLButtonElement) => button.click());
+  await expect(page.getByText(`1–${PAGE_SIZE} of ${PAGE_SIZE * 2} loaded`, { exact: true }))
+    .toBeVisible();
+  await page.getByRole("button", { name: "Next workspace results" }).click();
+  await expect(page.getByTestId("workspace-card-ws_perf_0101")).toBeVisible();
+
+  await page.getByRole("button", { name: "Filters" }).click();
+  const list = page.getByTestId("workspace-list-scroll");
+  await list.evaluate((element) => {
+    element.dataset.paintedEmptyWindow = "false";
+    new MutationObserver(() => {
+      if (!element.querySelector('[data-testid^="workspace-card-"]')) {
+        requestAnimationFrame(() => {
+          if (!element.querySelector('[data-testid^="workspace-card-"]')) {
+            element.dataset.paintedEmptyWindow = "true";
+          }
+        });
+      }
+    }).observe(element, { childList: true, subtree: true });
+  });
+
+  await page.getByPlaceholder("Search workspaces").fill("ws_perf_0001");
+
+  await expect(page.getByTestId("workspace-card-ws_perf_0001")).toBeVisible();
+  await list.evaluate(() => new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  }));
+  await expect(list).toHaveAttribute("data-painted-empty-window", "false");
+  await expect(page.locator('[data-testid^="workspace-card-"]')).toHaveCount(1);
+});
+
+test("a newer user scroll supersedes a pending history restore", async ({ page }) => {
+  const overviewRequests: Array<string | null> = [];
+  await mockAwfConsoleApi(page);
+  const releaseHistory = await installLargeFleetOverview(page, {
+    delayContinuation: true,
+    onRequest: (cursor) => overviewRequests.push(cursor),
+  });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+  const list = page.getByTestId("workspace-list-scroll");
+  await list.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+  await expect.poll(() => overviewRequests).toEqual([null, String(PAGE_SIZE)]);
+  await releaseHistory();
+  await expect(page.getByText(`1–${PAGE_SIZE} of ${PAGE_SIZE * 2} loaded`, { exact: true }))
+    .toBeVisible();
+
+  await list.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+  await expect.poll(() => overviewRequests).toEqual([
+    null,
+    String(PAGE_SIZE),
+    String(PAGE_SIZE * 2),
+  ]);
+  await list.evaluate((element) => element.scrollTo({ top: element.scrollHeight * 0.6 }));
+  const visibleAnchor = () => list.evaluate((element) => {
+    const viewportTop = element.querySelector<HTMLElement>(":scope > .sticky")
+      ?.getBoundingClientRect().bottom ?? element.getBoundingClientRect().top;
+    const row = Array.from(
+      element.querySelectorAll<HTMLElement>('[data-testid^="workspace-card-"]'),
+    ).find((candidate) => candidate.getBoundingClientRect().bottom > viewportTop);
+    const bounds = row?.getBoundingClientRect();
+    return {
+      id: row?.dataset.testid ?? null,
+      offsetRatio: bounds ? (bounds.top - viewportTop) / bounds.height : null,
+    };
+  });
+  await expect.poll(async () => (await visibleAnchor()).id).not.toBeNull();
+  const afterUserScroll = await visibleAnchor();
+
+  await releaseHistory();
+  await expect(page.getByText(`101–200 of ${PAGE_SIZE * 3} loaded`, { exact: true }))
+    .toBeVisible();
+  await expect.poll(async () => (await visibleAnchor()).id).toBe(afterUserScroll.id);
+  const afterAppend = await visibleAnchor();
+  expect(afterAppend.offsetRatio).toBeCloseTo(afterUserScroll.offsetRatio ?? 0, 1);
+  expect(overviewRequests.filter((cursor) => cursor !== null)).toHaveLength(2);
+  await expect(page.locator('[data-testid^="workspace-card-"]')).toHaveCount(PAGE_SIZE);
+});
+
+test("a same-window user scroll supersedes a pending history fallback", async ({ page }) => {
+  const overviewRequests: Array<string | null> = [];
+  await mockAwfConsoleApi(page);
+  const releaseHistory = await installLargeFleetOverview(page, {
+    delayContinuation: true,
+    onRequest: (cursor) => overviewRequests.push(cursor),
+  });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+  const list = page.getByTestId("workspace-list-scroll");
+  await list.evaluate((element) => element.scrollTo({ top: 1_000 }));
+  await expect.poll(() => list.evaluate((element) => element.scrollTop)).toBe(1_000);
+
+  await page.getByRole("button", { name: "Load more workspaces" })
+    .evaluate((button: HTMLButtonElement) => button.click());
+  await expect.poll(() => overviewRequests).toEqual([null, String(PAGE_SIZE)]);
+  const requestScrollTop = await list.evaluate((element) => element.scrollTop);
+
+  await list.evaluate((element) => element.scrollTo({ top: element.scrollTop + 400 }));
+  await expect.poll(() => list.evaluate((element) => element.scrollTop))
+    .toBe(requestScrollTop + 400);
+  const newerScrollTop = await list.evaluate((element) => element.scrollTop);
+
+  await releaseHistory();
+  await expect(page.getByText(`1–${PAGE_SIZE} of ${PAGE_SIZE * 2} loaded`, { exact: true }))
+    .toBeVisible();
+  await expect.poll(() => list.evaluate((element) => element.scrollTop)).toBe(newerScrollTop);
+});
+
 // Regression for PR #958 review thread PRRT_kwDOSJAM6s6hMh1_: when a full
 // page of newer workspaces makes page one disjoint, the old keyset cursor skips
 // the pages inserted ahead of its boundary.
@@ -873,6 +993,167 @@ test("selecting a visible workspace keeps its rail position", async ({ page }) =
     .toBe(scrollTopBeforeSelection);
 });
 
+// Regression for PR #965 review thread PRRT_kwDOSJAM6s6hrOrC: Previous uses
+// a suppressed programmatic scroll, so it must explicitly release anchoring
+// owned by a selected row on the page being left.
+test("explicit page navigation clears selection-owned refresh anchoring", async ({ page }) => {
+  let revision = 0;
+  await mockAwfConsoleApi(page);
+  await installLargeFleetOverview(page, {
+    resolvePageItems: (items, cursor) => {
+      if (cursor !== null || revision === 0) return items;
+      return items.map((item) => item.workspace_id === "ws_perf_0002"
+        ? { ...item, updated_at: "2026-09-11T12:02:00.000Z" }
+        : item);
+    },
+  });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+  await page.getByRole("button", { name: "Load more workspaces" }).click();
+  await expect(page.getByText(`1–${PAGE_SIZE} of ${PAGE_SIZE * 2} loaded`, { exact: true }))
+    .toBeVisible();
+  await page.getByRole("button", { name: "Next workspace results" }).click();
+  await page.getByTestId("workspace-card-ws_perf_0101").click();
+  await expect(page).toHaveURL(/workspaceId=ws_perf_0101/);
+
+  const list = page.getByTestId("workspace-list-scroll");
+  await page.getByRole("button", { name: "Previous workspace results" }).click();
+  await expect.poll(() => list.evaluate((element) => element.scrollTop)).toBe(0);
+
+  revision = 1;
+  await page.locator("header").getByRole("button", { name: "Refresh" }).evaluate(
+    (button: HTMLButtonElement) => button.click(),
+  );
+
+  await expect(page.getByTestId("workspace-card-ws_perf_0002")).toBeVisible();
+  await expect.poll(() => list.evaluate((element) => element.scrollTop)).toBe(0);
+});
+
+// Regression for PR #965 review thread PRRT_kwDOSJAM6s6htdHu: a suppressed
+// Previous scroll must cancel the request-time position held by an in-flight
+// near-bottom history load.
+test("explicit page navigation cancels a pending history restore", async ({ page }) => {
+  const overviewRequests: Array<string | null> = [];
+  const routeOptions: OverviewRouteOptions = {
+    delayContinuation: false,
+    onRequest: (cursor) => overviewRequests.push(cursor),
+  };
+  await mockAwfConsoleApi(page);
+  const releaseHistory = await installLargeFleetOverview(page, routeOptions);
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+  const loadMore = page.getByRole("button", { name: "Load more workspaces" });
+  for (const loaded of [PAGE_SIZE * 2, PAGE_SIZE * 3]) {
+    await loadMore.evaluate((button: HTMLButtonElement) => button.click());
+    await expect(page.getByTestId("workspace-history-scope")).toContainText(`${loaded} loaded`);
+  }
+
+  await page.getByRole("button", { name: "Next workspace results" }).click();
+  await page.getByRole("button", { name: "Next workspace results" }).click();
+  await expect(page.getByText("201–300 of 300 loaded", { exact: true })).toBeVisible();
+
+  routeOptions.delayContinuation = true;
+  const list = page.getByTestId("workspace-list-scroll");
+  await list.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+  await expect.poll(() => overviewRequests).toContain(String(PAGE_SIZE * 3));
+
+  await page.getByRole("button", { name: "Previous workspace results" }).click();
+  await expect(page.getByText("101–200 of 300 loaded", { exact: true })).toBeVisible();
+  const navigatedScrollTop = await list.evaluate((element) => element.scrollTop);
+
+  await releaseHistory();
+  await expect(page.getByText("101–200 of 400 loaded", { exact: true })).toBeVisible();
+  await expect.poll(() => list.evaluate((element) => element.scrollTop)).toBe(
+    navigatedScrollTop,
+  );
+  await expect(page.getByTestId("workspace-card-ws_perf_0101")).toBeVisible();
+});
+
+// Regression for PR #965 review thread PRRT_kwDOSJAM6s6htmJV: selecting an
+// already-loaded row outside the viewport must supersede the request-time
+// position held by an in-flight near-bottom history load.
+test("selection navigation cancels a pending history restore", async ({ page }) => {
+  const overviewRequests: Array<string | null> = [];
+  const routeOptions: OverviewRouteOptions = {
+    delayContinuation: false,
+    onRequest: (cursor) => overviewRequests.push(cursor),
+  };
+  await mockAwfConsoleApi(page);
+  const releaseHistory = await installLargeFleetOverview(page, routeOptions);
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+  const loadMore = page.getByRole("button", { name: "Load more workspaces" });
+  for (const loaded of [PAGE_SIZE * 2, PAGE_SIZE * 3]) {
+    await loadMore.evaluate((button: HTMLButtonElement) => button.click());
+    await expect(page.getByTestId("workspace-history-scope")).toContainText(`${loaded} loaded`);
+  }
+
+  await page.getByRole("button", { name: "Next workspace results" }).click();
+  await page.getByRole("button", { name: "Next workspace results" }).click();
+  await expect(page.getByText("201–300 of 300 loaded", { exact: true })).toBeVisible();
+
+  routeOptions.delayContinuation = true;
+  const list = page.getByTestId("workspace-list-scroll");
+  await list.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+  await expect.poll(() => overviewRequests).toContain(String(PAGE_SIZE * 3));
+
+  await page.evaluate(() => {
+    window.history.pushState(null, "", "/?workspaceId=ws_perf_0101");
+  });
+  await expect(page).toHaveURL(/workspaceId=ws_perf_0101/);
+  await expect(page.getByTestId("workspace-card-ws_perf_0101")).toBeVisible();
+  const selectedScrollTop = await list.evaluate((element) => element.scrollTop);
+
+  await releaseHistory();
+  await expect(page.getByText("101–200 of 400 loaded", { exact: true })).toBeVisible();
+  await expect.poll(() => list.evaluate((element) => element.scrollTop)).toBe(
+    selectedScrollTop,
+  );
+  await expect(page.getByTestId("workspace-card-ws_perf_0101")).toBeVisible();
+});
+
+// Regression for PR #965 review thread PRRT_kwDOSJAM6s6hrd2_: when a filter
+// removes the selected row but its fallback lookup fails, the unchanged
+// selection must stop owning refresh anchoring for the remaining rows.
+test("filtering a selected workspace releases refresh anchoring", async ({ page }) => {
+  let failSelectedLookup = false;
+  let revision = 0;
+  await mockAwfConsoleApi(page);
+  await installLargeFleetOverview(page, {
+    shouldFailBatch: () => failSelectedLookup,
+    resolvePageItems: (items, cursor) => {
+      if (cursor !== null || revision === 0) return items;
+      return items.map((item) => item.workspace_id === "ws_perf_0004"
+        ? { ...item, updated_at: "2026-09-11T12:04:00.000Z" }
+        : item);
+    },
+  });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+  await page.getByTestId("workspace-card-ws_perf_0001").click();
+  await expect(page).toHaveURL(/workspaceId=ws_perf_0001/);
+
+  failSelectedLookup = true;
+  await page.getByRole("button", { name: "Filters" }).click();
+  await page.getByPlaceholder("exact repo filter").fill("https://example.com/even.git");
+
+  const list = page.getByTestId("workspace-list-scroll");
+  await expect(page.getByTestId("workspace-card-ws_perf_0002")).toBeVisible();
+  await expect(page.getByTestId("workspace-card-ws_perf_0001")).toHaveCount(0);
+  await expect(page).toHaveURL(/workspaceId=ws_perf_0001/);
+  await expect.poll(() => list.evaluate((element) => element.scrollTop)).toBe(0);
+
+  revision = 1;
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+
+  await expect(page.getByTestId("workspace-card-ws_perf_0004")).toBeVisible();
+  await expect.poll(() => list.evaluate((element) => element.scrollTop)).toBe(0);
+});
+
 // Regression for PR #958 review thread PRRT_kwDOSJAM6s6hYbpe: a visible row
 // from the next page must not replace preceding viewport rows with a spacer.
 test("selecting a visible workspace keeps a boundary viewport covered", async ({ page }) => {
@@ -1058,6 +1339,219 @@ test("virtualization remeasures variable rows after filtering and viewport resiz
     boundaryGeometry.viewportBottom - 1,
   );
 });
+
+for (const inspectorWorkspaceId of [null, "ws_perf_0001", "ws_perf_0002"] as const) {
+test(`workspace list stays at the top during refresh reorders (inspectorWorkspaceId=${inspectorWorkspaceId})`, async ({
+  page,
+}) => {
+  let firstPageRequests = 0;
+  let revision = 0;
+  const expandedTitle = "Updated workspace title that wraps after a passive refresh ".repeat(8);
+  const prependedWorkspace = {
+    ...workspaceOverview(0),
+    updated_at: "2026-09-11T12:04:00.000Z",
+    last_activity_at: "2026-09-11T12:04:00.000Z",
+  };
+  const historyPrepend = {
+    ...workspaceOverview(0),
+    workspace_id: "ws_perf_newest",
+    task_id: "task-ws_perf_newest",
+    title: "Newest workspace while reading history",
+    task_prompt: "Inspect the newest workspace while reading history",
+    branch_name: "perf/newest",
+    updated_at: "2026-09-11T12:06:00.000Z",
+    last_activity_at: "2026-09-11T12:06:00.000Z",
+  };
+  await page.setViewportSize({ width: 1_508, height: 1_000 });
+  await mockAwfConsoleApi(page);
+  await installLargeFleetOverview(page, {
+    onRequest: (cursor) => {
+      if (cursor === null) firstPageRequests += 1;
+    },
+    resolvePageItems: (items, cursor) => {
+      if (cursor !== null || revision === 0) return items;
+      const updatedItems = items.map((item) => {
+        if (
+          revision === 1 &&
+          inspectorWorkspaceId === "ws_perf_0001" &&
+          item.workspace_id === "ws_perf_0001"
+        ) {
+          return { ...item, updated_at: "2026-09-10T11:59:30.500Z" };
+        }
+        if (revision === 1 && item.workspace_id === "ws_perf_0002") {
+          return { ...item, updated_at: "2026-09-11T12:02:00.000Z" };
+        }
+        if (revision === 2 && item.workspace_id === "ws_perf_0001") {
+          return { ...item, updated_at: "2026-09-11T12:03:00.000Z" };
+        }
+        if (revision === 4 && item.workspace_id === "ws_perf_0002") {
+          return {
+            ...item,
+            title: expandedTitle,
+            updated_at: "2026-09-11T12:05:00.000Z",
+          };
+        }
+        if (revision === 6 && item.workspace_id === "ws_perf_0001") {
+          return { ...item, updated_at: "2026-09-11T12:07:00.000Z" };
+        }
+        return item;
+      });
+      if (revision === 3 || revision === 4) {
+        return [prependedWorkspace, ...updatedItems.slice(0, -1)];
+      }
+      if (revision >= 5) {
+        return [historyPrepend, ...updatedItems.slice(0, -1)];
+      }
+      return updatedItems;
+    },
+  });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+  if (inspectorWorkspaceId) {
+    await page.getByTestId(`workspace-card-${inspectorWorkspaceId}`).click();
+    await expect(page.getByRole("button", { name: "Close inspector" })).toBeVisible();
+  }
+  const list = page.getByTestId("workspace-list-scroll");
+  const firstCardId = () =>
+    list.locator('[data-testid^="workspace-card-"]').first().getAttribute("data-testid");
+  const scrollTop = () => list.evaluate((element) => element.scrollTop);
+  const expectTop = async () => {
+    await expect.poll(scrollTop).toBe(0);
+  };
+  const publishRefresh = async (nextRevision: number, expectedFirstCardId: string) => {
+    revision = nextRevision;
+    const requestsBeforeRefresh = firstPageRequests;
+    await page.getByRole("button", { name: "Refresh", exact: true }).click();
+    await expect.poll(() => firstPageRequests).toBeGreaterThan(requestsBeforeRefresh);
+    await expect.poll(firstCardId).toBe(expectedFirstCardId);
+  };
+  const publishBackgroundRefresh = async (
+    nextRevision: number,
+    expectedFirstCardId: string,
+  ) => {
+    revision = nextRevision;
+    const requestsBeforeRefresh = firstPageRequests;
+    await expect
+      .poll(() => firstPageRequests, { timeout: 7_000 })
+      .toBeGreaterThan(requestsBeforeRefresh);
+    await expect.poll(firstCardId).toBe(expectedFirstCardId);
+  };
+
+  await expect.poll(firstCardId).toBe("workspace-card-ws_perf_0001");
+  await list.evaluate((element) => element.scrollTo({ top: 0 }));
+  await expectTop();
+
+  await publishBackgroundRefresh(1, "workspace-card-ws_perf_0002");
+  await expectTop();
+  if (inspectorWorkspaceId === "ws_perf_0001") {
+    await expect(page.getByRole("button", { name: "Close inspector" })).toBeVisible();
+  }
+  if (inspectorWorkspaceId) {
+    // Regression for PR #965 review thread PRRT_kwDOSJAM6s6hrFo_: once an
+    // unrelated selected row becomes first, the next reorder must not mistake
+    // that incidental position for selection-owned scrolling.
+    await publishBackgroundRefresh(2, "workspace-card-ws_perf_0001");
+    await expectTop();
+    if (inspectorWorkspaceId === "ws_perf_0001") {
+      // Regression for PR #965 review thread PRRT_kwDOSJAM6s6hrXgy: manually
+      // returning to the top while that selected row is first must not restore
+      // selection ownership and follow it on the next reorder.
+      await list.evaluate(async (element) => {
+        element.scrollTo({ top: 1_000 });
+        await new Promise(requestAnimationFrame);
+      });
+      expect(await scrollTop()).toBeGreaterThan(240);
+      await list.evaluate(async (element) => {
+        element.scrollTo({ top: 0 });
+        await new Promise(requestAnimationFrame);
+      });
+      await expectTop();
+      await publishBackgroundRefresh(3, "workspace-card-ws_perf_0000");
+      await expectTop();
+    }
+    return;
+  }
+
+  await publishRefresh(2, "workspace-card-ws_perf_0001");
+  await expectTop();
+  await publishRefresh(3, "workspace-card-ws_perf_0000");
+  await expectTop();
+
+  const initialRowHeight = await page.getByTestId("workspace-card-ws_perf_0002")
+    .evaluate((element) => element.getBoundingClientRect().height);
+  await publishRefresh(4, "workspace-card-ws_perf_0002");
+  await expect(page.getByTestId("workspace-title-ws_perf_0002")).toHaveText(expandedTitle);
+  await expect.poll(() => page.getByTestId("workspace-card-ws_perf_0002")
+    .evaluate((element) => element.getBoundingClientRect().height)).toBeGreaterThan(initialRowHeight);
+  await expectTop();
+
+  const historyAnchor = page.getByTestId("workspace-card-ws_perf_0020");
+  await historyAnchor.evaluate((element) => {
+    const listElement = element.closest<HTMLElement>('[data-testid="workspace-list-scroll"]');
+    if (!listElement) throw new Error("workspace list is missing");
+    listElement.scrollTo({
+      top: listElement.scrollTop + element.getBoundingClientRect().top -
+        listElement.getBoundingClientRect().top + element.getBoundingClientRect().height * 0.35,
+    });
+  });
+  const visibleAnchor = () => list.evaluate((element) => {
+    const viewportTop = element.querySelector<HTMLElement>(":scope > .sticky")
+      ?.getBoundingClientRect().bottom ?? element.getBoundingClientRect().top;
+    const row = Array.from(
+      element.querySelectorAll<HTMLElement>('[data-testid^="workspace-card-"]'),
+    ).find((candidate) => candidate.getBoundingClientRect().bottom > viewportTop);
+    const bounds = row?.getBoundingClientRect();
+    return {
+      id: row?.dataset.testid ?? null,
+      offsetRatio: bounds ? (bounds.top - viewportTop) / bounds.height : null,
+    };
+  });
+  const beforeHistoryRefresh = await visibleAnchor();
+  expect(beforeHistoryRefresh.id).not.toBeNull();
+  expect(await scrollTop()).toBeGreaterThan(240);
+
+  await publishRefresh(5, "workspace-card-ws_perf_newest");
+  await expect.poll(async () => (await visibleAnchor()).id).toBe(beforeHistoryRefresh.id);
+  const afterHistoryRefresh = await visibleAnchor();
+  expect(afterHistoryRefresh.offsetRatio).toBeCloseTo(beforeHistoryRefresh.offsetRatio ?? 0, 1);
+
+  await list.evaluate((element) => element.scrollTo({ top: 0 }));
+  await expectTop();
+  const fractionalTop = await list.evaluate((element) => {
+    element.scrollTo({ top: 0.25 });
+    return element.scrollTop;
+  });
+  expect(Math.abs(fractionalTop)).toBeLessThanOrEqual(0.5);
+
+  // Chromium clamps native scrollTop at zero, so simulate Safari's elastic
+  // overscroll while retaining the component's observable scrollTo behavior.
+  await list.evaluate((element) => {
+    let simulatedScrollTop = -20;
+    Object.defineProperty(element, "scrollTop", {
+      configurable: true,
+      get: () => simulatedScrollTop,
+    });
+    element.scrollTo = (options?: ScrollToOptions | number, y?: number) => {
+      if (typeof options === "number") {
+        simulatedScrollTop = y ?? simulatedScrollTop;
+      } else if (options?.top !== undefined) {
+        simulatedScrollTop = options.top;
+      }
+    };
+  });
+  expect(await scrollTop()).toBe(-20);
+
+  revision = 6;
+  const requestsBeforeFinalPoll = firstPageRequests;
+  await expect
+    .poll(() => firstPageRequests, { timeout: 7_000 })
+    .toBeGreaterThan(requestsBeforeFinalPoll);
+  await expect.poll(firstCardId).toBe("workspace-card-ws_perf_0001");
+  await expectTop();
+  await expect(page.locator('[data-testid^="workspace-card-"]')).toHaveCount(PAGE_SIZE);
+});
+}
 
 test("keeps the visible row anchored when a refresh changes row heights", async ({ page }) => {
   const expandedTitle =

--- a/apps/console/tests/dashboard-stage2-gates.spec.ts
+++ b/apps/console/tests/dashboard-stage2-gates.spec.ts
@@ -6640,6 +6640,52 @@ test("Finished stays visible when it differs from workflow_finished_at", async (
   await expect(dialog.getByText("Workflow finished", { exact: true })).toBeVisible();
 });
 
+test("malformed finished_at stays hidden when workflow_finished_at is valid", async ({ page }) => {
+  const overview = {
+    ...presentationOverview(),
+    workflow_finished_at: "2026-09-06T17:10:00Z",
+    finished_at: "not-a-timestamp",
+  };
+  await mockAwfConsoleApi(page, { overviewItems: [overview] });
+  await page.route("**/api/awf/workspaces/ws_presentation_sample**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (path === "/api/awf/workspaces/ws_presentation_sample") {
+      await fulfillJson(route, {
+        ...overview,
+        id: "ws_presentation_sample",
+        version: 1,
+      });
+      return;
+    }
+    if (path.endsWith("/runtime")) {
+      await fulfillJson(route, { status: "monitoring_pr" });
+      return;
+    }
+    if (path.includes("/events") || path.includes("/operations") || path.includes("/logs")) {
+      await fulfillJson(route, { items: [], next_cursor: null, has_more: false });
+      return;
+    }
+    await fulfillJson(route, { detail: { message: `unmocked ${path}` } }, 404);
+  });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+  await page.getByTestId("workspace-card-ws_presentation_sample").click();
+  await expect(page.getByText("Workflow finished", { exact: true })).toBeVisible();
+  await expect(page.getByText("Finished", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("not-a-timestamp", { exact: true })).toHaveCount(0);
+
+  await page
+    .getByTestId("workspace-card-ws_presentation_sample")
+    .getByRole("button", { name: "Details", exact: true })
+    .click();
+  const dialog = page.getByRole("dialog", { name: /Task details/i });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Workflow finished", { exact: true })).toBeVisible();
+  await expect(dialog.getByText("Finished", { exact: true })).toHaveCount(0);
+  await expect(dialog.getByText("not-a-timestamp", { exact: true })).toHaveCount(0);
+});
+
 test("capability 403 clears stale summary KPIs", async ({ page }) => {
   let authDenied = false;
   const summary = localDashboardSummary({

--- a/apps/console/tests/dashboard-summary-kpis.spec.ts
+++ b/apps/console/tests/dashboard-summary-kpis.spec.ts
@@ -1,5 +1,7 @@
 import { expect, type Page, test } from "@playwright/test";
 
+import type { ConsoleDashboardSummary } from "@/lib/types";
+
 import { localDashboardSummary, hostedDashboardSummary, mockAwfConsoleApi } from "./fixtures/console-api";
 
 async function waitForConsoleReady(page: Page) {
@@ -9,6 +11,46 @@ async function waitForConsoleReady(page: Page) {
 
 const kpi = (page: Page, label: string) =>
   page.getByText(label, { exact: true }).locator("..").filter({ has: page.locator(".kpi-value") });
+
+function hostedCountEvidenceSummary(): ConsoleDashboardSummary {
+  const base = hostedDashboardSummary() as ConsoleDashboardSummary;
+  return {
+    ...base,
+    coverage: {
+      status: "partial",
+      notes: ["terminal_timestamp_unavailable", "attention_evidence_unavailable"],
+    },
+    counts: {
+      active: 1,
+      executing: null,
+      monitoring_pr: null,
+      awaiting_operator: 0,
+      awaiting_human: null,
+      retrying: null,
+      queued: null,
+      completed_last_window: null,
+      cancelled_last_window: null,
+      failed_last_window: null,
+    },
+    count_evidence: {
+      total_workspaces: 30,
+      status_known_workspaces: 25,
+      status_unknown_workspaces: 5,
+      confirmed_counts: {
+        active: 1,
+        executing: 1,
+        monitoring_pr: 0,
+        awaiting_operator: 0,
+        awaiting_human: 0,
+        retrying: 0,
+        queued: 0,
+        completed_last_window: 0,
+        cancelled_last_window: 0,
+        failed_last_window: 0,
+      },
+    },
+  };
+}
 
 test("KPI values come from dashboard-summary when saturation absent", async ({ page }) => {
   const requested: string[] = [];
@@ -101,6 +143,54 @@ test("unknown dashboard coverage renders an explicit notice without a request er
   await expect(coverage).toContainText("provider lag");
   await expect(page.getByTestId("dashboard-summary-error")).toHaveCount(0);
 });
+
+for (const viewport of [
+  { name: "desktop", width: 1280, height: 900 },
+  { name: "mobile", width: 390, height: 844 },
+]) {
+  test(`count evidence stays qualified and readable on ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await mockAwfConsoleApi(page, {
+      mode: "hosted",
+      dashboardSummary: hostedCountEvidenceSummary(),
+    });
+
+    await page.goto("/");
+    await waitForConsoleReady(page);
+
+    // Exact values retain their existing naked rendering and win over matching evidence.
+    await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("1");
+    await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("0");
+    // Null exact values use explicit, visible lower-bound qualification, including zero.
+    await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("1 confirmed");
+    await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("0 confirmed");
+    await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("0 confirmed");
+    await expect(kpi(page, "Running")).toContainText("project total is incomplete");
+    await expect(kpi(page, "Completed")).toContainText("last 24h");
+    await expect(kpi(page, "Completed")).toContainText("project total is incomplete");
+
+    const coverage = page.getByTestId("dashboard-summary-coverage");
+    await expect(coverage).toContainText("25 of 30 workflow statuses known; 5 unknown");
+    await expect(coverage).toContainText("terminal timestamp unavailable");
+    await expect(coverage).toContainText("attention evidence unavailable");
+    await expect(page.getByTestId("dashboard-summary-error")).toHaveCount(0);
+
+    for (const label of ["Running", "Monitoring PR", "Completed"]) {
+      const card = kpi(page, label);
+      const valueBox = await card.locator(".kpi-value").boundingBox();
+      const hintBox = await card.getByText(/project total is incomplete/).boundingBox();
+      expect(valueBox, `${label} value is measurable`).not.toBeNull();
+      expect(hintBox, `${label} incomplete-total hint is measurable`).not.toBeNull();
+      expect(valueBox!.y + valueBox!.height, `${label} value does not overlap its hint`).toBeLessThanOrEqual(
+        hintBox!.y + 1,
+      );
+    }
+    const hasHorizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(hasHorizontalOverflow).toBe(false);
+  });
+}
 
 test("status counters stay consistent for escalation/retry/terminal fixtures", async ({ page }) => {
   await mockAwfConsoleApi(page, {

--- a/apps/console/tests/dashboard-summary-kpis.spec.ts
+++ b/apps/console/tests/dashboard-summary-kpis.spec.ts
@@ -165,9 +165,9 @@ for (const viewport of [
     await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("1 confirmed");
     await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("0 confirmed");
     await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("0 confirmed");
-    await expect(kpi(page, "Running")).toContainText("project total is incomplete");
+    await expect(kpi(page, "Running")).toContainText("exact metric count is incomplete");
     await expect(kpi(page, "Completed")).toContainText("last 24h");
-    await expect(kpi(page, "Completed")).toContainText("project total is incomplete");
+    await expect(kpi(page, "Completed")).toContainText("exact metric count is incomplete");
 
     const coverage = page.getByTestId("dashboard-summary-coverage");
     await expect(coverage).toContainText("25 of 30 workflow statuses known; 5 unknown");
@@ -178,9 +178,9 @@ for (const viewport of [
     for (const label of ["Running", "Monitoring PR", "Completed"]) {
       const card = kpi(page, label);
       const valueBox = await card.locator(".kpi-value").boundingBox();
-      const hintBox = await card.getByText(/project total is incomplete/).boundingBox();
+      const hintBox = await card.getByText(/exact metric count is incomplete/).boundingBox();
       expect(valueBox, `${label} value is measurable`).not.toBeNull();
-      expect(hintBox, `${label} incomplete-total hint is measurable`).not.toBeNull();
+      expect(hintBox, `${label} incomplete-metric hint is measurable`).not.toBeNull();
       expect(valueBox!.y + valueBox!.height, `${label} value does not overlap its hint`).toBeLessThanOrEqual(
         hintBox!.y + 1,
       );

--- a/apps/console/tests/dashboard-summary-kpis.spec.ts
+++ b/apps/console/tests/dashboard-summary-kpis.spec.ts
@@ -175,7 +175,7 @@ for (const viewport of [
     await expect(coverage).toContainText("attention evidence unavailable");
     await expect(page.getByTestId("dashboard-summary-error")).toHaveCount(0);
 
-    for (const label of ["Running", "Monitoring PR", "Completed"]) {
+    for (const label of ["Active", "Running", "Monitoring PR", "Awaiting operator", "Completed"]) {
       const card = kpi(page, label);
       const valueBox = await card.locator(".kpi-value").boundingBox();
       const hintBox = await card.getByText(/exact metric count is incomplete/).boundingBox();

--- a/apps/console/tests/dashboard-summary-kpis.spec.ts
+++ b/apps/console/tests/dashboard-summary-kpis.spec.ts
@@ -21,10 +21,10 @@ function hostedCountEvidenceSummary(): ConsoleDashboardSummary {
       notes: ["terminal_timestamp_unavailable", "attention_evidence_unavailable"],
     },
     counts: {
-      active: 1,
+      active: null,
       executing: null,
       monitoring_pr: null,
-      awaiting_operator: 0,
+      awaiting_operator: null,
       awaiting_human: null,
       retrying: null,
       queued: null,
@@ -158,10 +158,10 @@ for (const viewport of [
     await page.goto("/");
     await waitForConsoleReady(page);
 
-    // Exact values retain their existing naked rendering and win over matching evidence.
-    await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("1");
-    await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("0");
-    // Null exact values use explicit, visible lower-bound qualification, including zero.
+    // Unknown workflow statuses make every exact count unproven, so the fixture
+    // exposes only explicitly qualified lower bounds, including zero.
+    await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("1 confirmed");
+    await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("0 confirmed");
     await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("1 confirmed");
     await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("0 confirmed");
     await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("0 confirmed");

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -7,7 +7,7 @@ import type {
 } from "@/lib/types";
 import { formatDateTime } from "@/lib/format";
 
-import { mockAwfConsoleApi } from "./fixtures/console-api";
+import { fulfillJson, mockAwfConsoleApi } from "./fixtures/console-api";
 
 async function waitForConsoleReady(page: Page) {
   await expect(page.locator("header").filter({ hasText: "AWF Console" })).toBeVisible();
@@ -206,6 +206,40 @@ test("local terminal cards use one complete lifecycle interval", async ({ page }
       duration,
     );
   }
+});
+
+test("local terminal inspector uses the card lifecycle timing", async ({ page }) => {
+  const completed = overview("ws_local_inspector_timing", "completed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:02:00Z", 120),
+      stage("running", "2026-09-06T12:02:00Z", "2026-09-06T12:10:00Z", 480),
+      stage("completed", "2026-09-06T12:10:00Z", "2026-09-06T12:20:00Z", 600),
+    ],
+  });
+  await mockAwfConsoleApi(page, { overviewItems: [completed] });
+  await page.route(
+    `**/api/awf/workspaces/${completed.workspace_id}`,
+    async (route) => {
+      await fulfillJson(route, {
+        ...completed,
+        id: completed.workspace_id,
+        version: 1,
+      });
+    },
+  );
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  await page.getByTestId(`workspace-card-${completed.workspace_id}`).click();
+  const inspector = page.locator(".fixed.inset-y-0.right-0").first();
+  await expect(inspector.getByRole("button", { name: "Close inspector" })).toBeVisible();
+  const workflowFinished = inspector
+    .getByText("Workflow finished", { exact: true })
+    .locator("..");
+  await expect(workflowFinished).toContainText(formatDateTime("2026-09-06T12:10:00Z"));
+  const duration = inspector.getByText("Duration", { exact: true }).locator("..");
+  await expect(duration).toContainText("10m 0s");
 });
 
 test("local terminal task details use the card lifecycle timing", async ({ page }) => {

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -206,6 +206,36 @@ test("hosted terminal cards use workflow finish and recorded duration for every 
   }
 });
 
+test("destroyed hosted or legacy cards honor explicit workflow timing", async ({ page }) => {
+  const items = [
+    overview("ws_hosted_destroyed_explicit", "destroyed", {
+      workflow_finished_at: "2026-09-06T12:20:00Z",
+      duration_seconds: 1200,
+    }),
+    overview("ws_legacy_destroyed_explicit", "destroyed", {
+      finished_at: "2026-09-06T12:21:00Z",
+      duration_seconds: 1260,
+    }),
+  ];
+  await mockAwfConsoleApi(page, { mode: "hosted", overviewItems: items });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  for (const [index, item] of items.entries()) {
+    const timing = page.getByTestId(`workspace-timing-${item.workspace_id}`);
+    await expect(timing).toContainText("Finished");
+    await expect(timing).toContainText("Duration");
+    await expect(timing).not.toContainText("Last activity");
+    await expect(
+      page.getByTestId(`workspace-finished-${item.workspace_id}`),
+    ).toContainText(formatDateTime(index === 0 ? item.workflow_finished_at : item.finished_at));
+    await expect(
+      page.getByTestId(`workspace-duration-${item.workspace_id}`),
+    ).toContainText(`${20 + index}m 0s`);
+  }
+});
+
 test("local terminal cards use one complete lifecycle interval", async ({ page }) => {
   const completed = overview("ws_local_completed", "completed", {
     lifecycle: [

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -1,0 +1,349 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import type {
+  WorkspaceLifecycleStage,
+  WorkspaceOverview,
+  WorkspaceStatus,
+} from "@/lib/types";
+import { formatDateTime } from "@/lib/format";
+
+import { mockAwfConsoleApi } from "./fixtures/console-api";
+
+async function waitForConsoleReady(page: Page) {
+  await expect(page.locator("header").filter({ hasText: "AWF Console" })).toBeVisible();
+  await expect(page.getByText("API: ok")).toBeVisible();
+}
+
+function overview(
+  workspaceId: string,
+  status: WorkspaceStatus,
+  overrides: Partial<WorkspaceOverview> = {},
+): WorkspaceOverview {
+  return {
+    workspace_id: workspaceId,
+    task_id: `task_${workspaceId}`,
+    title: `${status} timing workspace`,
+    task_prompt: "Verify workspace card timing",
+    repo_url: "https://github.com/example/awf.git",
+    base_branch: "development",
+    branch_name: `awf/${workspaceId}`,
+    agent: "codex",
+    agent_model: "gpt-5.5",
+    agent_effort: "high",
+    agent_model_source: "task_policy",
+    agent_effort_source: "default",
+    network_posture: "restricted",
+    lifecycle: [],
+    llm_usage: {
+      input_tokens: null,
+      output_tokens: null,
+      total_tokens: null,
+      cost_estimate: null,
+      currency: null,
+      status: "unavailable",
+      source: "none",
+      reason: "usage_not_reported",
+    },
+    recovery: null,
+    coordination_warnings: [],
+    provider_readiness_preflight: null,
+    status,
+    subphase: null,
+    last_activity_at: "2026-09-06T12:15:00Z",
+    last_log_at: "2026-09-06T12:14:00Z",
+    is_stale_running: false,
+    current_phase: status,
+    active_operation: null,
+    last_event: null,
+    pr_url: null,
+    pr_number: null,
+    failure_reason: null,
+    failure_message: null,
+    created_at: "2026-09-06T12:00:00Z",
+    updated_at: "2026-09-06T12:45:00Z",
+    ...overrides,
+  };
+}
+
+function stage(
+  name: string,
+  startedAt: string | null,
+  endedAt: string | null,
+  durationSeconds: number | null,
+): WorkspaceLifecycleStage {
+  return {
+    stage: name,
+    started_at: startedAt,
+    ended_at: endedAt,
+    duration_seconds: durationSeconds,
+    status: startedAt ? "completed" : "pending",
+  };
+}
+
+const surfaces = [
+  { name: "local desktop", mode: "local" as const, width: 1280, height: 900 },
+  { name: "hosted mobile", mode: "hosted" as const, width: 390, height: 844 },
+];
+
+for (const surface of surfaces) {
+  test(`active cards show activity without Updated on ${surface.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: surface.width, height: surface.height });
+    const running = overview("ws_running_timing", "running");
+    const monitoring = overview("ws_monitoring_timing", "monitoring_pr", {
+      last_activity_at: "2026-09-06T12:20:00Z",
+      pr_url: "https://github.com/example/awf/pull/12",
+      pr_number: 12,
+    });
+    const requestedWithoutActivity = overview("ws_requested_timing", "requested", {
+      last_activity_at: null,
+    });
+    await mockAwfConsoleApi(page, {
+      mode: surface.mode,
+      overviewItems: [running, monitoring, requestedWithoutActivity],
+    });
+
+    await page.goto("/");
+    await waitForConsoleReady(page);
+
+    for (const item of [running, monitoring]) {
+      const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
+      const timing = card.getByTestId(`workspace-timing-${item.workspace_id}`);
+      await expect(timing).toContainText("Created");
+      await expect(timing).toContainText("Last activity");
+      await expect(timing).not.toContainText("Updated");
+      await expect(timing).not.toContainText("Finished");
+      await expect(timing).not.toContainText("Duration");
+    }
+    await expect(
+      page.getByTestId("workspace-last-activity-ws_requested_timing"),
+    ).toContainText("not recorded");
+
+    const runningCard = page.getByTestId("workspace-card-ws_running_timing");
+    await runningCard.getByRole("button", { name: "Details", exact: true }).click();
+    const details = page.getByRole("dialog", { name: /Task details/i });
+    await expect(details).toBeVisible();
+    await expect(details.getByText("Updated", { exact: true })).toBeVisible();
+  });
+}
+
+test("hosted terminal cards use workflow finish and recorded duration for every terminal status", async ({
+  page,
+}) => {
+  const terminals = (["completed", "failed", "cancelled", "destroyed"] as const).map(
+    (status, index) =>
+      overview(`ws_hosted_${status}`, status, {
+        started_at: "2026-09-06T12:00:00Z",
+        workflow_finished_at: `2026-09-06T12:${20 + index}:00Z`,
+        finished_at: null,
+        duration_seconds: 1200 + index * 60,
+        native_runtime_finished_at: "2026-09-06T12:05:00Z",
+        last_activity_at: "2026-09-06T12:40:00Z",
+        updated_at: "2026-09-06T12:45:00Z",
+      }),
+  );
+  await mockAwfConsoleApi(page, { mode: "hosted", overviewItems: terminals });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  for (const [index, item] of terminals.entries()) {
+    const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
+    const timing = card.getByTestId(`workspace-timing-${item.workspace_id}`);
+    await expect(timing).toContainText("Created");
+    await expect(timing).toContainText("Finished");
+    await expect(timing).toContainText("Duration");
+    await expect(timing).not.toContainText("Last activity");
+    await expect(timing).not.toContainText("Updated");
+    await expect(card.getByTestId(`workspace-finished-${item.workspace_id}`)).toContainText(
+      formatDateTime(item.workflow_finished_at),
+    );
+    await expect(card.getByTestId(`workspace-duration-${item.workspace_id}`)).toContainText(
+      `${20 + index}m 0s`,
+    );
+  }
+});
+
+test("local terminal cards use one complete lifecycle interval", async ({ page }) => {
+  const completed = overview("ws_local_completed", "completed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:02:00Z", 120),
+      stage("running", "2026-09-06T12:02:00Z", "2026-09-06T12:10:00Z", 480),
+      stage("completed", "2026-09-06T12:10:00Z", "2026-09-06T12:10:00Z", 0),
+    ],
+  });
+  const failed = overview("ws_local_failed", "failed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
+      stage("validating", null, null, null),
+    ],
+  });
+  const destroyed = overview("ws_local_destroyed", "destroyed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:09:00Z", 480),
+      // Cleanup closes the completed stage later; workflow finish remains its start.
+      stage("completed", "2026-09-06T12:09:00Z", "2026-09-06T12:30:00Z", 1260),
+    ],
+  });
+  await mockAwfConsoleApi(page, {
+    overviewItems: [completed, failed, destroyed],
+  });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  for (const [item, finished, duration] of [
+    [completed, "2026-09-06T12:10:00Z", "10m 0s"],
+    [failed, "2026-09-06T12:08:00Z", "8m 0s"],
+    [destroyed, "2026-09-06T12:09:00Z", "9m 0s"],
+  ] as const) {
+    const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
+    await expect(card.getByTestId(`workspace-finished-${item.workspace_id}`)).toContainText(
+      formatDateTime(finished),
+    );
+    await expect(card.getByTestId(`workspace-duration-${item.workspace_id}`)).toContainText(
+      duration,
+    );
+  }
+});
+
+test("local terminal task details use the card lifecycle timing", async ({ page }) => {
+  const completed = overview("ws_local_details_timing", "completed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:02:00Z", 120),
+      stage("running", "2026-09-06T12:02:00Z", "2026-09-06T12:10:00Z", 480),
+      stage("completed", "2026-09-06T12:10:00Z", "2026-09-06T12:20:00Z", 600),
+    ],
+  });
+  await mockAwfConsoleApi(page, { overviewItems: [completed] });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  const card = page.getByTestId(`workspace-card-${completed.workspace_id}`);
+  await expect(card.getByTestId(`workspace-finished-${completed.workspace_id}`)).toContainText(
+    formatDateTime("2026-09-06T12:10:00Z"),
+  );
+  await expect(card.getByTestId(`workspace-duration-${completed.workspace_id}`)).toContainText(
+    "10m 0s",
+  );
+
+  await card.getByRole("button", { name: "Details", exact: true }).click();
+  const details = page.getByRole("dialog", { name: /Task details/i });
+  const workflowFinished = details.getByText("Workflow finished", { exact: true }).locator("..");
+  await expect(workflowFinished).toContainText(formatDateTime("2026-09-06T12:10:00Z"));
+  const duration = details.getByText("Duration", { exact: true }).locator("..");
+  await expect(duration).toContainText("10m 0s");
+});
+
+test("terminal cards call missing or ambiguous timing not recorded while preserving zero", async ({
+  page,
+}) => {
+  const missing = overview("ws_timing_missing", "completed", {
+    native_runtime_finished_at: "2026-09-06T12:05:00Z",
+    workflow_finished_at: null,
+    finished_at: null,
+    duration_seconds: null,
+    lifecycle: [],
+  });
+  const invalid = overview("ws_timing_invalid", "failed", {
+    workflow_finished_at: "not-a-timestamp",
+    duration_seconds: -1,
+    lifecycle: [stage("running", "2026-09-06T12:00:00Z", "2026-09-06T12:11:00Z", 660)],
+  });
+  const missingDuration = overview("ws_duration_missing", "completed", {
+    workflow_finished_at: "2026-09-06T12:12:00Z",
+    duration_seconds: null,
+  });
+  const mismatchedDuration = overview("ws_duration_mismatch", "completed", {
+    workflow_finished_at: "2026-09-06T12:12:00Z",
+    finished_at: "2026-09-06T12:10:00Z",
+    duration_seconds: 600,
+  });
+  const lifecycleGap = overview("ws_duration_gap", "failed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("running", "2026-09-06T12:02:00Z", "2026-09-06T12:05:00Z", 180),
+    ],
+  });
+  const completedStageWithoutStart = overview("ws_timing_missing_stage_start", "failed", {
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      {
+        stage: "running",
+        started_at: null,
+        ended_at: null,
+        duration_seconds: null,
+        status: "completed",
+      },
+    ],
+  });
+  const retryAmbiguous = overview("ws_timing_retry", "destroyed", {
+    recovery: {
+      from_state: "failed",
+      to_state: "requested",
+      reason_code: "retry",
+      action: "retry",
+      recovery_mode: null,
+      started_at: "2026-09-06T12:10:00Z",
+      current_operation: null,
+      summary: "Workflow retried.",
+      payload: null,
+    },
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
+      // A later completion no longer matches the collapsed earlier-stage lifecycle.
+      stage("completed", "2026-09-06T12:20:00Z", "2026-09-06T12:30:00Z", 600),
+    ],
+  });
+  const zero = overview("ws_timing_zero", "cancelled", {
+    workflow_finished_at: null,
+    finished_at: "2026-09-06T12:00:00Z",
+    duration_seconds: 0,
+  });
+  await mockAwfConsoleApi(page, {
+    overviewItems: [
+      missing,
+      invalid,
+      missingDuration,
+      mismatchedDuration,
+      lifecycleGap,
+      completedStageWithoutStart,
+      retryAmbiguous,
+      zero,
+    ],
+  });
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  for (const item of [missing, invalid, completedStageWithoutStart, retryAmbiguous]) {
+    const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
+    await expect(card.getByTestId(`workspace-finished-${item.workspace_id}`)).toContainText(
+      "not recorded",
+    );
+    await expect(card.getByTestId(`workspace-duration-${item.workspace_id}`)).toContainText(
+      "not recorded",
+    );
+  }
+
+  for (const item of [missingDuration, mismatchedDuration, lifecycleGap]) {
+    const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
+    await expect(card.getByTestId(`workspace-finished-${item.workspace_id}`)).not.toContainText(
+      "not recorded",
+    );
+    await expect(card.getByTestId(`workspace-duration-${item.workspace_id}`)).toContainText(
+      "not recorded",
+    );
+  }
+
+  const zeroCard = page.getByTestId("workspace-card-ws_timing_zero");
+  await expect(zeroCard.getByTestId("workspace-finished-ws_timing_zero")).not.toContainText(
+    "not recorded",
+  );
+  await expect(zeroCard.getByTestId("workspace-duration-ws_timing_zero")).toContainText(
+    "0s",
+  );
+});

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -233,6 +233,85 @@ test("local terminal cards use one complete lifecycle interval", async ({ page }
   }
 });
 
+test("destroying cards preserve terminal timing only after a workflow terminal boundary", async ({
+  page,
+}) => {
+  const postTerminal = overview("ws_destroying_post_terminal", "destroying", {
+    latest_workflow_terminal_state_change: stateChangedEvent(
+      "ws_destroying_post_terminal",
+      "running",
+      "failed",
+      "2026-09-06T12:08:00Z",
+    ),
+    latest_state_change: stateChangedEvent(
+      "ws_destroying_post_terminal",
+      "failed",
+      "destroying",
+      "2026-09-06T12:20:00Z",
+    ),
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
+    ],
+  });
+  const directDestroy = overview("ws_destroying_direct", "destroying", {
+    latest_state_change: stateChangedEvent(
+      "ws_destroying_direct",
+      "ready",
+      "destroying",
+      "2026-09-06T12:02:00Z",
+    ),
+    last_activity_at: "2026-09-06T12:02:00Z",
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("ready", "2026-09-06T12:01:00Z", "2026-09-06T12:02:00Z", 60),
+    ],
+  });
+  await mockAwfConsoleApi(page, { overviewItems: [postTerminal, directDestroy] });
+  await page.route(
+    `**/api/awf/workspaces/${postTerminal.workspace_id}`,
+    async (route) => {
+      await fulfillJson(route, {
+        ...postTerminal,
+        id: postTerminal.workspace_id,
+        version: 1,
+      });
+    },
+  );
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  const terminalCard = page.getByTestId(`workspace-card-${postTerminal.workspace_id}`);
+  const terminalTiming = terminalCard.getByTestId(
+    `workspace-timing-${postTerminal.workspace_id}`,
+  );
+  await expect(terminalTiming).toContainText("Finished");
+  await expect(terminalTiming).toContainText("Duration");
+  await expect(terminalTiming).not.toContainText("Last activity");
+  await expect(
+    terminalCard.getByTestId(`workspace-finished-${postTerminal.workspace_id}`),
+  ).toContainText(formatDateTime("2026-09-06T12:08:00Z"));
+  await expect(
+    terminalCard.getByTestId(`workspace-duration-${postTerminal.workspace_id}`),
+  ).toContainText("8m 0s");
+
+  const directTiming = page.getByTestId(`workspace-timing-${directDestroy.workspace_id}`);
+  await expect(directTiming).toContainText("Last activity");
+  await expect(directTiming).not.toContainText("Finished");
+  await expect(directTiming).not.toContainText("Duration");
+
+  await terminalCard.click();
+  const inspector = page.locator(".fixed.inset-y-0.right-0").first();
+  await expect(inspector.getByRole("button", { name: "Close inspector" })).toBeVisible();
+  await expect(
+    inspector.getByText("Workflow finished", { exact: true }).locator(".."),
+  ).toContainText(formatDateTime("2026-09-06T12:08:00Z"));
+  await expect(inspector.getByText("Duration", { exact: true }).locator("..")).toContainText(
+    "8m 0s",
+  );
+});
+
 test("local terminal inspector uses the card lifecycle timing", async ({ page }) => {
   const completed = overview("ws_local_inspector_timing", "completed", {
     lifecycle: [

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -374,6 +374,57 @@ test("local terminal inspector uses the card lifecycle timing", async ({ page })
   await expect(duration).toContainText("10m 0s");
 });
 
+test("inspector keeps timing on the overview snapshot when detail is newer", async ({
+  page,
+}) => {
+  const running = overview("ws_detail_ahead_of_overview", "running", {
+    latest_state_change: stateChangedEvent(
+      "ws_detail_ahead_of_overview",
+      "ready",
+      "running",
+      "2026-09-06T12:02:00Z",
+    ),
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("ready", "2026-09-06T12:01:00Z", "2026-09-06T12:02:00Z", 60),
+      {
+        ...stage("running", "2026-09-06T12:02:00Z", null, null),
+        status: "active",
+      },
+    ],
+  });
+  await mockAwfConsoleApi(page, { overviewItems: [running] });
+  await page.route(
+    `**/api/awf/workspaces/${running.workspace_id}`,
+    async (route) => {
+      await fulfillJson(route, {
+        ...running,
+        id: running.workspace_id,
+        status: "failed",
+        workflow_finished_at: "2026-09-06T12:10:00Z",
+        duration_seconds: 600,
+        lifecycle: [
+          stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+          stage("ready", "2026-09-06T12:01:00Z", "2026-09-06T12:02:00Z", 60),
+          stage("running", "2026-09-06T12:02:00Z", "2026-09-06T12:10:00Z", 480),
+        ],
+        version: 2,
+      });
+    },
+  );
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  await page.getByTestId(`workspace-card-${running.workspace_id}`).click();
+  const inspector = page.locator(".fixed.inset-y-0.right-0").first();
+  await expect(inspector.getByRole("button", { name: "Close inspector" })).toBeVisible();
+  await expect(
+    inspector.getByText("Workflow finished", { exact: true }).locator(".."),
+  ).toContainText("not recorded");
+  await expect(inspector.getByText("Duration", { exact: true })).toHaveCount(0);
+});
+
 test("local terminal task details use the card lifecycle timing", async ({ page }) => {
   const completed = overview("ws_local_details_timing", "completed", {
     lifecycle: [

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -267,7 +267,28 @@ test("destroying cards preserve terminal timing only after a workflow terminal b
       stage("ready", "2026-09-06T12:01:00Z", "2026-09-06T12:02:00Z", 60),
     ],
   });
-  await mockAwfConsoleApi(page, { overviewItems: [postTerminal, directDestroy] });
+  const retriedDirectDestroy = overview("ws_destroying_retried_direct", "destroying", {
+    latest_workflow_terminal_state_change: stateChangedEvent(
+      "ws_destroying_retried_direct",
+      "running",
+      "failed",
+      "2026-09-06T12:08:00Z",
+    ),
+    latest_state_change: stateChangedEvent(
+      "ws_destroying_retried_direct",
+      "ready",
+      "destroying",
+      "2026-09-06T12:22:00Z",
+    ),
+    last_activity_at: "2026-09-06T12:22:00Z",
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
+    ],
+  });
+  await mockAwfConsoleApi(page, {
+    overviewItems: [postTerminal, directDestroy, retriedDirectDestroy],
+  });
   await page.route(
     `**/api/awf/workspaces/${postTerminal.workspace_id}`,
     async (route) => {
@@ -300,6 +321,13 @@ test("destroying cards preserve terminal timing only after a workflow terminal b
   await expect(directTiming).toContainText("Last activity");
   await expect(directTiming).not.toContainText("Finished");
   await expect(directTiming).not.toContainText("Duration");
+
+  const retriedDirectTiming = page.getByTestId(
+    `workspace-timing-${retriedDirectDestroy.workspace_id}`,
+  );
+  await expect(retriedDirectTiming).toContainText("Last activity");
+  await expect(retriedDirectTiming).not.toContainText("Finished");
+  await expect(retriedDirectTiming).not.toContainText("Duration");
 
   await terminalCard.click();
   const inspector = page.locator(".fixed.inset-y-0.right-0").first();

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -1,6 +1,7 @@
 import { expect, type Page, test } from "@playwright/test";
 
 import type {
+  WorkspaceEvent,
   WorkspaceLifecycleStage,
   WorkspaceOverview,
   WorkspaceStatus,
@@ -62,6 +63,24 @@ function overview(
     created_at: "2026-09-06T12:00:00Z",
     updated_at: "2026-09-06T12:45:00Z",
     ...overrides,
+  };
+}
+
+function stateChangedEvent(
+  workspaceId: string,
+  oldState: string,
+  newState: WorkspaceStatus,
+  occurredAt: string,
+): WorkspaceEvent {
+  return {
+    id: `event_${workspaceId}_${newState}`,
+    workspace_id: workspaceId,
+    event_type: "workspace.state_changed",
+    old_state: oldState,
+    new_state: newState,
+    reason_code: null,
+    payload: null,
+    occurred_at: occurredAt,
   };
 }
 
@@ -172,6 +191,12 @@ test("local terminal cards use one complete lifecycle interval", async ({ page }
     ],
   });
   const failed = overview("ws_local_failed", "failed", {
+    last_event: stateChangedEvent(
+      "ws_local_failed",
+      "running",
+      "failed",
+      "2026-09-06T12:08:00Z",
+    ),
     lifecycle: [
       stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
       stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
@@ -296,6 +321,12 @@ test("terminal cards call missing or ambiguous timing not recorded while preserv
     duration_seconds: 600,
   });
   const lifecycleGap = overview("ws_duration_gap", "failed", {
+    last_event: stateChangedEvent(
+      "ws_duration_gap",
+      "running",
+      "failed",
+      "2026-09-06T12:05:00Z",
+    ),
     lifecycle: [
       stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
       stage("running", "2026-09-06T12:02:00Z", "2026-09-06T12:05:00Z", 180),

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -315,7 +315,7 @@ test("terminal cards call missing or ambiguous timing not recorded while preserv
     workflow_finished_at: "2026-09-06T12:12:00Z",
     duration_seconds: null,
   });
-  const mismatchedDuration = overview("ws_duration_mismatch", "completed", {
+  const distinctFinishedAtDuration = overview("ws_duration_distinct_finish", "completed", {
     workflow_finished_at: "2026-09-06T12:12:00Z",
     finished_at: "2026-09-06T12:10:00Z",
     duration_seconds: 600,
@@ -373,7 +373,7 @@ test("terminal cards call missing or ambiguous timing not recorded while preserv
       missing,
       invalid,
       missingDuration,
-      mismatchedDuration,
+      distinctFinishedAtDuration,
       lifecycleGap,
       completedStageWithoutStart,
       retryAmbiguous,
@@ -394,7 +394,7 @@ test("terminal cards call missing or ambiguous timing not recorded while preserv
     );
   }
 
-  for (const item of [missingDuration, mismatchedDuration, lifecycleGap]) {
+  for (const item of [missingDuration, lifecycleGap]) {
     const card = page.getByTestId(`workspace-card-${item.workspace_id}`);
     await expect(card.getByTestId(`workspace-finished-${item.workspace_id}`)).not.toContainText(
       "not recorded",
@@ -403,6 +403,14 @@ test("terminal cards call missing or ambiguous timing not recorded while preserv
       "not recorded",
     );
   }
+
+  const distinctFinishCard = page.getByTestId("workspace-card-ws_duration_distinct_finish");
+  await expect(
+    distinctFinishCard.getByTestId("workspace-finished-ws_duration_distinct_finish"),
+  ).not.toContainText("not recorded");
+  await expect(
+    distinctFinishCard.getByTestId("workspace-duration-ws_duration_distinct_finish"),
+  ).toContainText("10m 0s");
 
   const zeroCard = page.getByTestId("workspace-card-ws_timing_zero");
   await expect(zeroCard.getByTestId("workspace-finished-ws_timing_zero")).not.toContainText(

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -149,8 +149,9 @@ test("hosted terminal cards use workflow finish and recorded duration for every 
   page,
 }) => {
   const terminals = (["completed", "failed", "cancelled", "destroyed"] as const).map(
-    (status, index) =>
-      overview(`ws_hosted_${status}`, status, {
+    (status, index) => {
+      const workspaceId = `ws_hosted_${status}`;
+      return overview(workspaceId, status, {
         started_at: "2026-09-06T12:00:00Z",
         workflow_finished_at: `2026-09-06T12:${20 + index}:00Z`,
         finished_at: null,
@@ -158,7 +159,30 @@ test("hosted terminal cards use workflow finish and recorded duration for every 
         native_runtime_finished_at: "2026-09-06T12:05:00Z",
         last_activity_at: "2026-09-06T12:40:00Z",
         updated_at: "2026-09-06T12:45:00Z",
-      }),
+        ...(status === "destroyed"
+          ? {
+              latest_workflow_terminal_state_change: stateChangedEvent(
+                workspaceId,
+                "monitoring_pr",
+                "completed",
+                `2026-09-06T12:${20 + index}:00Z`,
+              ),
+              latest_destroying_state_change: stateChangedEvent(
+                workspaceId,
+                "completed",
+                "destroying",
+                "2026-09-06T12:35:00Z",
+              ),
+              latest_state_change: stateChangedEvent(
+                workspaceId,
+                "destroying",
+                "destroyed",
+                "2026-09-06T12:36:00Z",
+              ),
+            }
+          : {}),
+      });
+    },
   );
   await mockAwfConsoleApi(page, { mode: "hosted", overviewItems: terminals });
 
@@ -204,6 +228,24 @@ test("local terminal cards use one complete lifecycle interval", async ({ page }
     ],
   });
   const destroyed = overview("ws_local_destroyed", "destroyed", {
+    latest_workflow_terminal_state_change: stateChangedEvent(
+      "ws_local_destroyed",
+      "running",
+      "completed",
+      "2026-09-06T12:09:00Z",
+    ),
+    latest_destroying_state_change: stateChangedEvent(
+      "ws_local_destroyed",
+      "completed",
+      "destroying",
+      "2026-09-06T12:20:00Z",
+    ),
+    latest_state_change: stateChangedEvent(
+      "ws_local_destroyed",
+      "destroying",
+      "destroyed",
+      "2026-09-06T12:30:00Z",
+    ),
     lifecycle: [
       stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
       stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:09:00Z", 480),
@@ -233,7 +275,7 @@ test("local terminal cards use one complete lifecycle interval", async ({ page }
   }
 });
 
-test("destroying cards preserve terminal timing only after a workflow terminal boundary", async ({
+test("destroy cleanup cards preserve terminal timing only after a workflow terminal boundary", async ({
   page,
 }) => {
   const postTerminal = overview("ws_destroying_post_terminal", "destroying", {
@@ -286,8 +328,32 @@ test("destroying cards preserve terminal timing only after a workflow terminal b
       stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
     ],
   });
+  const destroyedDirectly = overview("ws_destroyed_direct", "destroyed", {
+    latest_state_change: stateChangedEvent(
+      "ws_destroyed_direct",
+      "destroying",
+      "destroyed",
+      "2026-09-06T12:04:00Z",
+    ),
+    latest_destroying_state_change: stateChangedEvent(
+      "ws_destroyed_direct",
+      "ready",
+      "destroying",
+      "2026-09-06T12:02:00Z",
+    ),
+    last_activity_at: "2026-09-06T12:04:00Z",
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("ready", "2026-09-06T12:01:00Z", "2026-09-06T12:02:00Z", 60),
+    ],
+  });
   await mockAwfConsoleApi(page, {
-    overviewItems: [postTerminal, directDestroy, retriedDirectDestroy],
+    overviewItems: [
+      postTerminal,
+      directDestroy,
+      retriedDirectDestroy,
+      destroyedDirectly,
+    ],
   });
   await page.route(
     `**/api/awf/workspaces/${postTerminal.workspace_id}`,
@@ -328,6 +394,13 @@ test("destroying cards preserve terminal timing only after a workflow terminal b
   await expect(retriedDirectTiming).toContainText("Last activity");
   await expect(retriedDirectTiming).not.toContainText("Finished");
   await expect(retriedDirectTiming).not.toContainText("Duration");
+
+  const destroyedDirectTiming = page.getByTestId(
+    `workspace-timing-${destroyedDirectly.workspace_id}`,
+  );
+  await expect(destroyedDirectTiming).toContainText("Last activity");
+  await expect(destroyedDirectTiming).not.toContainText("Finished");
+  await expect(destroyedDirectTiming).not.toContainText("Duration");
 
   await terminalCard.click();
   const inspector = page.locator(".fixed.inset-y-0.right-0").first();
@@ -580,6 +653,24 @@ test("terminal cards call missing or ambiguous timing not recorded while preserv
       summary: "Workflow retried.",
       payload: null,
     },
+    latest_workflow_terminal_state_change: stateChangedEvent(
+      "ws_timing_retry",
+      "running",
+      "failed",
+      "2026-09-06T12:08:00Z",
+    ),
+    latest_destroying_state_change: stateChangedEvent(
+      "ws_timing_retry",
+      "failed",
+      "destroying",
+      "2026-09-06T12:31:00Z",
+    ),
+    latest_state_change: stateChangedEvent(
+      "ws_timing_retry",
+      "destroying",
+      "destroyed",
+      "2026-09-06T12:32:00Z",
+    ),
     lifecycle: [
       stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
       stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -244,16 +244,25 @@ test("local terminal cards use one complete lifecycle interval", async ({ page }
       stage("completed", "2026-09-06T12:10:00Z", "2026-09-06T12:10:00Z", 0),
     ],
   });
-  const failed = overview("ws_local_failed", "failed", {
-    last_event: stateChangedEvent(
+  const failedTerminalEvent = {
+    ...stateChangedEvent(
       "ws_local_failed",
       "running",
       "failed",
       "2026-09-06T12:08:00Z",
     ),
+    event_order: 7,
+  };
+  const failed = overview("ws_local_failed", "failed", {
+    last_event: failedTerminalEvent,
+    latest_state_change: failedTerminalEvent,
+    latest_workflow_terminal_state_change: failedTerminalEvent,
     lifecycle: [
       stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
-      stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
+      {
+        ...stage("running", "2026-09-06T12:01:00Z", "2026-09-06T12:08:00Z", 420),
+        ended_event_order: 7,
+      },
       stage("validating", null, null, null),
     ],
   });

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -403,6 +403,72 @@ test("local terminal task details use the card lifecycle timing", async ({ page 
   await expect(duration).toContainText("10m 0s");
 });
 
+test("recovered terminal surfaces use the retained terminal event without a duration", async ({
+  page,
+}) => {
+  const completed = overview("ws_recovered_terminal_timing", "completed", {
+    recovery: {
+      from_state: "monitoring_pr",
+      to_state: "ready",
+      reason_code: "STALE_TARGET_ADVANCED",
+      action: "rebase",
+      recovery_mode: "rebase_only",
+      started_at: "2026-09-06T12:10:00Z",
+      current_operation: null,
+      summary: "Workflow recovered and completed.",
+      payload: null,
+    },
+    latest_workflow_terminal_state_change: stateChangedEvent(
+      "ws_recovered_terminal_timing",
+      "monitoring_pr",
+      "completed",
+      "2026-09-06T12:20:00Z",
+    ),
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("completed", "2026-09-06T12:20:00Z", "2026-09-06T12:20:00Z", 0),
+    ],
+  });
+  await mockAwfConsoleApi(page, { overviewItems: [completed] });
+  await page.route(
+    `**/api/awf/workspaces/${completed.workspace_id}`,
+    async (route) => {
+      await fulfillJson(route, {
+        ...completed,
+        id: completed.workspace_id,
+        version: 1,
+      });
+    },
+  );
+
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  const card = page.getByTestId(`workspace-card-${completed.workspace_id}`);
+  await expect(card.getByTestId(`workspace-finished-${completed.workspace_id}`)).toContainText(
+    formatDateTime("2026-09-06T12:20:00Z"),
+  );
+  await expect(card.getByTestId(`workspace-duration-${completed.workspace_id}`)).toContainText(
+    "not recorded",
+  );
+
+  await card.click();
+  const inspector = page.locator(".fixed.inset-y-0.right-0").first();
+  await expect(inspector.getByRole("button", { name: "Close inspector" })).toBeVisible();
+  await expect(
+    inspector.getByText("Workflow finished", { exact: true }).locator(".."),
+  ).toContainText(formatDateTime("2026-09-06T12:20:00Z"));
+  await expect(inspector.getByText("Duration", { exact: true })).toHaveCount(0);
+  await inspector.getByRole("button", { name: "Close inspector" }).click();
+
+  await card.getByRole("button", { name: "Details", exact: true }).click();
+  const details = page.getByRole("dialog", { name: /Task details/i });
+  await expect(
+    details.getByText("Workflow finished", { exact: true }).locator(".."),
+  ).toContainText(formatDateTime("2026-09-06T12:20:00Z"));
+  await expect(details.getByText("Duration", { exact: true })).toHaveCount(0);
+});
+
 test("terminal cards call missing or ambiguous timing not recorded while preserving zero", async ({
   page,
 }) => {

--- a/apps/console/tests/dashboard-workspace-card-timing.spec.ts
+++ b/apps/console/tests/dashboard-workspace-card-timing.spec.ts
@@ -347,12 +347,33 @@ test("destroy cleanup cards preserve terminal timing only after a workflow termi
       stage("ready", "2026-09-06T12:01:00Z", "2026-09-06T12:02:00Z", 60),
     ],
   });
+  const cleanupFailedDirectly = overview("ws_cleanup_failed_direct", "failed", {
+    latest_state_change: stateChangedEvent(
+      "ws_cleanup_failed_direct",
+      "destroying",
+      "failed",
+      "2026-09-06T12:04:00Z",
+    ),
+    latest_destroying_state_change: stateChangedEvent(
+      "ws_cleanup_failed_direct",
+      "ready",
+      "destroying",
+      "2026-09-06T12:02:00Z",
+    ),
+    latest_workflow_terminal_state_change: null,
+    last_activity_at: "2026-09-06T12:04:00Z",
+    lifecycle: [
+      stage("requested", "2026-09-06T12:00:00Z", "2026-09-06T12:01:00Z", 60),
+      stage("ready", "2026-09-06T12:01:00Z", "2026-09-06T12:02:00Z", 60),
+    ],
+  });
   await mockAwfConsoleApi(page, {
     overviewItems: [
       postTerminal,
       directDestroy,
       retriedDirectDestroy,
       destroyedDirectly,
+      cleanupFailedDirectly,
     ],
   });
   await page.route(
@@ -401,6 +422,13 @@ test("destroy cleanup cards preserve terminal timing only after a workflow termi
   await expect(destroyedDirectTiming).toContainText("Last activity");
   await expect(destroyedDirectTiming).not.toContainText("Finished");
   await expect(destroyedDirectTiming).not.toContainText("Duration");
+
+  const cleanupFailedDirectTiming = page.getByTestId(
+    `workspace-timing-${cleanupFailedDirectly.workspace_id}`,
+  );
+  await expect(cleanupFailedDirectTiming).toContainText("Last activity");
+  await expect(cleanupFailedDirectTiming).not.toContainText("Finished");
+  await expect(cleanupFailedDirectTiming).not.toContainText("Duration");
 
   await terminalCard.click();
   const inspector = page.locator(".fixed.inset-y-0.right-0").first();

--- a/docs/CONSOLE_BACKEND_CONTRACT.md
+++ b/docs/CONSOLE_BACKEND_CONTRACT.md
@@ -78,7 +78,61 @@ Never guess mode from hostname, browser location, query strings, or failed metri
 | `*_last_window` | Terminal statuses in the rolling window by `updated_at` |
 
 **Null ≠ zero.** Incomplete fields stay `null` with `coverage.status=partial|unknown`.
-UI renders `—` and never coerces null to `0`.
+UI renders `—` and never coerces null to `0`. When the optional
+`count_evidence` object is present and valid, the UI may render a confirmed
+lower bound for a null exact count, but it visibly qualifies the value as
+`N confirmed`; it never replaces the null exact value or presents the lower
+bound as an exact total. A non-null exact count always takes precedence.
+
+### Optional count evidence
+
+`count_evidence` is an optional, nullable schema-version-1 extension. When
+non-null it has four required fields and permits no unknown fields:
+
+| Field | Contract |
+| --- | --- |
+| `total_workspaces` | Strict nonnegative integer population in the authorized project-wide snapshot |
+| `status_known_workspaces` | Strict nonnegative integer count with authoritative workflow status |
+| `status_unknown_workspaces` | Strict nonnegative integer count without authoritative workflow status |
+| `confirmed_counts` | Object containing the same ten required names as `counts`, each a strict nonnegative integer lower bound |
+
+All evidence comes from the same authorized project-wide snapshot as the
+summary. The following invariants are required:
+
+- `status_known_workspaces + status_unknown_workspaces = total_workspaces`.
+- Every confirmed counter is at most `status_known_workspaces`.
+- The documented subset, overlap, and disjoint-active constraints apply to
+  `confirmed_counts` exactly as they apply to non-null exact counts.
+- Every non-null exact counter equals its confirmed counterpart when evidence
+  is present. Null exact counters remain null.
+- `coverage.status=complete` cannot coexist with a nonzero unknown-status
+  population.
+- Missing, invalid, or stale current-attempt status is status-unknown and
+  contributes to no confirmed counter.
+- A known authoritative workflow status can still lack attention evidence or
+  the authoritative original terminal timestamp. Those counters remain
+  incomplete, and `coverage.status` plus notes continue to name the attention
+  or terminal-window gap independently of status coverage.
+- Terminal-window confirmation requires the authoritative original terminal
+  timestamp. A later observation, collection, or unrelated update timestamp
+  must not be substituted.
+- `status_unknown_workspaces=0` does not by itself upgrade overall coverage to
+  `complete`; attention, terminal-time, and other required evidence may still
+  be partial.
+
+For example, a snapshot of 29 workspaces with 24 known statuses and five
+unknown statuses may publish all ten confirmed counters as zero. The UI shows
+`0 confirmed` for null exact counters and reports
+`24 of 29 workflow statuses known; 5 unknown`. If the next same-scope snapshot
+adds one authoritative running workflow, the evidence is total 30, known 25,
+unknown five, with `active=1` and `executing=1` in `confirmed_counts`; those
+null exact counters render as `1 confirmed`.
+
+Omission and explicit null are accepted for reader compatibility. Core's local
+exact-summary producer omits the field when unused, so its existing serialized
+payload shape does not gain a null key. Shared readers that predate this
+extension continue to receive the old shape; compatible shared readers must be
+deployed before a hosted producer begins emitting evidence.
 
 A stopped **native** execution is **not** a completed overall workflow. Native
 runtime finish and workflow finish remain distinct presentation concepts.
@@ -203,9 +257,13 @@ feeds.
 ### Dashboard summary (required)
 `schema_version`, `scope`, `generated_at`, `as_of`, `last_success_at`, `window`, `coverage`, `counts`, `overlap`
 
+Optional: `count_evidence` (object or `null`, as defined above).
+
 `last_success_at` must be present. The value is an RFC 3339 timestamp or `null`
 when no fully successful summary exists yet. `coverage.status=complete` requires
 a timestamp.
 
 ### Counts
-Each count key is required on the object; values may be `number | null`.
+Each count key is required on the object; values are strict nonnegative
+`integer | null`. The ten exact fields and their meanings are unchanged by the
+optional evidence extension.

--- a/openapi.json
+++ b/openapi.json
@@ -11227,6 +11227,16 @@
             ],
             "title": "Last Log At"
           },
+          "latest_state_change": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkspaceEventResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "lifecycle": {
             "items": {
               "$ref": "#/components/schemas/WorkspaceLifecycleStageResponse"

--- a/openapi.json
+++ b/openapi.json
@@ -9496,6 +9496,17 @@
       "WorkspaceEventResponse": {
         "description": "Representation of an immutable workspace event.",
         "properties": {
+          "event_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Order"
+          },
           "event_type": {
             "title": "Event Type",
             "type": "string"
@@ -11964,6 +11975,17 @@
             "format": "date-time",
             "title": "Started At",
             "type": "string"
+          },
+          "started_event_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started Event Order"
           },
           "summary": {
             "title": "Summary",

--- a/openapi.json
+++ b/openapi.json
@@ -1686,6 +1686,108 @@
         "title": "ConsoleCapabilityItemResponse",
         "type": "object"
       },
+      "ConsoleDashboardConfirmedCountsResponse": {
+        "additionalProperties": false,
+        "description": "Strict confirmed lower bounds using the exact v1 count-key inventory.",
+        "properties": {
+          "active": {
+            "minimum": 0.0,
+            "title": "Active",
+            "type": "integer"
+          },
+          "awaiting_human": {
+            "minimum": 0.0,
+            "title": "Awaiting Human",
+            "type": "integer"
+          },
+          "awaiting_operator": {
+            "minimum": 0.0,
+            "title": "Awaiting Operator",
+            "type": "integer"
+          },
+          "cancelled_last_window": {
+            "minimum": 0.0,
+            "title": "Cancelled Last Window",
+            "type": "integer"
+          },
+          "completed_last_window": {
+            "minimum": 0.0,
+            "title": "Completed Last Window",
+            "type": "integer"
+          },
+          "executing": {
+            "minimum": 0.0,
+            "title": "Executing",
+            "type": "integer"
+          },
+          "failed_last_window": {
+            "minimum": 0.0,
+            "title": "Failed Last Window",
+            "type": "integer"
+          },
+          "monitoring_pr": {
+            "minimum": 0.0,
+            "title": "Monitoring Pr",
+            "type": "integer"
+          },
+          "queued": {
+            "minimum": 0.0,
+            "title": "Queued",
+            "type": "integer"
+          },
+          "retrying": {
+            "minimum": 0.0,
+            "title": "Retrying",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "active",
+          "executing",
+          "monitoring_pr",
+          "awaiting_operator",
+          "awaiting_human",
+          "retrying",
+          "queued",
+          "completed_last_window",
+          "cancelled_last_window",
+          "failed_last_window"
+        ],
+        "title": "ConsoleDashboardConfirmedCountsResponse",
+        "type": "object"
+      },
+      "ConsoleDashboardCountEvidenceResponse": {
+        "additionalProperties": false,
+        "description": "Population coverage and confirmed lower bounds from the summary snapshot.\n\nKnown plus unknown equals total; every confirmed counter is at most the\nknown population and follows the v1 count relationships. At the summary\nlevel, every non-null exact counter equals its confirmed counterpart.",
+        "properties": {
+          "confirmed_counts": {
+            "$ref": "#/components/schemas/ConsoleDashboardConfirmedCountsResponse"
+          },
+          "status_known_workspaces": {
+            "minimum": 0.0,
+            "title": "Status Known Workspaces",
+            "type": "integer"
+          },
+          "status_unknown_workspaces": {
+            "minimum": 0.0,
+            "title": "Status Unknown Workspaces",
+            "type": "integer"
+          },
+          "total_workspaces": {
+            "minimum": 0.0,
+            "title": "Total Workspaces",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_workspaces",
+          "status_known_workspaces",
+          "status_unknown_workspaces",
+          "confirmed_counts"
+        ],
+        "title": "ConsoleDashboardCountEvidenceResponse",
+        "type": "object"
+      },
       "ConsoleDashboardCountsResponse": {
         "additionalProperties": false,
         "description": "Nullable nonnegative fleet counts as strict ints (no string/bool coerce).",
@@ -1887,6 +1989,17 @@
             "format": "date-time",
             "title": "As Of",
             "type": "string"
+          },
+          "count_evidence": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConsoleDashboardCountEvidenceResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional same-snapshot population evidence and confirmed lower bounds; semantic sibling-field invariants are enforced by producers and readers."
           },
           "counts": {
             "$ref": "#/components/schemas/ConsoleDashboardCountsResponse"

--- a/openapi.json
+++ b/openapi.json
@@ -11237,6 +11237,16 @@
               }
             ]
           },
+          "latest_workflow_terminal_state_change": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkspaceEventResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "lifecycle": {
             "items": {
               "$ref": "#/components/schemas/WorkspaceLifecycleStageResponse"

--- a/openapi.json
+++ b/openapi.json
@@ -11238,6 +11238,16 @@
             ],
             "title": "Last Log At"
           },
+          "latest_destroying_state_change": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkspaceEventResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "latest_state_change": {
             "anyOf": [
               {

--- a/openapi.json
+++ b/openapi.json
@@ -1758,7 +1758,7 @@
       },
       "ConsoleDashboardCountEvidenceResponse": {
         "additionalProperties": false,
-        "description": "Population coverage and confirmed lower bounds from the summary snapshot.\n\nKnown plus unknown equals total; every confirmed counter is at most the\nknown population and follows the v1 count relationships. At the summary\nlevel, every non-null exact counter equals its confirmed counterpart.",
+        "description": "Population coverage and confirmed lower bounds from the summary snapshot.\n\nKnown plus unknown equals total; every confirmed counter is at most the\nknown population and follows the v1 count relationships. At the summary\nlevel, every non-null exact counter equals its confirmed counterpart, and\nexact counters require every workspace workflow status to be known.",
         "properties": {
           "confirmed_counts": {
             "$ref": "#/components/schemas/ConsoleDashboardConfirmedCountsResponse"

--- a/openapi.json
+++ b/openapi.json
@@ -10200,6 +10200,17 @@
             ],
             "title": "Ended At"
           },
+          "ended_event_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ended Event Order"
+          },
           "stage": {
             "title": "Stage",
             "type": "string"

--- a/src/awf/api/routes/console.py
+++ b/src/awf/api/routes/console.py
@@ -623,7 +623,8 @@ class ConsoleDashboardCountEvidenceResponse(BaseModel):
 
     Known plus unknown equals total; every confirmed counter is at most the
     known population and follows the v1 count relationships. At the summary
-    level, every non-null exact counter equals its confirmed counterpart.
+    level, every non-null exact counter equals its confirmed counterpart, and
+    exact counters require every workspace workflow status to be known.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -746,6 +747,12 @@ class ConsoleDashboardSummaryResponse(BaseModel):
             if self.coverage.status == "complete" and evidence.status_unknown_workspaces != 0:
                 raise ValueError(
                     "coverage.status complete requires status_unknown_workspaces to be zero"
+                )
+            if evidence.status_unknown_workspaces > 0 and any(
+                exact[key] is not None for key in _DASHBOARD_COUNT_FIELDS
+            ):
+                raise ValueError(
+                    "status_unknown_workspaces must be zero when any exact count is non-null"
                 )
         return self
 

--- a/src/awf/api/routes/console.py
+++ b/src/awf/api/routes/console.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Annotated, Any, Literal, Self
 
@@ -535,6 +536,127 @@ class ConsoleDashboardCountsResponse(BaseModel):
     failed_last_window: StrictInt | None = Field(ge=0)
 
 
+_DASHBOARD_COUNT_FIELDS = (
+    "active",
+    "executing",
+    "monitoring_pr",
+    "awaiting_operator",
+    "awaiting_human",
+    "retrying",
+    "queued",
+    "completed_last_window",
+    "cancelled_last_window",
+    "failed_last_window",
+)
+
+
+def _validate_dashboard_count_relationships(
+    counts: Mapping[str, int | None],
+    *,
+    label: str,
+) -> None:
+    """Enforce the shared v1 subset/disjoint rules for exacts or lower bounds."""
+    active = counts["active"]
+    executing = counts["executing"]
+    monitoring_pr = counts["monitoring_pr"]
+    awaiting_operator = counts["awaiting_operator"]
+    awaiting_human = counts["awaiting_human"]
+    retrying = counts["retrying"]
+    queued = counts["queued"]
+
+    for subset_name, subset in (
+        ("executing", executing),
+        ("monitoring_pr", monitoring_pr),
+        ("queued", queued),
+        ("awaiting_operator", awaiting_operator),
+        ("retrying", retrying),
+    ):
+        if active is not None and subset is not None and subset > active:
+            raise ValueError(f"{label}.{subset_name} must be <= {label}.active")
+    if awaiting_human is not None and monitoring_pr is not None and awaiting_human > monitoring_pr:
+        raise ValueError(f"{label}.awaiting_human must be <= {label}.monitoring_pr")
+    for disjoint_name, disjoint_count in (
+        ("awaiting_operator", awaiting_operator),
+        ("retrying", retrying),
+    ):
+        if (
+            active is not None
+            and executing is not None
+            and disjoint_count is not None
+            and disjoint_count + executing > active
+        ):
+            raise ValueError(
+                f"{label}.{disjoint_name} + {label}.executing must be <= {label}.active"
+            )
+
+    # Current active status buckets are mutually disjoint. With nullable exact
+    # counters, validate the relationship among the available parts only.
+    if active is not None:
+        disjoint_parts = [
+            value
+            for value in (executing, monitoring_pr, queued, awaiting_operator, retrying)
+            if value is not None
+        ]
+        if len(disjoint_parts) >= 2 and sum(disjoint_parts) > active:
+            raise ValueError(f"sum of disjoint {label} active status buckets must be <= active")
+
+
+class ConsoleDashboardConfirmedCountsResponse(BaseModel):
+    """Strict confirmed lower bounds using the exact v1 count-key inventory."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    active: StrictInt = Field(ge=0)
+    executing: StrictInt = Field(ge=0)
+    monitoring_pr: StrictInt = Field(ge=0)
+    awaiting_operator: StrictInt = Field(ge=0)
+    awaiting_human: StrictInt = Field(ge=0)
+    retrying: StrictInt = Field(ge=0)
+    queued: StrictInt = Field(ge=0)
+    completed_last_window: StrictInt = Field(ge=0)
+    cancelled_last_window: StrictInt = Field(ge=0)
+    failed_last_window: StrictInt = Field(ge=0)
+
+
+class ConsoleDashboardCountEvidenceResponse(BaseModel):
+    """Population coverage and confirmed lower bounds from the summary snapshot.
+
+    Known plus unknown equals total; every confirmed counter is at most the
+    known population and follows the v1 count relationships. At the summary
+    level, every non-null exact counter equals its confirmed counterpart.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_workspaces: StrictInt = Field(ge=0)
+    status_known_workspaces: StrictInt = Field(ge=0)
+    status_unknown_workspaces: StrictInt = Field(ge=0)
+    confirmed_counts: ConsoleDashboardConfirmedCountsResponse
+
+    @model_validator(mode="after")
+    def population_and_confirmed_counts_are_consistent(self) -> Self:
+        if self.status_known_workspaces + self.status_unknown_workspaces != self.total_workspaces:
+            raise ValueError(
+                "status_known_workspaces + status_unknown_workspaces must equal total_workspaces"
+            )
+        confirmed = self.confirmed_counts.model_dump()
+        if any(value > self.status_known_workspaces for value in confirmed.values()):
+            raise ValueError("every confirmed count must be <= status_known_workspaces")
+        confirmed_status_categories = (
+            confirmed["active"]
+            + confirmed["completed_last_window"]
+            + confirmed["cancelled_last_window"]
+            + confirmed["failed_last_window"]
+        )
+        if confirmed_status_categories > self.status_known_workspaces:
+            raise ValueError(
+                "sum of confirmed active and terminal status categories must be "
+                "<= status_known_workspaces"
+            )
+        _validate_dashboard_count_relationships(confirmed, label="confirmed_counts")
+        return self
+
+
 class ConsoleDashboardOverlapResponse(BaseModel):
     """Fixed v1 count-semantics invariants (literal true; no provider toggles).
 
@@ -561,6 +683,14 @@ class ConsoleDashboardSummaryResponse(BaseModel):
     window: ConsoleDashboardWindowResponse
     coverage: ConsoleDashboardCoverageResponse
     counts: ConsoleDashboardCountsResponse
+    count_evidence: ConsoleDashboardCountEvidenceResponse | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Optional same-snapshot population evidence and confirmed lower bounds; "
+            "semantic sibling-field invariants are enforced by producers and readers."
+        ),
+    )
     overlap: ConsoleDashboardOverlapResponse
 
     @model_validator(mode="after")
@@ -599,84 +729,24 @@ class ConsoleDashboardSummaryResponse(BaseModel):
         payloads fail closed rather than rendering impossible KPI relationships.
         """
         counts = self.counts
-        count_values = (
-            counts.active,
-            counts.executing,
-            counts.monitoring_pr,
-            counts.awaiting_operator,
-            counts.awaiting_human,
-            counts.retrying,
-            counts.queued,
-            counts.completed_last_window,
-            counts.cancelled_last_window,
-            counts.failed_last_window,
-        )
+        exact = counts.model_dump()
         # Contract: null counters require coverage.status partial|unknown.
-        if self.coverage.status == "complete" and any(value is None for value in count_values):
+        if self.coverage.status == "complete" and any(
+            exact[key] is None for key in _DASHBOARD_COUNT_FIELDS
+        ):
             raise ValueError("coverage.status complete requires all counts to be non-null")
-        if (
-            counts.active is not None
-            and counts.executing is not None
-            and counts.executing > counts.active
-        ):
-            raise ValueError("counts.executing must be <= counts.active")
-        if (
-            counts.active is not None
-            and counts.monitoring_pr is not None
-            and counts.monitoring_pr > counts.active
-        ):
-            raise ValueError("counts.monitoring_pr must be <= counts.active")
-        if (
-            counts.active is not None
-            and counts.queued is not None
-            and counts.queued > counts.active
-        ):
-            raise ValueError("counts.queued must be <= counts.active")
-        # Overlap flags are Literal[True] fixed v1 invariants; always enforce when
-        # related counts are present (null counts + partial/unknown coverage instead).
-        if (
-            counts.awaiting_human is not None
-            and counts.monitoring_pr is not None
-            and counts.awaiting_human > counts.monitoring_pr
-        ):
-            raise ValueError("counts.awaiting_human must be <= counts.monitoring_pr")
-        if counts.awaiting_operator is not None:
-            if counts.active is not None and counts.awaiting_operator > counts.active:
-                raise ValueError("counts.awaiting_operator must be <= counts.active")
-            if (
-                counts.active is not None
-                and counts.executing is not None
-                and counts.awaiting_operator + counts.executing > counts.active
-            ):
+        _validate_dashboard_count_relationships(exact, label="counts")
+        if self.count_evidence is not None:
+            evidence = self.count_evidence
+            confirmed = evidence.confirmed_counts.model_dump()
+            for key in _DASHBOARD_COUNT_FIELDS:
+                exact_value = exact[key]
+                if exact_value is not None and exact_value != confirmed[key]:
+                    raise ValueError(f"exact count counts.{key} must equal confirmed_counts.{key}")
+            if self.coverage.status == "complete" and evidence.status_unknown_workspaces != 0:
                 raise ValueError(
-                    "counts.awaiting_operator + counts.executing must be <= counts.active"
+                    "coverage.status complete requires status_unknown_workspaces to be zero"
                 )
-        if counts.retrying is not None:
-            if counts.active is not None and counts.retrying > counts.active:
-                raise ValueError("counts.retrying must be <= counts.active")
-            if (
-                counts.active is not None
-                and counts.executing is not None
-                and counts.retrying + counts.executing > counts.active
-            ):
-                raise ValueError("counts.retrying + counts.executing must be <= counts.active")
-        # Combined disjoint active status buckets: pairwise checks miss cases
-        # like active=3 with executing=monitoring_pr=awaiting_operator=retrying=1.
-        # queued (requested) is always a distinct non-terminal status ⊆ active.
-        if counts.active is not None:
-            disjoint_parts: list[int] = []
-            if counts.executing is not None:
-                disjoint_parts.append(counts.executing)
-            if counts.monitoring_pr is not None:
-                disjoint_parts.append(counts.monitoring_pr)
-            if counts.queued is not None:
-                disjoint_parts.append(counts.queued)
-            if counts.awaiting_operator is not None:
-                disjoint_parts.append(counts.awaiting_operator)
-            if counts.retrying is not None:
-                disjoint_parts.append(counts.retrying)
-            if len(disjoint_parts) >= 2 and sum(disjoint_parts) > counts.active:
-                raise ValueError("sum of disjoint active status buckets must be <= counts.active")
         return self
 
 

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -1160,6 +1160,8 @@ class WorkspaceOverviewResponse(CursorAutoModeResponseMixin):
     last_event: WorkspaceEventResponse | None
     # Latest state transition, even when a newer cleanup/audit event is last.
     latest_state_change: WorkspaceEventResponse | None = None
+    # Latest transition into destroying, retained after cleanup reaches destroyed.
+    latest_destroying_state_change: WorkspaceEventResponse | None = None
     # Latest transition into a workflow-terminal state, retained across the
     # later destroying/destroyed cleanup sequence.
     latest_workflow_terminal_state_change: WorkspaceEventResponse | None = None

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -1158,6 +1158,9 @@ class WorkspaceOverviewResponse(CursorAutoModeResponseMixin):
     last_event: WorkspaceEventResponse | None
     # Latest state transition, even when a newer cleanup/audit event is last.
     latest_state_change: WorkspaceEventResponse | None = None
+    # Latest transition into a workflow-terminal state, retained across the
+    # later destroying/destroyed cleanup sequence.
+    latest_workflow_terminal_state_change: WorkspaceEventResponse | None = None
     pr_url: str | None
     pr_number: int | None = None
     failure_reason: str | None

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -567,6 +567,7 @@ class WorkspaceRecoverySummaryResponse(BaseModel):
     action: str | None = None
     recovery_mode: str | None = None
     started_at: datetime
+    started_event_order: int | None = None
     current_operation: WorkspaceRecoveryCurrentOperationResponse | None = None
     summary: str
     payload: dict[str, Any] | None = None
@@ -1027,6 +1028,7 @@ class WorkspaceEventResponse(BaseModel):
     new_state: str | None
     reason_code: str | None
     payload: dict[str, Any] | None
+    event_order: int | None = None
     occurred_at: datetime
 
 

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -519,6 +519,7 @@ class WorkspaceLifecycleStageResponse(BaseModel):
     stage: str
     started_at: datetime | None = None
     ended_at: datetime | None = None
+    ended_event_order: int | None = None
     duration_seconds: int | None = None
     status: WorkspaceLifecycleStageStatus
 

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -1156,6 +1156,8 @@ class WorkspaceOverviewResponse(CursorAutoModeResponseMixin):
     current_phase: str
     active_operation: str | None
     last_event: WorkspaceEventResponse | None
+    # Latest state transition, even when a newer cleanup/audit event is last.
+    latest_state_change: WorkspaceEventResponse | None = None
     pr_url: str | None
     pr_number: int | None = None
     failure_reason: str | None

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -387,6 +387,14 @@ def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
         ordered_events=ordered_events,
     )
     latest_event = ordered_events[-1] if ordered_events else None
+    latest_state_change = next(
+        (
+            event
+            for event in reversed(ordered_events)
+            if event.event_type == "workspace.state_changed"
+        ),
+        None,
+    )
     active_operation = next(
         (
             op
@@ -435,6 +443,11 @@ def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
         last_event=(
             WorkspaceEventResponse.model_validate(latest_event)
             if latest_event is not None
+            else None
+        ),
+        latest_state_change=(
+            WorkspaceEventResponse.model_validate(latest_state_change)
+            if latest_state_change is not None
             else None
         ),
         pr_url=ws.pr_url,

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -1444,9 +1444,18 @@ def _created_at(workspace: Workspace) -> datetime:
     return _ensure_utc(workspace.created_at)
 
 
-def _event_sort_key(event: WorkspaceEvent) -> tuple[datetime, str]:
+def _event_sort_key(event: WorkspaceEvent) -> tuple[datetime, int, int, str]:
     event_id = getattr(event, "id", "")
-    return _ensure_utc(event.occurred_at), event_id if isinstance(event_id, str) else ""
+    raw_event_order = getattr(event, "event_order", None)
+    event_order = raw_event_order if isinstance(raw_event_order, int) else None
+    # Null-first ascending order makes reverse scans match the authoritative
+    # SQL ordering: event_order DESC NULLS LAST, then ID as a final fallback.
+    return (
+        _ensure_utc(event.occurred_at),
+        int(event_order is not None),
+        event_order if event_order is not None else 0,
+        event_id if isinstance(event_id, str) else "",
+    )
 
 
 def _latest_started_stage(

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -96,6 +96,13 @@ _TERMINAL_SKIP_STATUSES = frozenset(
         WorkspaceStatus.cancelled,
     }
 )
+_WORKFLOW_TERMINAL_STATUSES = frozenset(
+    {
+        WorkspaceStatus.completed,
+        WorkspaceStatus.failed,
+        WorkspaceStatus.cancelled,
+    }
+)
 _RECOVERY_EVENT_TYPES = frozenset(
     {
         "monitor.recovery_dispatched",
@@ -395,6 +402,16 @@ def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
         ),
         None,
     )
+    latest_workflow_terminal_state_change = next(
+        (
+            event
+            for event in reversed(ordered_events)
+            if event.event_type == "workspace.state_changed"
+            and _coerce_workspace_status(event.new_state) in _WORKFLOW_TERMINAL_STATUSES
+            and _coerce_workspace_status(event.old_state) != WorkspaceStatus.destroying
+        ),
+        None,
+    )
     active_operation = next(
         (
             op
@@ -448,6 +465,11 @@ def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
         latest_state_change=(
             WorkspaceEventResponse.model_validate(latest_state_change)
             if latest_state_change is not None
+            else None
+        ),
+        latest_workflow_terminal_state_change=(
+            WorkspaceEventResponse.model_validate(latest_workflow_terminal_state_change)
+            if latest_workflow_terminal_state_change is not None
             else None
         ),
         pr_url=ws.pr_url,

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -31,6 +31,7 @@ from awf.db.enums import AgentRuntime, OperationStatus, WorkspaceStatus, parse_a
 from awf.db.models import Workspace, WorkspaceEvent
 from awf.db.repositories import StaleReasonRepository, WorkspaceRepository
 from awf.profiles.pricing import PRICING_MAX_AGE_DAYS, PricingMetadata
+from awf.service import workspace_overview_pagination as _overview_pagination
 from awf.service.bounded_list import (
     bounded_list_limit,
     decode_bounded_list_cursor,
@@ -65,24 +66,16 @@ from awf.service.workspace_observability_types import (
     LifecycleStageStatus as LifecycleStageStatus,
 )
 from awf.service.workspace_observability_types import LlmUsageStatus as LlmUsageStatus
-from awf.service.workspace_overview_pagination import (
-    InvalidWorkspaceOverviewCursorError as InvalidWorkspaceOverviewCursorError,
-)
-from awf.service.workspace_overview_pagination import (
-    _decode_overview_cursor as _decode_overview_cursor,
-)
-from awf.service.workspace_overview_pagination import (
-    _encode_overview_cursor as _encode_overview_cursor,
-)
-from awf.service.workspace_overview_pagination import (
-    _WorkspaceOverviewCursor as _WorkspaceOverviewCursor,
-)
+
+InvalidWorkspaceOverviewCursorError = _overview_pagination.InvalidWorkspaceOverviewCursorError
+_WorkspaceOverviewCursor = _overview_pagination._WorkspaceOverviewCursor
+_decode_overview_cursor = _overview_pagination._decode_overview_cursor
+_encode_overview_cursor = _overview_pagination._encode_overview_cursor
 
 _log = get_logger(__name__)
 
 DEFAULT_STALE_REASON_LIMIT = 50
 MAX_STALE_REASON_LIMIT = 500
-
 STALE_RUNNING_THRESHOLD_SECONDS = 600
 
 
@@ -147,9 +140,6 @@ _GENERIC_RECOVERY_REASON_CODES = frozenset(
         "OPERATOR_VALIDATE_REQUESTED",
     }
 )
-_MAX_RECOVERY_PAYLOAD_KEYS = 32
-_MAX_RECOVERY_PAYLOAD_DEPTH = 4
-_MAX_RECOVERY_PAYLOAD_SEQUENCE_ITEMS = 20
 
 
 async def list_workspace_overview_response(
@@ -268,13 +258,13 @@ def workspace_attention_fields(ws: Workspace) -> dict[str, Any]:
     }
 
 
+def _event_response(event: WorkspaceEvent | None) -> WorkspaceEventResponse | None:
+    return WorkspaceEventResponse.model_validate(event) if event is not None else None
+
+
 def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
     ordered_events = workspace_events_by_occurrence(ws)
-    observability = workspace_observability_payload(
-        ws,
-        ordered_events=ordered_events,
-    )
-    latest_event = ordered_events[-1] if ordered_events else None
+    observability = workspace_observability_payload(ws, ordered_events=ordered_events)
     latest_state_change = next(
         (
             event
@@ -314,14 +304,11 @@ def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
         ),
         None,
     )
-    last_activity_at = getattr(ws, "last_activity_at", None)
-    is_stale_running = is_workspace_stale_running(ws)
-
     return WorkspaceOverviewResponse(
         subphase=getattr(ws, "subphase", None),
-        last_activity_at=last_activity_at,
+        last_activity_at=getattr(ws, "last_activity_at", None),
         last_log_at=getattr(ws, "last_log_at", None),
-        is_stale_running=is_stale_running,
+        is_stale_running=is_workspace_stale_running(ws),
         workspace_id=ws.id,
         task_id=ws.task_external_id or ws.id,
         task_key=ws.task_tag,
@@ -351,33 +338,17 @@ def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
         status=WorkspaceStatus(ws.status),
         current_phase=ws.status,
         active_operation=active_operation.type if active_operation is not None else None,
-        last_event=(
-            WorkspaceEventResponse.model_validate(latest_event)
-            if latest_event is not None
-            else None
-        ),
-        latest_state_change=(
-            WorkspaceEventResponse.model_validate(latest_state_change)
-            if latest_state_change is not None
-            else None
-        ),
-        latest_destroying_state_change=(
-            WorkspaceEventResponse.model_validate(latest_destroying_state_change)
-            if latest_destroying_state_change is not None
-            else None
-        ),
-        latest_workflow_terminal_state_change=(
-            WorkspaceEventResponse.model_validate(latest_workflow_terminal_state_change)
-            if latest_workflow_terminal_state_change is not None
-            else None
+        last_event=_event_response(ordered_events[-1] if ordered_events else None),
+        latest_state_change=_event_response(latest_state_change),
+        latest_destroying_state_change=_event_response(latest_destroying_state_change),
+        latest_workflow_terminal_state_change=_event_response(
+            latest_workflow_terminal_state_change
         ),
         pr_url=ws.pr_url,
         pr_number=ws.pr_number,
         failure_reason=ws.failure_reason,
         failure_message=ws.failure_message,
-        # Only surface the authoritative pause start while actually blocked: the
-        # ``blocked_at`` column is not cleared on resume, so gating on live status
-        # keeps a resumed workspace from reporting a stale block time.
+        # ``blocked_at`` is not cleared on resume; surface it only while blocked.
         blocked_at=(
             getattr(ws, "blocked_at", None)
             if str(ws.status) == WorkspaceStatus.blocked.value
@@ -1230,13 +1201,7 @@ def _payload_string(payload: Mapping[str, object] | None, key: str) -> str | Non
 def _bounded_payload(payload: Mapping[str, object] | None) -> dict[str, Any] | None:
     if payload is None:
         return None
-    bounded: dict[str, Any] = {}
-    for index, (key, value) in enumerate(payload.items()):
-        if index >= _MAX_RECOVERY_PAYLOAD_KEYS:
-            bounded["__truncated__"] = True
-            break
-        bounded[str(key)] = _json_safe_value(value)
-    return bounded
+    return cast(dict[str, Any], _json_safe_value(payload, depth=-1))
 
 
 def _json_safe_value(value: object, *, depth: int = 0) -> Any:
@@ -1244,24 +1209,19 @@ def _json_safe_value(value: object, *, depth: int = 0) -> Any:
         return value
     if isinstance(value, datetime):
         return _ensure_utc(value).isoformat()
-    if depth >= _MAX_RECOVERY_PAYLOAD_DEPTH:
+    if depth >= 4:
         return str(value)
     if isinstance(value, Mapping):
         safe: dict[str, Any] = {}
         for index, (key, nested_value) in enumerate(value.items()):
-            if index >= _MAX_RECOVERY_PAYLOAD_KEYS:
+            if index >= 32:
                 safe["__truncated__"] = True
                 break
             safe[str(key)] = _json_safe_value(nested_value, depth=depth + 1)
         return safe
     if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
-        items = [
-            _json_safe_value(item, depth=depth + 1)
-            for item in list(value)[:_MAX_RECOVERY_PAYLOAD_SEQUENCE_ITEMS]
-        ]
-        if len(value) > _MAX_RECOVERY_PAYLOAD_SEQUENCE_ITEMS:
-            items.append("__truncated__")
-        return items
+        items = [_json_safe_value(item, depth=depth + 1) for item in list(value)[:20]]
+        return items + ["__truncated__"] if len(value) > 20 else items
     return str(value)
 
 
@@ -1416,6 +1376,4 @@ def _duration_seconds(started_at: datetime, ended_at: datetime) -> int:
 
 
 def _ensure_utc(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value.astimezone(UTC)
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -3,9 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
-import binascii
-import json
 import re
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
@@ -51,6 +48,18 @@ from awf.service.usage_store import (
     UsageSnapshot,
     read_latest_usage_snapshot,
     read_latest_usage_snapshots,
+)
+from awf.service.workspace_overview_pagination import (
+    InvalidWorkspaceOverviewCursorError as InvalidWorkspaceOverviewCursorError,
+)
+from awf.service.workspace_overview_pagination import (
+    _decode_overview_cursor as _decode_overview_cursor,
+)
+from awf.service.workspace_overview_pagination import (
+    _encode_overview_cursor as _encode_overview_cursor,
+)
+from awf.service.workspace_overview_pagination import (
+    _WorkspaceOverviewCursor as _WorkspaceOverviewCursor,
 )
 
 AgentIdentitySource = Literal["task_policy", "default", "unavailable"]
@@ -128,16 +137,6 @@ _GENERIC_RECOVERY_REASON_CODES = frozenset(
 _MAX_RECOVERY_PAYLOAD_KEYS = 32
 _MAX_RECOVERY_PAYLOAD_DEPTH = 4
 _MAX_RECOVERY_PAYLOAD_SEQUENCE_ITEMS = 20
-
-
-@dataclass(frozen=True)
-class _WorkspaceOverviewCursor:
-    created_at: datetime
-    workspace_id: str
-
-
-class InvalidWorkspaceOverviewCursorError(ValueError):
-    """Raised when a workspace overview pagination cursor cannot be decoded."""
 
 
 @dataclass(frozen=True)
@@ -513,40 +512,6 @@ def _provider_readiness_preflight_from_task_policy(
         return None
     value = task_policy.get("provider_readiness_preflight")
     return dict(value) if isinstance(value, Mapping) else None
-
-
-def _encode_overview_cursor(workspace: Workspace) -> str:
-    payload = {
-        "t": workspace.created_at.isoformat(),
-        "id": workspace.id,
-    }
-    encoded = base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
-    return encoded.decode("ascii").rstrip("=")
-
-
-def _decode_overview_cursor(cursor: str | None) -> _WorkspaceOverviewCursor | None:
-    if cursor is None:
-        return None
-    try:
-        padded_cursor = cursor + ("=" * (-len(cursor) % 4))
-        decoded = base64.urlsafe_b64decode(padded_cursor.encode("ascii"))
-        payload = json.loads(decoded.decode("utf-8"))
-        created_at = datetime.fromisoformat(
-            payload["t"] if "t" in payload else payload["created_at"]
-        )
-        workspace_id = payload["id"] if "id" in payload else payload["workspace_id"]
-    except (
-        binascii.Error,
-        KeyError,
-        TypeError,
-        UnicodeDecodeError,
-        ValueError,
-        json.JSONDecodeError,
-    ) as exc:
-        raise InvalidWorkspaceOverviewCursorError("Invalid workspace overview cursor") from exc
-    if not isinstance(workspace_id, str) or workspace_id == "":
-        raise InvalidWorkspaceOverviewCursorError("Invalid workspace overview cursor")
-    return _WorkspaceOverviewCursor(created_at=created_at, workspace_id=workspace_id)
 
 
 def effective_agent_identity(

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -1017,11 +1017,15 @@ def workspace_recovery_summary(
         return None
 
     recovery_event = _latest_recovery_event_after(events, reverse_event)
-    active_operation = _latest_recovery_operation(workspace, active_only=True)
-    relevant_operation = active_operation or _latest_recovery_operation(
-        workspace,
-        active_only=False,
-    )
+    if getattr(reverse_event, "event_type", None) == "workspace.remonitor_requested":
+        active_operation = None
+        relevant_operation = None
+    else:
+        active_operation = _latest_recovery_operation(workspace, active_only=True)
+        relevant_operation = active_operation or _latest_recovery_operation(
+            workspace,
+            active_only=False,
+        )
     operation_payload = _payload_mapping(getattr(relevant_operation, "payload", None))
     event_payload = _payload_mapping(
         getattr(recovery_event, "payload", None) if recovery_event is not None else None

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -191,6 +191,7 @@ class WorkspaceRecoverySummary:
     current_operation: WorkspaceRecoveryCurrentOperation | None
     summary: str
     payload: dict[str, Any] | None
+    started_event_order: int | None = None
     provider_recovery: ProviderRecoveryStateView | None = None
 
 
@@ -239,6 +240,7 @@ class WorkspaceRecoveryPayload(TypedDict):
     action: str | None
     recovery_mode: str | None
     started_at: datetime
+    started_event_order: int | None
     current_operation: WorkspaceRecoveryCurrentOperationPayload | None
     summary: str
     payload: dict[str, Any] | None
@@ -1024,6 +1026,10 @@ def workspace_recovery_summary(
     )
     payload = _bounded_payload(operation_payload or event_payload or reverse_payload)
     provider_recovery_view = provider_recovery_state_for_workspace(workspace)
+    raw_started_event_order = getattr(reverse_event, "event_order", None)
+    started_event_order = (
+        raw_started_event_order if isinstance(raw_started_event_order, int) else None
+    )
 
     return WorkspaceRecoverySummary(
         from_state=getattr(reverse_event, "old_state", None),
@@ -1032,6 +1038,7 @@ def workspace_recovery_summary(
         action=action,
         recovery_mode=recovery_mode,
         started_at=_ensure_utc(reverse_event.occurred_at),
+        started_event_order=started_event_order,
         current_operation=current_operation,
         summary=_recovery_summary_text(
             workspace=workspace,
@@ -1062,6 +1069,7 @@ def recovery_payload(
         "action": summary.action,
         "recovery_mode": summary.recovery_mode,
         "started_at": summary.started_at,
+        "started_event_order": summary.started_event_order,
         "current_operation": (
             {
                 "id": current_operation.id,

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -7,9 +7,8 @@ import re
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Literal, Protocol, TypedDict, cast
+from typing import Any, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,16 +38,33 @@ from awf.service.bounded_list import (
 )
 from awf.service.coordination import coordination_warnings_from_task_policy
 from awf.service.profile_metadata import network_posture_from_profile_snapshot
-from awf.service.provider_recovery import (
-    ProviderRecoveryStateView,
-    provider_recovery_state_for_workspace,
-)
+from awf.service.provider_recovery import provider_recovery_state_for_workspace
 from awf.service.usage_store import (
     USAGE_SOURCE,
     UsageSnapshot,
     read_latest_usage_snapshot,
     read_latest_usage_snapshots,
 )
+from awf.service.workspace_observability_types import (
+    AgentIdentity,
+    AgentIdentityPayload,
+    AgentIdentitySource,
+    LifecycleStagePayload,
+    LifecycleStageSummary,
+    LlmUsagePayload,
+    LlmUsageSummary,
+    WorkspaceIdentityUsagePayload,
+    WorkspaceObservabilityPayload,
+    WorkspaceRecoveryCurrentOperation,
+    WorkspaceRecoveryPayload,
+    WorkspaceRecoverySummary,
+    _LifecycleAccumulator,
+    _RecoveryOperationLike,
+)
+from awf.service.workspace_observability_types import (
+    LifecycleStageStatus as LifecycleStageStatus,
+)
+from awf.service.workspace_observability_types import LlmUsageStatus as LlmUsageStatus
 from awf.service.workspace_overview_pagination import (
     InvalidWorkspaceOverviewCursorError as InvalidWorkspaceOverviewCursorError,
 )
@@ -62,9 +78,6 @@ from awf.service.workspace_overview_pagination import (
     _WorkspaceOverviewCursor as _WorkspaceOverviewCursor,
 )
 
-AgentIdentitySource = Literal["task_policy", "default", "unavailable"]
-LifecycleStageStatus = Literal["pending", "active", "completed", "terminal_skipped"]
-LlmUsageStatus = Literal["available", "unavailable"]
 _log = get_logger(__name__)
 
 DEFAULT_STALE_REASON_LIMIT = 50
@@ -137,139 +150,6 @@ _GENERIC_RECOVERY_REASON_CODES = frozenset(
 _MAX_RECOVERY_PAYLOAD_KEYS = 32
 _MAX_RECOVERY_PAYLOAD_DEPTH = 4
 _MAX_RECOVERY_PAYLOAD_SEQUENCE_ITEMS = 20
-
-
-@dataclass(frozen=True)
-class AgentIdentity:
-    model: str | None
-    effort: str | None
-    model_source: AgentIdentitySource
-    effort_source: AgentIdentitySource
-
-
-@dataclass(frozen=True)
-class LifecycleStageSummary:
-    stage: str
-    started_at: datetime | None
-    ended_at: datetime | None
-    duration_seconds: int | None
-    status: LifecycleStageStatus
-
-
-@dataclass(frozen=True)
-class LlmUsageSummary:
-    input_tokens: int | None
-    output_tokens: int | None
-    total_tokens: int | None
-    cost_estimate: float | None
-    currency: str | None
-    status: LlmUsageStatus
-    source: str
-    reason: str | None
-    cached_input_tokens: int | None = None
-    reasoning_output_tokens: int | None = None
-
-
-@dataclass(frozen=True)
-class WorkspaceRecoveryCurrentOperation:
-    id: str
-    type: str
-    status: str
-    created_at: datetime
-    started_at: datetime | None
-    payload: dict[str, Any] | None
-
-
-@dataclass(frozen=True)
-class WorkspaceRecoverySummary:
-    from_state: str | None
-    to_state: str | None
-    reason_code: str | None
-    action: str | None
-    recovery_mode: str | None
-    started_at: datetime
-    current_operation: WorkspaceRecoveryCurrentOperation | None
-    summary: str
-    payload: dict[str, Any] | None
-    started_event_order: int | None = None
-    provider_recovery: ProviderRecoveryStateView | None = None
-
-
-class AgentIdentityPayload(TypedDict):
-    agent_model: str | None
-    agent_effort: str | None
-    cursor_auto_mode: str | None
-    agent_model_source: AgentIdentitySource
-    agent_effort_source: AgentIdentitySource
-
-
-class LifecycleStagePayload(TypedDict):
-    stage: str
-    started_at: datetime | None
-    ended_at: datetime | None
-    duration_seconds: int | None
-    status: LifecycleStageStatus
-
-
-class LlmUsagePayload(TypedDict):
-    input_tokens: int | None
-    cached_input_tokens: int | None
-    output_tokens: int | None
-    reasoning_output_tokens: int | None
-    total_tokens: int | None
-    cost_estimate: float | None
-    currency: str | None
-    status: LlmUsageStatus
-    source: str
-    reason: str | None
-
-
-class WorkspaceRecoveryCurrentOperationPayload(TypedDict):
-    id: str
-    type: str
-    status: str
-    created_at: datetime
-    started_at: datetime | None
-    payload: dict[str, Any] | None
-
-
-class WorkspaceRecoveryPayload(TypedDict):
-    from_state: str | None
-    to_state: str | None
-    reason_code: str | None
-    action: str | None
-    recovery_mode: str | None
-    started_at: datetime
-    started_event_order: int | None
-    current_operation: WorkspaceRecoveryCurrentOperationPayload | None
-    summary: str
-    payload: dict[str, Any] | None
-    provider_recovery: dict[str, Any] | None
-
-
-class WorkspaceObservabilityPayload(AgentIdentityPayload):
-    lifecycle: list[LifecycleStagePayload]
-    llm_usage: LlmUsagePayload
-    recovery: WorkspaceRecoveryPayload | None
-
-
-class WorkspaceIdentityUsagePayload(AgentIdentityPayload):
-    llm_usage: LlmUsagePayload
-
-
-class _RecoveryOperationLike(Protocol):
-    id: object
-    type: object
-    status: object
-    payload: object
-    created_at: datetime
-    started_at: datetime | None
-
-
-@dataclass
-class _LifecycleAccumulator:
-    started_at: datetime | None = None
-    ended_at: datetime | None = None
 
 
 async def list_workspace_overview_response(

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -1149,7 +1149,19 @@ def _latest_reverse_state_event(
     events: Sequence[WorkspaceEvent],
 ) -> WorkspaceEvent | None:
     for event in reversed(events):
-        if getattr(event, "event_type", None) != "workspace.state_changed":
+        event_type = getattr(event, "event_type", None)
+        # Remonitor persists its failed -> monitoring reset on the request event
+        # instead of emitting a separate workspace.state_changed event.
+        if event_type == "workspace.remonitor_requested":
+            if (
+                _coerce_workspace_status(getattr(event, "old_state", None))
+                == WorkspaceStatus.failed
+                and _coerce_workspace_status(getattr(event, "new_state", None))
+                == WorkspaceStatus.monitoring_pr
+            ):
+                return event
+            continue
+        if event_type != "workspace.state_changed":
             continue
         if _is_reverse_lifecycle_transition(
             getattr(event, "old_state", None),
@@ -1174,6 +1186,8 @@ def _latest_recovery_event_after(
     events: Sequence[WorkspaceEvent],
     reverse_event: WorkspaceEvent,
 ) -> WorkspaceEvent | None:
+    if getattr(reverse_event, "event_type", None) == "workspace.remonitor_requested":
+        return reverse_event
     reverse_at = _ensure_utc(reverse_event.occurred_at)
     candidates = [
         event

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -398,6 +398,10 @@ def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
             event
             for event in reversed(ordered_events)
             if event.event_type == "workspace.state_changed"
+            or (
+                event.event_type == "workspace.remonitor_requested"
+                and event.old_state != event.new_state
+            )
         ),
         None,
     )

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -407,6 +407,15 @@ def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
         ),
         None,
     )
+    latest_destroying_state_change = next(
+        (
+            event
+            for event in reversed(ordered_events)
+            if event.event_type == "workspace.state_changed"
+            and _coerce_workspace_status(event.new_state) == WorkspaceStatus.destroying
+        ),
+        None,
+    )
     latest_workflow_terminal_state_change = next(
         (
             event
@@ -470,6 +479,11 @@ def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
         latest_state_change=(
             WorkspaceEventResponse.model_validate(latest_state_change)
             if latest_state_change is not None
+            else None
+        ),
+        latest_destroying_state_change=(
+            WorkspaceEventResponse.model_validate(latest_destroying_state_change)
+            if latest_destroying_state_change is not None
             else None
         ),
         latest_workflow_terminal_state_change=(

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -480,6 +480,10 @@ def workspace_lifecycle_summary(
                 old_accumulator.started_at = occurred_at
             if old_accumulator.ended_at is None:
                 old_accumulator.ended_at = occurred_at
+                raw_event_order = getattr(event, "event_order", None)
+                old_accumulator.ended_event_order = (
+                    raw_event_order if isinstance(raw_event_order, int) else None
+                )
         if new_status is not None and new_status in accumulators:
             new_accumulator = accumulators[new_status]
             if new_accumulator.started_at is None:
@@ -819,6 +823,7 @@ def lifecycle_payload(
             "stage": item.stage,
             "started_at": item.started_at,
             "ended_at": item.ended_at,
+            "ended_event_order": item.ended_event_order,
             "duration_seconds": item.duration_seconds,
             "status": item.status,
         }
@@ -1335,6 +1340,7 @@ def _stage_summary(
             stage=stage.value,
             started_at=None,
             ended_at=None,
+            ended_event_order=None,
             duration_seconds=None,
             status="terminal_skipped",
         )
@@ -1343,6 +1349,7 @@ def _stage_summary(
             stage=stage.value,
             started_at=None,
             ended_at=None,
+            ended_event_order=None,
             duration_seconds=None,
             status="pending",
         )
@@ -1351,6 +1358,7 @@ def _stage_summary(
             stage=stage.value,
             started_at=accumulator.started_at,
             ended_at=accumulator.ended_at,
+            ended_event_order=accumulator.ended_event_order,
             duration_seconds=_duration_seconds(accumulator.started_at, accumulator.ended_at),
             status="completed",
         )
@@ -1359,6 +1367,7 @@ def _stage_summary(
             stage=stage.value,
             started_at=accumulator.started_at,
             ended_at=None,
+            ended_event_order=None,
             duration_seconds=_duration_seconds(accumulator.started_at, now),
             status="active",
         )
@@ -1366,6 +1375,7 @@ def _stage_summary(
         stage=stage.value,
         started_at=accumulator.started_at,
         ended_at=None,
+        ended_event_order=None,
         duration_seconds=None,
         status="completed",
     )

--- a/src/awf/service/workspace_observability_types.py
+++ b/src/awf/service/workspace_observability_types.py
@@ -1,0 +1,146 @@
+"""Value objects and payload types for workspace observability projections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal, Protocol, TypedDict
+
+from awf.service.provider_recovery import ProviderRecoveryStateView
+
+AgentIdentitySource = Literal["task_policy", "default", "unavailable"]
+LifecycleStageStatus = Literal["pending", "active", "completed", "terminal_skipped"]
+LlmUsageStatus = Literal["available", "unavailable"]
+
+
+@dataclass(frozen=True)
+class AgentIdentity:
+    model: str | None
+    effort: str | None
+    model_source: AgentIdentitySource
+    effort_source: AgentIdentitySource
+
+
+@dataclass(frozen=True)
+class LifecycleStageSummary:
+    stage: str
+    started_at: datetime | None
+    ended_at: datetime | None
+    duration_seconds: int | None
+    status: LifecycleStageStatus
+
+
+@dataclass(frozen=True)
+class LlmUsageSummary:
+    input_tokens: int | None
+    output_tokens: int | None
+    total_tokens: int | None
+    cost_estimate: float | None
+    currency: str | None
+    status: LlmUsageStatus
+    source: str
+    reason: str | None
+    cached_input_tokens: int | None = None
+    reasoning_output_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class WorkspaceRecoveryCurrentOperation:
+    id: str
+    type: str
+    status: str
+    created_at: datetime
+    started_at: datetime | None
+    payload: dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class WorkspaceRecoverySummary:
+    from_state: str | None
+    to_state: str | None
+    reason_code: str | None
+    action: str | None
+    recovery_mode: str | None
+    started_at: datetime
+    current_operation: WorkspaceRecoveryCurrentOperation | None
+    summary: str
+    payload: dict[str, Any] | None
+    started_event_order: int | None = None
+    provider_recovery: ProviderRecoveryStateView | None = None
+
+
+class AgentIdentityPayload(TypedDict):
+    agent_model: str | None
+    agent_effort: str | None
+    cursor_auto_mode: str | None
+    agent_model_source: AgentIdentitySource
+    agent_effort_source: AgentIdentitySource
+
+
+class LifecycleStagePayload(TypedDict):
+    stage: str
+    started_at: datetime | None
+    ended_at: datetime | None
+    duration_seconds: int | None
+    status: LifecycleStageStatus
+
+
+class LlmUsagePayload(TypedDict):
+    input_tokens: int | None
+    cached_input_tokens: int | None
+    output_tokens: int | None
+    reasoning_output_tokens: int | None
+    total_tokens: int | None
+    cost_estimate: float | None
+    currency: str | None
+    status: LlmUsageStatus
+    source: str
+    reason: str | None
+
+
+class WorkspaceRecoveryCurrentOperationPayload(TypedDict):
+    id: str
+    type: str
+    status: str
+    created_at: datetime
+    started_at: datetime | None
+    payload: dict[str, Any] | None
+
+
+class WorkspaceRecoveryPayload(TypedDict):
+    from_state: str | None
+    to_state: str | None
+    reason_code: str | None
+    action: str | None
+    recovery_mode: str | None
+    started_at: datetime
+    started_event_order: int | None
+    current_operation: WorkspaceRecoveryCurrentOperationPayload | None
+    summary: str
+    payload: dict[str, Any] | None
+    provider_recovery: dict[str, Any] | None
+
+
+class WorkspaceObservabilityPayload(AgentIdentityPayload):
+    lifecycle: list[LifecycleStagePayload]
+    llm_usage: LlmUsagePayload
+    recovery: WorkspaceRecoveryPayload | None
+
+
+class WorkspaceIdentityUsagePayload(AgentIdentityPayload):
+    llm_usage: LlmUsagePayload
+
+
+class _RecoveryOperationLike(Protocol):
+    id: object
+    type: object
+    status: object
+    payload: object
+    created_at: datetime
+    started_at: datetime | None
+
+
+@dataclass
+class _LifecycleAccumulator:
+    started_at: datetime | None = None
+    ended_at: datetime | None = None

--- a/src/awf/service/workspace_observability_types.py
+++ b/src/awf/service/workspace_observability_types.py
@@ -26,6 +26,7 @@ class LifecycleStageSummary:
     stage: str
     started_at: datetime | None
     ended_at: datetime | None
+    ended_event_order: int | None
     duration_seconds: int | None
     status: LifecycleStageStatus
 
@@ -81,6 +82,7 @@ class LifecycleStagePayload(TypedDict):
     stage: str
     started_at: datetime | None
     ended_at: datetime | None
+    ended_event_order: int | None
     duration_seconds: int | None
     status: LifecycleStageStatus
 
@@ -144,3 +146,4 @@ class _RecoveryOperationLike(Protocol):
 class _LifecycleAccumulator:
     started_at: datetime | None = None
     ended_at: datetime | None = None
+    ended_event_order: int | None = None

--- a/src/awf/service/workspace_overview_pagination.py
+++ b/src/awf/service/workspace_overview_pagination.py
@@ -1,0 +1,55 @@
+"""Cursor encoding for the workspace overview projection."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from dataclasses import dataclass
+from datetime import datetime
+
+from awf.db.models import Workspace
+
+
+@dataclass(frozen=True)
+class _WorkspaceOverviewCursor:
+    created_at: datetime
+    workspace_id: str
+
+
+class InvalidWorkspaceOverviewCursorError(ValueError):
+    """Raised when a workspace overview pagination cursor cannot be decoded."""
+
+
+def _encode_overview_cursor(workspace: Workspace) -> str:
+    payload = {
+        "t": workspace.created_at.isoformat(),
+        "id": workspace.id,
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    return encoded.decode("ascii").rstrip("=")
+
+
+def _decode_overview_cursor(cursor: str | None) -> _WorkspaceOverviewCursor | None:
+    if cursor is None:
+        return None
+    try:
+        padded_cursor = cursor + ("=" * (-len(cursor) % 4))
+        decoded = base64.urlsafe_b64decode(padded_cursor.encode("ascii"))
+        payload = json.loads(decoded.decode("utf-8"))
+        created_at = datetime.fromisoformat(
+            payload["t"] if "t" in payload else payload["created_at"]
+        )
+        workspace_id = payload["id"] if "id" in payload else payload["workspace_id"]
+    except (
+        binascii.Error,
+        KeyError,
+        TypeError,
+        UnicodeDecodeError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        raise InvalidWorkspaceOverviewCursorError("Invalid workspace overview cursor") from exc
+    if not isinstance(workspace_id, str) or workspace_id == "":
+        raise InvalidWorkspaceOverviewCursorError("Invalid workspace overview cursor")
+    return _WorkspaceOverviewCursor(created_at=created_at, workspace_id=workspace_id)

--- a/tests/unit/api/test_console_dashboard_summary.py
+++ b/tests/unit/api/test_console_dashboard_summary.py
@@ -412,6 +412,17 @@ def test_dashboard_summary_count_evidence_rejects_exact_count_mismatch(count_key
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("count_key", _COUNT_KEYS)
+def test_dashboard_summary_count_evidence_rejects_unproven_exact_count(
+    count_key: str,
+) -> None:
+    payload = _summary_with_count_evidence()
+    payload["counts"][count_key] = payload["count_evidence"]["confirmed_counts"][count_key]
+    with pytest.raises(ValidationError, match="unknown.*exact"):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
 def test_dashboard_summary_count_evidence_keeps_coverage_reasons_independent() -> None:
     payload = _summary_with_count_evidence(total=1, known=1, unknown=0)
     payload["coverage"]["notes"] = [

--- a/tests/unit/api/test_console_dashboard_summary.py
+++ b/tests/unit/api/test_console_dashboard_summary.py
@@ -423,6 +423,19 @@ def test_dashboard_summary_count_evidence_rejects_unproven_exact_count(
 
 
 @pytest.mark.unit
+def test_dashboard_summary_count_evidence_rejects_positive_exact_lower_bound() -> None:
+    payload = _summary_with_count_evidence(
+        total=30,
+        known=29,
+        unknown=1,
+        confirmed_patch={"active": 8, "executing": 8},
+    )
+    payload["counts"]["active"] = 8
+    with pytest.raises(ValidationError, match="unknown.*exact"):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
 def test_dashboard_summary_count_evidence_keeps_coverage_reasons_independent() -> None:
     payload = _summary_with_count_evidence(total=1, known=1, unknown=0)
     payload["coverage"]["notes"] = [

--- a/tests/unit/api/test_console_dashboard_summary.py
+++ b/tests/unit/api/test_console_dashboard_summary.py
@@ -11,7 +11,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 from httpx import AsyncClient
+from jsonschema import Draft202012Validator
 from pydantic import ValidationError
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.api.routes.console import ConsoleDashboardSummaryResponse
@@ -21,10 +24,77 @@ from awf.db.session import make_session_factory
 from tests.unit.helpers import create_workspace
 
 _FIXTURES = Path(__file__).resolve().parents[3] / "docs" / "console" / "fixtures" / "v1"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_OPENAPI_JSON = _REPO_ROOT / "openapi.json"
+_COUNT_KEYS = (
+    "active",
+    "executing",
+    "monitoring_pr",
+    "awaiting_operator",
+    "awaiting_human",
+    "retrying",
+    "queued",
+    "completed_last_window",
+    "cancelled_last_window",
+    "failed_last_window",
+)
 
 
 def _dashboard_summary_payload() -> dict[str, Any]:
     return json.loads((_FIXTURES / "dashboard-summary.local.json").read_text(encoding="utf-8"))
+
+
+def _zero_confirmed_counts() -> dict[str, int]:
+    return dict.fromkeys(_COUNT_KEYS, 0)
+
+
+def _summary_with_count_evidence(
+    *,
+    total: int = 29,
+    known: int = 24,
+    unknown: int = 5,
+    confirmed_patch: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    payload = _dashboard_summary_payload()
+    payload["coverage"] = {"status": "partial", "notes": ["workflow_status_incomplete"]}
+    payload["counts"] = dict.fromkeys(_COUNT_KEYS, None)
+    confirmed = _zero_confirmed_counts()
+    confirmed.update(confirmed_patch or {})
+    payload["count_evidence"] = {
+        "total_workspaces": total,
+        "status_known_workspaces": known,
+        "status_unknown_workspaces": unknown,
+        "confirmed_counts": confirmed,
+    }
+    return payload
+
+
+def _rewrite_component_refs(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        if "$ref" in obj:
+            ref = obj["$ref"]
+            assert isinstance(ref, str)
+            assert ref.startswith("#/components/schemas/")
+            return {"$ref": f"urn:awf:schemas/{ref.rsplit('/', 1)[-1]}"}
+        return {key: _rewrite_component_refs(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_rewrite_component_refs(item) for item in obj]
+    return obj
+
+
+def _dashboard_summary_openapi_validator() -> Draft202012Validator:
+    spec = json.loads(_OPENAPI_JSON.read_text(encoding="utf-8"))
+    schemas = spec["components"]["schemas"]
+    rewritten = {
+        f"urn:awf:schemas/{name}": Resource(
+            contents=_rewrite_component_refs(schema),
+            specification=DRAFT202012,
+        )
+        for name, schema in schemas.items()
+    }
+    registry = Registry().with_resources(rewritten.items())
+    root = _rewrite_component_refs(copy.deepcopy(schemas["ConsoleDashboardSummaryResponse"]))
+    return Draft202012Validator(root, registry=registry)
 
 
 @pytest.mark.unit
@@ -113,6 +183,7 @@ async def test_dashboard_summary_independent_of_capacity(
     assert body["overlap"]["awaiting_operator_in_active_not_executing"] is True
     assert body["window"]["anchor"] == "generated_at"
     assert body["window"]["since_hours"] == 24
+    assert "count_evidence" not in body
     docker_probe.assert_not_called()
 
 
@@ -178,6 +249,226 @@ async def test_dashboard_summary_null_not_zero_on_partial(
     assert body["counts"]["cancelled_last_window"] is None
     assert "queued" in body["counts"]
     assert body["counts"]["failed_last_window"] == 0
+
+
+@pytest.mark.unit
+def test_dashboard_summary_count_evidence_is_optional_nullable_and_omitted_when_unused() -> None:
+    payload = _dashboard_summary_payload()
+    absent = ConsoleDashboardSummaryResponse.model_validate(payload)
+    assert absent.count_evidence is None
+    assert "count_evidence" not in absent.model_dump(mode="json")
+
+    payload["count_evidence"] = None
+    explicit_null = ConsoleDashboardSummaryResponse.model_validate(payload)
+    assert explicit_null.count_evidence is None
+    assert "count_evidence" not in explicit_null.model_dump(mode="json")
+
+
+@pytest.mark.unit
+def test_dashboard_summary_accepts_confirmed_lower_bound_examples() -> None:
+    all_zero = ConsoleDashboardSummaryResponse.model_validate(_summary_with_count_evidence())
+    assert all_zero.count_evidence is not None
+    assert all_zero.count_evidence.total_workspaces == 29
+    assert all_zero.count_evidence.status_known_workspaces == 24
+    assert all_zero.count_evidence.status_unknown_workspaces == 5
+    assert all_zero.count_evidence.confirmed_counts.active == 0
+
+    running_payload = _summary_with_count_evidence(
+        total=30,
+        known=25,
+        unknown=5,
+        confirmed_patch={"active": 1, "executing": 1},
+    )
+    running = ConsoleDashboardSummaryResponse.model_validate(running_payload)
+    assert running.count_evidence is not None
+    assert running.count_evidence.confirmed_counts.active == 1
+    assert running.count_evidence.confirmed_counts.executing == 1
+    assert running.counts.active is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("object_name", ["count_evidence", "confirmed_counts"])
+def test_dashboard_summary_count_evidence_rejects_unknown_object_keys(object_name: str) -> None:
+    payload = _summary_with_count_evidence()
+    target = payload["count_evidence"]
+    if object_name == "confirmed_counts":
+        target = target["confirmed_counts"]
+    target["unpublished_field"] = 0
+    with pytest.raises(ValidationError):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("object_name", "required_key"),
+    [
+        ("count_evidence", "total_workspaces"),
+        ("count_evidence", "status_known_workspaces"),
+        ("count_evidence", "status_unknown_workspaces"),
+        ("count_evidence", "confirmed_counts"),
+        *(("confirmed_counts", key) for key in _COUNT_KEYS),
+    ],
+)
+def test_dashboard_summary_count_evidence_rejects_missing_required_fields(
+    object_name: str,
+    required_key: str,
+) -> None:
+    payload = _summary_with_count_evidence()
+    target = payload["count_evidence"]
+    if object_name == "confirmed_counts":
+        target = target["confirmed_counts"]
+    del target[required_key]
+    with pytest.raises(ValidationError):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("invalid", ["1", True, -1, 1.5])
+@pytest.mark.parametrize(
+    "field_path",
+    [
+        ("total_workspaces",),
+        ("status_known_workspaces",),
+        ("status_unknown_workspaces",),
+        ("confirmed_counts", "active"),
+    ],
+)
+def test_dashboard_summary_count_evidence_rejects_non_strict_nonnegative_integers(
+    field_path: tuple[str, ...],
+    invalid: object,
+) -> None:
+    payload = _summary_with_count_evidence()
+    target = payload["count_evidence"]
+    for key in field_path[:-1]:
+        target = target[key]
+    target[field_path[-1]] = invalid
+    with pytest.raises(ValidationError):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_dashboard_summary_count_evidence_rejects_population_contradictions() -> None:
+    bad_sum = _summary_with_count_evidence(total=30, known=24, unknown=5)
+    with pytest.raises(ValidationError, match="known.*unknown.*total"):
+        ConsoleDashboardSummaryResponse.model_validate(bad_sum)
+
+    above_known = _summary_with_count_evidence(confirmed_patch={"active": 25})
+    with pytest.raises(ValidationError, match="confirmed.*known"):
+        ConsoleDashboardSummaryResponse.model_validate(above_known)
+
+    disjoint_statuses_above_known = _summary_with_count_evidence(
+        confirmed_patch={
+            "active": 20,
+            "completed_last_window": 10,
+            "cancelled_last_window": 10,
+            "failed_last_window": 10,
+        }
+    )
+    with pytest.raises(ValidationError, match="status categories.*known"):
+        ConsoleDashboardSummaryResponse.model_validate(disjoint_statuses_above_known)
+
+    complete_with_unknown_status = _summary_with_count_evidence(total=1, known=0, unknown=1)
+    complete_with_unknown_status["coverage"] = {"status": "complete", "notes": []}
+    complete_with_unknown_status["counts"] = _zero_confirmed_counts()
+    with pytest.raises(ValidationError, match="complete.*unknown"):
+        ConsoleDashboardSummaryResponse.model_validate(complete_with_unknown_status)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "confirmed_patch",
+    [
+        {"active": 1, "executing": 2},
+        {"active": 1, "monitoring_pr": 2, "awaiting_human": 0},
+        {"active": 1, "queued": 2},
+        {"active": 2, "monitoring_pr": 1, "awaiting_human": 2},
+        {"active": 2, "executing": 2, "awaiting_operator": 1},
+        {"active": 2, "executing": 2, "retrying": 1},
+        {
+            "active": 3,
+            "executing": 1,
+            "monitoring_pr": 1,
+            "awaiting_operator": 1,
+            "retrying": 1,
+        },
+        {"active": 1, "executing": 1, "queued": 1},
+    ],
+)
+def test_dashboard_summary_count_evidence_rejects_relationship_contradictions(
+    confirmed_patch: dict[str, int],
+) -> None:
+    payload = _summary_with_count_evidence(confirmed_patch=confirmed_patch)
+    with pytest.raises(ValidationError):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("count_key", _COUNT_KEYS)
+def test_dashboard_summary_count_evidence_rejects_exact_count_mismatch(count_key: str) -> None:
+    payload = _summary_with_count_evidence()
+    payload["counts"][count_key] = 1
+    with pytest.raises(ValidationError, match="exact.*confirmed"):
+        ConsoleDashboardSummaryResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_dashboard_summary_count_evidence_keeps_coverage_reasons_independent() -> None:
+    payload = _summary_with_count_evidence(total=1, known=1, unknown=0)
+    payload["coverage"]["notes"] = [
+        "terminal_timestamp_unavailable",
+        "attention_evidence_unavailable",
+    ]
+    payload["counts"].update(_zero_confirmed_counts())
+    payload["counts"]["completed_last_window"] = None
+    payload["counts"]["awaiting_human"] = None
+    model = ConsoleDashboardSummaryResponse.model_validate(payload)
+    assert model.coverage.status == "partial"
+    assert model.count_evidence is not None
+    assert model.count_evidence.status_unknown_workspaces == 0
+    assert model.counts.completed_last_window is None
+    assert model.counts.awaiting_human is None
+    assert model.coverage.notes == [
+        "terminal_timestamp_unavailable",
+        "attention_evidence_unavailable",
+    ]
+
+
+@pytest.mark.unit
+def test_dashboard_summary_openapi_exposes_strict_optional_count_evidence() -> None:
+    validator = _dashboard_summary_openapi_validator()
+    legacy = _dashboard_summary_payload()
+    assert not list(validator.iter_errors(legacy))
+
+    explicit_null = copy.deepcopy(legacy)
+    explicit_null["count_evidence"] = None
+    assert not list(validator.iter_errors(explicit_null))
+
+    valid = _summary_with_count_evidence()
+    assert not list(validator.iter_errors(valid))
+
+    malformed_payloads: list[dict[str, Any]] = []
+    for field_path, invalid in (
+        (("total_workspaces",), "29"),
+        (("status_known_workspaces",), True),
+        (("status_unknown_workspaces",), -1),
+        (("confirmed_counts", "active"), 0.5),
+    ):
+        payload = _summary_with_count_evidence()
+        target = payload["count_evidence"]
+        for key in field_path[:-1]:
+            target = target[key]
+        target[field_path[-1]] = invalid
+        malformed_payloads.append(payload)
+
+    missing = _summary_with_count_evidence()
+    del missing["count_evidence"]["confirmed_counts"]["queued"]
+    malformed_payloads.append(missing)
+    extra = _summary_with_count_evidence()
+    extra["count_evidence"]["extra"] = 0
+    malformed_payloads.append(extra)
+
+    for malformed in malformed_payloads:
+        assert list(validator.iter_errors(malformed))
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_events.py
+++ b/tests/unit/api/test_events.py
@@ -162,8 +162,10 @@ class TestListEvents:
             "new_state",
             "reason_code",
             "payload",
+            "event_order",
             "occurred_at",
         }
+        assert isinstance(body["items"][0]["event_order"], int)
         assert body["items"][0]["event_type"] == "workspace.created"
         assert body["items"][0]["new_state"] == "requested"
         assert body["items"][0]["reason_code"] == "CREATED"

--- a/tests/unit/api/test_events.py
+++ b/tests/unit/api/test_events.py
@@ -169,6 +169,7 @@ class TestListEvents:
         assert body["items"][0]["event_type"] == "workspace.created"
         assert body["items"][0]["new_state"] == "requested"
         assert body["items"][0]["reason_code"] == "CREATED"
+        assert body["items"][0]["event_order"] == 1
 
     @pytest.mark.unit
     async def test_filters_by_workspace_id(self, client: AsyncClient) -> None:

--- a/tests/unit/api/test_pagination_envelopes.py
+++ b/tests/unit/api/test_pagination_envelopes.py
@@ -124,8 +124,10 @@ async def test_enveloped_list_preserves_representative_item_shape(
         "new_state",
         "reason_code",
         "payload",
+        "event_order",
         "occurred_at",
     }
+    assert isinstance(body["items"][0]["event_order"], int)
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_pagination_envelopes.py
+++ b/tests/unit/api/test_pagination_envelopes.py
@@ -128,6 +128,7 @@ async def test_enveloped_list_preserves_representative_item_shape(
         "occurred_at",
     }
     assert isinstance(body["items"][0]["event_order"], int)
+    assert body["items"][0]["event_order"] > 0
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_workspaces_parts/test_workspaces_part_005.py
+++ b/tests/unit/api/test_workspaces_parts/test_workspaces_part_005.py
@@ -1083,6 +1083,11 @@ class TestCreateWorkspacePolicyMetadata:
                 for event in workspace.events
                 if event.event_type in {"workspace.created", "workspace.state_changed"}
             ]
+            requested_end_order = next(
+                event.event_order
+                for event in state_events
+                if event.old_state == WorkspaceStatus.requested.value
+            )
             for event, occurred_at in zip(
                 sorted(state_events, key=lambda item: item.occurred_at),
                 [
@@ -1107,12 +1112,14 @@ class TestCreateWorkspacePolicyMetadata:
             assert stages["requested"]["ended_at"] == (
                 base + timedelta(seconds=10)
             ).isoformat().replace("+00:00", "Z")
+            assert stages["requested"]["ended_event_order"] == requested_end_order
             assert stages["requested"]["duration_seconds"] == 10
             assert stages["requested"]["status"] == "completed"
             assert stages["running"]["started_at"] == (
                 base + timedelta(seconds=40)
             ).isoformat().replace("+00:00", "Z")
             assert stages["running"]["ended_at"] is None
+            assert stages["running"]["ended_event_order"] is None
             assert stages["running"]["duration_seconds"] >= 0
             assert stages["running"]["status"] == "active"
 

--- a/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
+++ b/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
@@ -748,6 +748,53 @@ class TestWorkspaceDirectRoutes:
         assert item.latest_workflow_terminal_state_change.new_state == WorkspaceStatus.failed.value
 
     @pytest.mark.unit
+    async def test_overview_reports_remonitor_reset_as_latest_state_change(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        workspace_id = await _create_workspace(client, task_title="remonitored failure")
+        await _transition_workspace(
+            engine,
+            workspace_id,
+            WorkspaceStatus.provisioning,
+            WorkspaceStatus.ready,
+            WorkspaceStatus.running,
+            WorkspaceStatus.failed,
+        )
+
+        factory = make_session_factory(engine)
+        async with factory() as session:
+            repo = WorkspaceRepository(session)
+            workspace = await repo.get(workspace_id)
+            assert workspace is not None
+            workspace.status = WorkspaceStatus.monitoring_pr.value
+            await repo.add_event_with_states(
+                workspace,
+                event_type="workspace.remonitor_requested",
+                old_state=WorkspaceStatus.failed,
+                new_state=WorkspaceStatus.monitoring_pr,
+                reason_code="OPERATOR_REMONITOR",
+                payload={"state_reset": {"from": "failed", "to": "monitoring_pr"}},
+            )
+            await repo.add_event(
+                workspace,
+                event_type="workspace.remonitor_requested",
+                reason_code="OPERATOR_REMONITOR",
+                payload={"reason": "refresh the active monitor"},
+            )
+            await session.commit()
+
+        async with factory() as session:
+            response = await workspaces_route.list_workspace_overview(session=session)
+
+        item = next(item for item in response.items if item.workspace_id == workspace_id)
+        assert item.latest_state_change is not None
+        assert item.latest_state_change.event_type == "workspace.remonitor_requested"
+        assert item.latest_state_change.old_state == WorkspaceStatus.failed.value
+        assert item.latest_state_change.new_state == WorkspaceStatus.monitoring_pr.value
+
+    @pytest.mark.unit
     @pytest.mark.parametrize("task_tag", [None, "AIRA-T109"])
     async def test_overview_route_reuses_ordered_events_for_last_event(
         self,

--- a/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
+++ b/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
@@ -778,10 +778,10 @@ class TestWorkspaceDirectRoutes:
             event_order=1,
             occurred_at=base,
         )
-        # The same-tick IDs deliberately sort opposite to append order so the
-        # overview must use persisted event_order to select the latest state.
+        # The same-tick terminal IDs deliberately sort opposite to append order
+        # so both reverse scans must use persisted event_order.
         older_state_changed_event = SimpleNamespace(
-            id="evt_state_changed_z",
+            id="evt_state_changed_ready",
             workspace_id=workspace_id,
             event_type="workspace.state_changed",
             old_state=WorkspaceStatus.requested.value,
@@ -789,10 +789,10 @@ class TestWorkspaceDirectRoutes:
             reason_code="READY",
             payload=None,
             event_order=2,
-            occurred_at=base + timedelta(seconds=4),
+            occurred_at=base + timedelta(seconds=3),
         )
         state_changed_event = SimpleNamespace(
-            id="evt_state_changed_a",
+            id="evt_state_changed_running",
             workspace_id=workspace_id,
             event_type="workspace.state_changed",
             old_state=WorkspaceStatus.ready.value,
@@ -800,6 +800,28 @@ class TestWorkspaceDirectRoutes:
             reason_code="STARTED",
             payload=None,
             event_order=3,
+            occurred_at=base + timedelta(seconds=3),
+        )
+        older_terminal_event = SimpleNamespace(
+            id="evt_terminal_z",
+            workspace_id=workspace_id,
+            event_type="workspace.state_changed",
+            old_state=WorkspaceStatus.running.value,
+            new_state=WorkspaceStatus.failed.value,
+            reason_code="FAILED",
+            payload=None,
+            event_order=4,
+            occurred_at=base + timedelta(seconds=4),
+        )
+        latest_terminal_event = SimpleNamespace(
+            id="evt_terminal_a",
+            workspace_id=workspace_id,
+            event_type="workspace.state_changed",
+            old_state=WorkspaceStatus.failed.value,
+            new_state=WorkspaceStatus.cancelled.value,
+            reason_code="CANCELLED",
+            payload=None,
+            event_order=5,
             occurred_at=base + timedelta(seconds=4),
         )
         latest_event = SimpleNamespace(
@@ -810,11 +832,18 @@ class TestWorkspaceDirectRoutes:
             new_state=None,
             reason_code="TEST",
             payload={"source": "unit"},
-            event_order=4,
+            event_order=6,
             occurred_at=base + timedelta(seconds=5),
         )
         events = SinglePassEvents(
-            [latest_event, state_changed_event, created_event, older_state_changed_event]
+            [
+                latest_event,
+                latest_terminal_event,
+                state_changed_event,
+                created_event,
+                older_terminal_event,
+                older_state_changed_event,
+            ]
         )
         workspace = SimpleNamespace(
             id=workspace_id,
@@ -830,7 +859,7 @@ class TestWorkspaceDirectRoutes:
             task_policy={},
             events=events,
             operations=[],
-            status=WorkspaceStatus.running.value,
+            status=WorkspaceStatus.cancelled.value,
             pr_url="https://github.com/example/app/pull/7",
             pr_number=7,
             failure_reason=None,
@@ -862,7 +891,11 @@ class TestWorkspaceDirectRoutes:
         assert item.last_event.event_type == "workspace.test_marker"
         assert item.latest_state_change is not None
         assert item.latest_state_change.event_type == "workspace.state_changed"
-        assert item.latest_state_change.new_state == WorkspaceStatus.running.value
+        assert item.latest_state_change.new_state == WorkspaceStatus.cancelled.value
+        assert item.latest_workflow_terminal_state_change is not None
+        assert (
+            item.latest_workflow_terminal_state_change.new_state == WorkspaceStatus.cancelled.value
+        )
         assert events.iterations == 1
         assert item.pr_number == 7
         assert item.pr_url == "https://github.com/example/app/pull/7"

--- a/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
+++ b/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
@@ -711,6 +711,7 @@ class TestWorkspaceDirectRoutes:
         assert item.title == "overview direct"
         assert item.active_operation is None
         assert item.last_event is not None
+        assert item.latest_state_change is None
         assert response.next_cursor is None
         assert response.has_more is False
         assert response.limit == 50
@@ -746,6 +747,16 @@ class TestWorkspaceDirectRoutes:
             payload=None,
             occurred_at=base,
         )
+        state_changed_event = SimpleNamespace(
+            id="evt_state_changed",
+            workspace_id=workspace_id,
+            event_type="workspace.state_changed",
+            old_state=WorkspaceStatus.requested.value,
+            new_state=WorkspaceStatus.running.value,
+            reason_code="STARTED",
+            payload=None,
+            occurred_at=base + timedelta(seconds=4),
+        )
         latest_event = SimpleNamespace(
             id="evt_latest",
             workspace_id=workspace_id,
@@ -756,7 +767,7 @@ class TestWorkspaceDirectRoutes:
             payload={"source": "unit"},
             occurred_at=base + timedelta(seconds=5),
         )
-        events = SinglePassEvents([latest_event, created_event])
+        events = SinglePassEvents([latest_event, created_event, state_changed_event])
         workspace = SimpleNamespace(
             id=workspace_id,
             task_external_id=None,
@@ -771,7 +782,7 @@ class TestWorkspaceDirectRoutes:
             task_policy={},
             events=events,
             operations=[],
-            status=WorkspaceStatus.requested.value,
+            status=WorkspaceStatus.running.value,
             pr_url="https://github.com/example/app/pull/7",
             pr_number=7,
             failure_reason=None,
@@ -801,6 +812,9 @@ class TestWorkspaceDirectRoutes:
         item = response.items[0]
         assert item.last_event is not None
         assert item.last_event.event_type == "workspace.test_marker"
+        assert item.latest_state_change is not None
+        assert item.latest_state_change.event_type == "workspace.state_changed"
+        assert item.latest_state_change.new_state == WorkspaceStatus.running.value
         assert events.iterations == 1
         assert item.pr_number == 7
         assert item.pr_url == "https://github.com/example/app/pull/7"

--- a/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
+++ b/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
@@ -718,6 +718,36 @@ class TestWorkspaceDirectRoutes:
         assert response.cursor is None
 
     @pytest.mark.unit
+    async def test_overview_retains_workflow_terminal_transition_after_destroy(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        workspace_id = await _create_workspace(client, task_title="destroyed failure")
+        await _transition_workspace(
+            engine,
+            workspace_id,
+            WorkspaceStatus.provisioning,
+            WorkspaceStatus.ready,
+            WorkspaceStatus.running,
+            WorkspaceStatus.failed,
+            WorkspaceStatus.destroying,
+            WorkspaceStatus.destroyed,
+        )
+
+        factory = make_session_factory(engine)
+        async with factory() as session:
+            response = await workspaces_route.list_workspace_overview(session=session)
+
+        item = next(item for item in response.items if item.workspace_id == workspace_id)
+        assert item.latest_state_change is not None
+        assert item.latest_state_change.old_state == WorkspaceStatus.destroying.value
+        assert item.latest_state_change.new_state == WorkspaceStatus.destroyed.value
+        assert item.latest_workflow_terminal_state_change is not None
+        assert item.latest_workflow_terminal_state_change.old_state == WorkspaceStatus.running.value
+        assert item.latest_workflow_terminal_state_change.new_state == WorkspaceStatus.failed.value
+
+    @pytest.mark.unit
     @pytest.mark.parametrize("task_tag", [None, "AIRA-T109"])
     async def test_overview_route_reuses_ordered_events_for_last_event(
         self,

--- a/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
+++ b/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
@@ -793,6 +793,9 @@ class TestWorkspaceDirectRoutes:
         assert item.latest_state_change.event_type == "workspace.remonitor_requested"
         assert item.latest_state_change.old_state == WorkspaceStatus.failed.value
         assert item.latest_state_change.new_state == WorkspaceStatus.monitoring_pr.value
+        assert item.latest_state_change.event_order is not None
+        assert item.recovery is not None
+        assert item.recovery.started_event_order == item.latest_state_change.event_order
 
     @pytest.mark.unit
     @pytest.mark.parametrize("task_tag", [None, "AIRA-T109"])
@@ -936,13 +939,16 @@ class TestWorkspaceDirectRoutes:
         item = response.items[0]
         assert item.last_event is not None
         assert item.last_event.event_type == "workspace.test_marker"
+        assert item.last_event.event_order == 6
         assert item.latest_state_change is not None
         assert item.latest_state_change.event_type == "workspace.state_changed"
         assert item.latest_state_change.new_state == WorkspaceStatus.cancelled.value
+        assert item.latest_state_change.event_order == 5
         assert item.latest_workflow_terminal_state_change is not None
         assert (
             item.latest_workflow_terminal_state_change.new_state == WorkspaceStatus.cancelled.value
         )
+        assert item.latest_workflow_terminal_state_change.event_order == 5
         assert events.iterations == 1
         assert item.pr_number == 7
         assert item.pr_url == "https://github.com/example/app/pull/7"

--- a/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
+++ b/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
@@ -775,16 +775,31 @@ class TestWorkspaceDirectRoutes:
             new_state=WorkspaceStatus.requested.value,
             reason_code="CREATED",
             payload=None,
+            event_order=1,
             occurred_at=base,
         )
-        state_changed_event = SimpleNamespace(
-            id="evt_state_changed",
+        # The same-tick IDs deliberately sort opposite to append order so the
+        # overview must use persisted event_order to select the latest state.
+        older_state_changed_event = SimpleNamespace(
+            id="evt_state_changed_z",
             workspace_id=workspace_id,
             event_type="workspace.state_changed",
             old_state=WorkspaceStatus.requested.value,
+            new_state=WorkspaceStatus.ready.value,
+            reason_code="READY",
+            payload=None,
+            event_order=2,
+            occurred_at=base + timedelta(seconds=4),
+        )
+        state_changed_event = SimpleNamespace(
+            id="evt_state_changed_a",
+            workspace_id=workspace_id,
+            event_type="workspace.state_changed",
+            old_state=WorkspaceStatus.ready.value,
             new_state=WorkspaceStatus.running.value,
             reason_code="STARTED",
             payload=None,
+            event_order=3,
             occurred_at=base + timedelta(seconds=4),
         )
         latest_event = SimpleNamespace(
@@ -795,9 +810,12 @@ class TestWorkspaceDirectRoutes:
             new_state=None,
             reason_code="TEST",
             payload={"source": "unit"},
+            event_order=4,
             occurred_at=base + timedelta(seconds=5),
         )
-        events = SinglePassEvents([latest_event, created_event, state_changed_event])
+        events = SinglePassEvents(
+            [latest_event, state_changed_event, created_event, older_state_changed_event]
+        )
         workspace = SimpleNamespace(
             id=workspace_id,
             task_external_id=None,

--- a/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
+++ b/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
@@ -743,6 +743,9 @@ class TestWorkspaceDirectRoutes:
         assert item.latest_state_change is not None
         assert item.latest_state_change.old_state == WorkspaceStatus.destroying.value
         assert item.latest_state_change.new_state == WorkspaceStatus.destroyed.value
+        assert item.latest_destroying_state_change is not None
+        assert item.latest_destroying_state_change.old_state == WorkspaceStatus.failed.value
+        assert item.latest_destroying_state_change.new_state == WorkspaceStatus.destroying.value
         assert item.latest_workflow_terminal_state_change is not None
         assert item.latest_workflow_terminal_state_change.old_state == WorkspaceStatus.running.value
         assert item.latest_workflow_terminal_state_change.new_state == WorkspaceStatus.failed.value

--- a/tests/unit/contracts/test_console_contract_fixtures.py
+++ b/tests/unit/contracts/test_console_contract_fixtures.py
@@ -51,8 +51,12 @@ def test_capabilities_fixtures_validate(name: str) -> None:
 )
 def test_dashboard_summary_fixtures_validate(name: str) -> None:
     payload = _load(name)
+    assert isinstance(payload, dict)
+    assert "count_evidence" not in payload
     model = ConsoleDashboardSummaryResponse.model_validate(payload)
     assert model.schema_version == 1
+    assert model.count_evidence is None
+    assert "count_evidence" not in model.model_dump(mode="json")
     if name.endswith("no-prior-success.json"):
         assert model.coverage.status == "partial"
         assert model.last_success_at is None

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_fix_pass_parts/test_pr_monitor_pre_push_validation_fix_pass_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_fix_pass_parts/test_pr_monitor_pre_push_validation_fix_pass_part_005.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator
+from contextlib import suppress
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -407,11 +408,13 @@ async def test_pre_push_validation_fix_pass_timeout_head_probe_is_bounded_best_e
             validation_commands=("pytest -q",),
         )
     )
-    probe_started_task = asyncio.create_task(probe_started.wait())
+    probe_started_task: asyncio.Task[bool] | None = None
+    fix_pass_result_consumed = False
     # Give unrelated setup and database scheduling their own generous guard.
     # The tight bound below begins only when the preservation probe actually
     # starts, which keeps this assertion meaningful under loaded CI shards.
     try:
+        probe_started_task = asyncio.create_task(probe_started.wait())
         started, _pending = await asyncio.wait(
             {probe_started_task, fix_pass_task},
             timeout=5.0,
@@ -420,15 +423,26 @@ async def test_pre_push_validation_fix_pass_timeout_head_probe_is_bounded_best_e
         if probe_started_task not in started:
             if fix_pass_task in started:
                 await fix_pass_task
+                fix_pass_result_consumed = True
             pytest.fail("preservation probe did not start within 5 seconds")
 
         with pytest.raises(expected_exception) as raised:
             await asyncio.wait_for(fix_pass_task, timeout=0.5)
+        fix_pass_result_consumed = True
     finally:
-        for task in (probe_started_task, fix_pass_task):
+        for task in (fix_pass_task, probe_started_task):
+            if task is None:
+                continue
             if not task.done():
                 task.cancel()
-        await asyncio.gather(probe_started_task, fix_pass_task, return_exceptions=True)
+        try:
+            if not fix_pass_result_consumed:
+                with suppress(asyncio.CancelledError):
+                    await fix_pass_task
+        finally:
+            if probe_started_task is not None:
+                with suppress(asyncio.CancelledError):
+                    await probe_started_task
 
     if probe_failure != "cancels":
         assert raised.value is cleanup_error

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_fix_pass_parts/test_pr_monitor_pre_push_validation_fix_pass_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_fix_pass_parts/test_pr_monitor_pre_push_validation_fix_pass_part_005.py
@@ -407,12 +407,28 @@ async def test_pre_push_validation_fix_pass_timeout_head_probe_is_bounded_best_e
             validation_commands=("pytest -q",),
         )
     )
+    probe_started_task = asyncio.create_task(probe_started.wait())
     # Give unrelated setup and database scheduling their own generous guard.
     # The tight bound below begins only when the preservation probe actually
     # starts, which keeps this assertion meaningful under loaded CI shards.
-    await asyncio.wait_for(probe_started.wait(), timeout=5.0)
-    with pytest.raises(expected_exception) as raised:
-        await asyncio.wait_for(fix_pass_task, timeout=0.5)
+    try:
+        started, _pending = await asyncio.wait(
+            {probe_started_task, fix_pass_task},
+            timeout=5.0,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if probe_started_task not in started:
+            if fix_pass_task in started:
+                await fix_pass_task
+            pytest.fail("preservation probe did not start within 5 seconds")
+
+        with pytest.raises(expected_exception) as raised:
+            await asyncio.wait_for(fix_pass_task, timeout=0.5)
+    finally:
+        for task in (probe_started_task, fix_pass_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(probe_started_task, fix_pass_task, return_exceptions=True)
 
     if probe_failure != "cancels":
         assert raised.value is cleanup_error

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_fix_pass_parts/test_pr_monitor_pre_push_validation_fix_pass_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_fix_pass_parts/test_pr_monitor_pre_push_validation_fix_pass_part_005.py
@@ -349,6 +349,7 @@ async def test_pre_push_validation_fix_pass_timeout_head_probe_is_bounded_best_e
         message="tagged process still running",
     )
     cleanup_error.agent_reason_code = "AGENT_TIMEOUT"
+    probe_started = asyncio.Event()
 
     async def _run_agent_with_recovery(**_kwargs: object) -> None:
         raise cleanup_error
@@ -357,6 +358,7 @@ async def test_pre_push_validation_fix_pass_timeout_head_probe_is_bounded_best_e
         return fix_start_head
 
     async def _verify_head_object_exists(_worktree_path: Path) -> bool:
+        probe_started.set()
         if probe_failure == "raises":
             raise OSError("cannot spawn git")
         if probe_failure == "cancels":
@@ -386,27 +388,31 @@ async def test_pre_push_validation_fix_pass_timeout_head_probe_is_bounded_best_e
     expected_exception = (
         asyncio.CancelledError if probe_failure == "cancels" else ComposeExecCleanupError
     )
-    with pytest.raises(expected_exception) as raised:
-        await asyncio.wait_for(
-            pre_push_validation._run_pre_push_validation_fix_pass(
-                runner,
-                workspace_id=workspace_id,
-                compose_project="proj",
-                compose_file=tmp_path / "compose.yml",
-                remote_branch="codex/pr",
-                remote_url=None,
-                state=None,
-                validation_result=_failed_validation_result(
-                    pre_push_validation,
-                    tmp_path,
-                    workspace_head_sha=fix_start_head,
-                ),
-                pass_number=1,
-                total_passes=1,
-                validation_commands=("pytest -q",),
+    fix_pass_task = asyncio.create_task(
+        pre_push_validation._run_pre_push_validation_fix_pass(
+            runner,
+            workspace_id=workspace_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            remote_branch="codex/pr",
+            remote_url=None,
+            state=None,
+            validation_result=_failed_validation_result(
+                pre_push_validation,
+                tmp_path,
+                workspace_head_sha=fix_start_head,
             ),
-            timeout=0.5,
+            pass_number=1,
+            total_passes=1,
+            validation_commands=("pytest -q",),
         )
+    )
+    # Give unrelated setup and database scheduling their own generous guard.
+    # The tight bound below begins only when the preservation probe actually
+    # starts, which keeps this assertion meaningful under loaded CI shards.
+    await asyncio.wait_for(probe_started.wait(), timeout=5.0)
+    with pytest.raises(expected_exception) as raised:
+        await asyncio.wait_for(fix_pass_task, timeout=0.5)
 
     if probe_failure != "cancels":
         assert raised.value is cleanup_error

--- a/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_002.py
+++ b/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_002.py
@@ -39,6 +39,7 @@ def _lifecycle_event(
     occurred_at: datetime,
     old_state: str | None = None,
     new_state: str | None = None,
+    event_order: int | None = None,
 ) -> object:
     return SimpleNamespace(
         event_type=event_type,
@@ -47,6 +48,7 @@ def _lifecycle_event(
         reason_code="TEST",
         payload=None,
         occurred_at=occurred_at,
+        event_order=event_order,
     )
 
 
@@ -441,6 +443,7 @@ def test_lifecycle_summary_marks_future_stages_terminal_skipped() -> None:
                 occurred_at=failed_at,
                 old_state=WorkspaceStatus.validating.value,
                 new_state=WorkspaceStatus.failed.value,
+                event_order=6,
             ),
         ],
     )
@@ -454,11 +457,63 @@ def test_lifecycle_summary_marks_future_stages_terminal_skipped() -> None:
     }
 
     assert stages["validating"].ended_at == failed_at
+    assert stages["validating"].ended_event_order == 6
     assert stages["validating"].duration_seconds == 15
     assert stages["validating"].status == "completed"
     assert stages["pushing"].status == "terminal_skipped"
     assert stages["monitoring_pr"].status == "terminal_skipped"
     assert stages["completed"].status == "terminal_skipped"
+
+
+@pytest.mark.unit
+def test_lifecycle_summary_retains_first_boundary_order_across_reentry() -> None:
+    base = datetime(2026, 4, 27, 13, 30, tzinfo=UTC)
+    terminal_at = base + timedelta(seconds=30)
+    workspace = _workspace_for_lifecycle(
+        status=WorkspaceStatus.failed,
+        created_at=base,
+        events=[
+            _lifecycle_event(
+                event_type="workspace.state_changed",
+                occurred_at=base + timedelta(seconds=10),
+                old_state=WorkspaceStatus.requested.value,
+                new_state=WorkspaceStatus.running.value,
+                event_order=1,
+            ),
+            _lifecycle_event(
+                event_type="workspace.state_changed",
+                occurred_at=terminal_at,
+                old_state=WorkspaceStatus.running.value,
+                new_state=WorkspaceStatus.blocked.value,
+                event_order=2,
+            ),
+            _lifecycle_event(
+                event_type="workspace.state_changed",
+                occurred_at=terminal_at,
+                old_state=WorkspaceStatus.blocked.value,
+                new_state=WorkspaceStatus.running.value,
+                event_order=3,
+            ),
+            _lifecycle_event(
+                event_type="workspace.state_changed",
+                occurred_at=terminal_at,
+                old_state=WorkspaceStatus.running.value,
+                new_state=WorkspaceStatus.failed.value,
+                event_order=4,
+            ),
+        ],
+    )
+
+    stages = {
+        item.stage: item
+        for item in workspace_lifecycle_summary(
+            workspace,
+            now=terminal_at,
+        )
+    }
+
+    assert stages["running"].ended_at == terminal_at
+    assert stages["running"].ended_event_order == 2
 
 
 @pytest.mark.unit
@@ -793,6 +848,7 @@ def test_observability_payloads_include_identity_lifecycle_and_usage() -> None:
         "stage": "requested",
         "started_at": base,
         "ended_at": None,
+        "ended_event_order": None,
         "duration_seconds": 12,
         "status": "active",
     }

--- a/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_004.py
+++ b/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_004.py
@@ -519,6 +519,60 @@ def test_recovery_summary_is_none_without_reverse_transition() -> None:
 
 
 @pytest.mark.unit
+def test_recovery_summary_uses_failed_remonitor_reset_as_latest_boundary() -> None:
+    base = datetime(2026, 4, 27, 20, 15, tzinfo=UTC)
+    failed_at = base + timedelta(seconds=30)
+    remonitor_at = base + timedelta(seconds=60)
+    remonitor_payload: dict[str, object] = {
+        "reason": "resume the PR monitor",
+        "state_reset": {
+            "from": WorkspaceStatus.failed.value,
+            "to": WorkspaceStatus.monitoring_pr.value,
+        },
+    }
+    workspace = _workspace_for_recovery(
+        status=WorkspaceStatus.destroyed,
+        created_at=base,
+        events=[
+            _recovery_event(
+                event_id="evt_earlier_recovery",
+                event_type="workspace.state_changed",
+                occurred_at=base + timedelta(seconds=10),
+                old_state=WorkspaceStatus.monitoring_pr.value,
+                new_state=WorkspaceStatus.ready.value,
+                reason_code="STALE_TARGET_ADVANCED",
+            ),
+            _recovery_event(
+                event_id="evt_failed",
+                event_type="workspace.state_changed",
+                occurred_at=failed_at,
+                old_state=WorkspaceStatus.running.value,
+                new_state=WorkspaceStatus.failed.value,
+                reason_code="AGENT_FAILED",
+            ),
+            _recovery_event(
+                event_id="evt_remonitor",
+                event_type="workspace.remonitor_requested",
+                occurred_at=remonitor_at,
+                old_state=WorkspaceStatus.failed.value,
+                new_state=WorkspaceStatus.monitoring_pr.value,
+                reason_code="OPERATOR_REMONITOR",
+                payload=remonitor_payload,
+            ),
+        ],
+    )
+
+    summary = workspace_recovery_summary(workspace)  # type: ignore[arg-type]
+
+    assert summary is not None
+    assert summary.from_state == WorkspaceStatus.failed.value
+    assert summary.to_state == WorkspaceStatus.monitoring_pr.value
+    assert summary.started_at == remonitor_at
+    assert summary.reason_code == "resume the PR monitor"
+    assert summary.payload == remonitor_payload
+
+
+@pytest.mark.unit
 def test_recovery_summary_pairs_reverse_transition_with_monitor_event_payload() -> None:
     base = datetime(2026, 4, 27, 20, 30, tzinfo=UTC)
     reverse_at = base + timedelta(seconds=40)

--- a/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_004.py
+++ b/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_004.py
@@ -38,6 +38,7 @@ def _recovery_event(
     reason_code: str | None = "RECOVERY_DISPATCH",
     payload: dict[str, object] | None = None,
     event_id: str = "evt_recovery",
+    event_order: int | None = None,
 ) -> object:
     return SimpleNamespace(
         id=event_id,
@@ -47,6 +48,7 @@ def _recovery_event(
         new_state=new_state,
         reason_code=reason_code,
         payload=payload,
+        event_order=event_order,
         occurred_at=occurred_at,
     )
 
@@ -554,6 +556,7 @@ def test_recovery_summary_uses_failed_remonitor_reset_as_latest_boundary() -> No
                 event_id="evt_remonitor",
                 event_type="workspace.remonitor_requested",
                 occurred_at=remonitor_at,
+                event_order=17,
                 old_state=WorkspaceStatus.failed.value,
                 new_state=WorkspaceStatus.monitoring_pr.value,
                 reason_code="OPERATOR_REMONITOR",
@@ -568,6 +571,7 @@ def test_recovery_summary_uses_failed_remonitor_reset_as_latest_boundary() -> No
     assert summary.from_state == WorkspaceStatus.failed.value
     assert summary.to_state == WorkspaceStatus.monitoring_pr.value
     assert summary.started_at == remonitor_at
+    assert summary.started_event_order == 17
     assert summary.reason_code == "resume the PR monitor"
     assert summary.payload == remonitor_payload
 

--- a/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_004.py
+++ b/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_004.py
@@ -532,9 +532,24 @@ def test_recovery_summary_uses_failed_remonitor_reset_as_latest_boundary() -> No
             "to": WorkspaceStatus.monitoring_pr.value,
         },
     }
+    stale_operation_payload: dict[str, object] = {
+        "source": "pr_monitor",
+        "reason": "stale recovery from the previous monitor episode",
+        "requested_action": "rebase",
+        "recovery_mode": "rebase_only",
+    }
     workspace = _workspace_for_recovery(
         status=WorkspaceStatus.destroyed,
         created_at=base,
+        operations=[
+            _recovery_operation(
+                operation_id="op_old_recovery",
+                operation_type=OperationType.rebase.value,
+                status=OperationStatus.succeeded.value,
+                created_at=failed_at - timedelta(seconds=5),
+                payload=stale_operation_payload,
+            )
+        ],
         events=[
             _recovery_event(
                 event_id="evt_earlier_recovery",
@@ -573,6 +588,9 @@ def test_recovery_summary_uses_failed_remonitor_reset_as_latest_boundary() -> No
     assert summary.started_at == remonitor_at
     assert summary.started_event_order == 17
     assert summary.reason_code == "resume the PR monitor"
+    assert summary.action is None
+    assert summary.recovery_mode is None
+    assert summary.current_operation is None
     assert summary.payload == remonitor_payload
 
 


### PR DESCRIPTION
Automated AWF release PR syncing `development` into `main`.

<!-- AWF:release-merge-policy:start -->
Opened by the `sync_release_pr` task kind and monitored with release/manual behavior (auto-merge disabled). Merging into the release target stays human-gated.
<!-- AWF:release-merge-policy:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator-visible timing and fleet counts via complex inference rules; risk is mitigated by extensive validation tests and fail-closed summary parsing, but edge-case workspace states could still display differently than before.
> 
> **Overview**
> **Console operators get more trustworthy workflow timing and fleet KPIs when backend data is incomplete or messy.**
> 
> The console adds **`resolveWorkflowTiming`** and **`hasTerminalWorkflowTiming`** in `agent-format` to unify finish time and duration across cards, task details, and the workspace inspector. Terminal workspaces show **Finished** and **Duration** (with explicit “not recorded” fallbacks); active ones show **Last activity**. The resolver validates RFC3339 timestamps, rejects malformed or contradictory lifecycle/event provenance (recovery, destroy cleanup, pause/resume), and only infers duration when evidence is consistent.
> 
> **Fleet health** now understands optional **`count_evidence`** on dashboard summaries: KPIs can show exact counts or **confirmed** lower bounds with suffixes and hints, and partial-coverage banners quantify known vs unknown workflow statuses. Parsing stays fail-closed when evidence contradicts exact counts or coverage claims.
> 
> **Workspace list scrolling** is tightened (top-edge tolerance, selection-owned scroll anchor) so virtualized history loads do not fight selection follow. The inspector workspace summary uses a single-column grid to avoid horizontal overflow; Playwright covers long-content layout at multiple viewport widths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abdb2ab63c6380468c003ed028d9b68c34974c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard metrics distinguish exact counts from confirmed lower-bound counts when workspace coverage is incomplete.
  * Coverage notices clarify known and unknown workspace statuses.
  * Workspace cards and task details show consistent completion times and recorded durations for finished workflows.
  * Active workspaces display their latest activity more clearly.

* **Bug Fixes**
  * Improved handling of missing, invalid, ambiguous, or inconsistent workflow timing data.
  * Improved responsive layouts to prevent content and controls from overflowing on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->