### PR TITLE
fix(console): restore plain fleet counters

### DIFF
--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -49,7 +49,6 @@ import {
   displayedTaskKey,
   MAX_FULLSCREEN_LOG_WORKSPACES,
 } from "@/lib/console-dashboard-derived";
-import { formatDashboardCoverageNotice } from "@/lib/console-dashboard-summary";
 import { copyTextToClipboard } from "@/lib/clipboard";
 import {
   attentionAgeSeconds,
@@ -72,7 +71,7 @@ import type { OperatorPreferences } from "@/lib/operator-preferences";
 import {
 formatRecoveryBadge
 } from "@/lib/recovery-format";
-import type { ConsoleDashboardCountEvidence, WorkspaceOverview } from "@/lib/types";
+import type { WorkspaceOverview } from "@/lib/types";
 import {
 Badge, KpiStat,
 SmallExternalAnchor,
@@ -258,25 +257,14 @@ export function FleetHealthStrip({
   kpis,
   error,
   lastSuccessAt,
-  coverageStatus,
-  coverageNotes,
-  countEvidence,
 }: {
   kpis: FleetKpi[];
   error?: string | null;
   lastSuccessAt?: string | null;
-  coverageStatus?: "complete" | "partial" | "unknown" | null;
-  coverageNotes?: readonly string[] | null;
-  countEvidence?: ConsoleDashboardCountEvidence | null;
 }) {
   const anyStale = kpis.some((kpi) => kpi.stale);
-  // HTTP 200 can still be incomplete. Do not treat partial/unknown as a request
-  // error — that banner is cleared on success — but do not let non-null counts
-  // look fully current either.
-  const coverageNotice = formatDashboardCoverageNotice(
-    coverageStatus ? { status: coverageStatus, notes: coverageNotes ?? [] } : null,
-    countEvidence,
-  );
+  // Partial/unknown coverage on HTTP 200 is presentation-silent: keep request-error
+  // and stale banners only. Backend coverage/count_evidence fields remain parsed.
   return (
     <div className="border-b border-line bg-canvas px-4 py-3" aria-label="Fleet health">
       {error ? (
@@ -289,19 +277,6 @@ export function FleetHealthStrip({
           <span>{error}</span>
           {lastSuccessAt ? (
             <span className="text-danger-text/80">· last success {lastSuccessAt}</span>
-          ) : null}
-        </div>
-      ) : null}
-      {coverageNotice ? (
-        <div
-          className="mb-2 inline-flex max-w-full flex-wrap items-center gap-1 rounded-[var(--radius-control)] border border-attention-border bg-attention-soft px-2 py-0.5 text-[11px] font-medium text-attention-text"
-          role="status"
-          data-testid="dashboard-summary-coverage"
-        >
-          <span aria-hidden>⚠</span>
-          <span>{coverageNotice}</span>
-          {!error && lastSuccessAt ? (
-            <span className="text-attention-text/80">· last complete {lastSuccessAt}</span>
           ) : null}
         </div>
       ) : null}

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -1176,15 +1176,6 @@ export function ConsoleDashboard() {
           lastSuccessAt={
             fleetSummaryAvailable ? (dashboardSummary?.last_success_at ?? null) : null
           }
-          coverageStatus={
-            fleetSummaryAvailable ? (dashboardSummary?.coverage.status ?? null) : null
-          }
-          coverageNotes={
-            fleetSummaryAvailable ? (dashboardSummary?.coverage.notes ?? null) : null
-          }
-          countEvidence={
-            fleetSummaryAvailable ? (dashboardSummary?.count_evidence ?? null) : null
-          }
         />
       ) : null}
       <SectionNav

--- a/apps/console/lib/console-dashboard-summary.test.mjs
+++ b/apps/console/lib/console-dashboard-summary.test.mjs
@@ -4,7 +4,6 @@ import test from "node:test";
 
 import {
   fleetKpisFromDashboardSummary,
-  formatDashboardCoverageNotice,
   parseDashboardSummary,
 } from "./console-dashboard-summary.ts";
 
@@ -148,47 +147,6 @@ test("parseDashboardSummary accepts string coverage.notes arrays", () => {
   );
   assert.ok(parsed);
   assert.deepEqual(parsed.coverage.notes, ["queued_count_unavailable"]);
-});
-
-test("formatDashboardCoverageNotice surfaces partial and unknown notes", () => {
-  const partial = JSON.parse(
-    readFileSync(
-      new URL("../../../docs/console/fixtures/v1/dashboard-summary.partial.json", import.meta.url),
-      "utf8",
-    ),
-  );
-  assert.equal(
-    formatDashboardCoverageNotice(partial.coverage),
-    "partial coverage — queued count unavailable",
-  );
-  const noPrior = JSON.parse(
-    readFileSync(
-      new URL(
-        "../../../docs/console/fixtures/v1/dashboard-summary.no-prior-success.json",
-        import.meta.url,
-      ),
-      "utf8",
-    ),
-  );
-  assert.equal(
-    formatDashboardCoverageNotice(noPrior.coverage),
-    "partial coverage — queued count unavailable; no prior successful snapshot",
-  );
-  assert.equal(
-    formatDashboardCoverageNotice({ status: "unknown", notes: ["provider_lag"] }),
-    "coverage unknown — provider lag",
-  );
-  assert.equal(
-    formatDashboardCoverageNotice({ status: "unknown", notes: [] }),
-    "coverage unknown — some counts are incomplete",
-  );
-  assert.equal(
-    formatDashboardCoverageNotice({ status: "partial", notes: ["", "  "] }),
-    "partial coverage — some counts are incomplete",
-  );
-  assert.equal(formatDashboardCoverageNotice({ status: "complete", notes: [] }), null);
-  assert.equal(formatDashboardCoverageNotice(null), null);
-  assert.equal(formatDashboardCoverageNotice(undefined), null);
 });
 
 test("parseDashboardSummary accepts absent, null, and valid count evidence", () => {
@@ -335,11 +293,15 @@ test("parseDashboardSummary rejects a positive exact lower bound with one unknow
   assert.equal(parseDashboardSummary(payload), null);
 });
 
-test("confirmed KPI lower bounds stay qualified while exact values win", () => {
+test("confirmed KPI values render as plain numbers while exact values win", () => {
+  // Production-shaped 29/24/5 evidence: confirmed nonzero + evidenced zero → plain numbers.
   const lowerBounds = parseDashboardSummary(
     summaryWithCountEvidence({ confirmed: { active: 1, executing: 1 } }),
   );
   assert.ok(lowerBounds);
+  assert.equal(lowerBounds.count_evidence.total_workspaces, 29);
+  assert.equal(lowerBounds.count_evidence.status_known_workspaces, 24);
+  assert.equal(lowerBounds.count_evidence.status_unknown_workspaces, 5);
   const lowerBoundKpis = fleetKpisFromDashboardSummary({
     summary: lowerBounds,
     summaryStale: true,
@@ -352,16 +314,15 @@ test("confirmed KPI lower bounds stay qualified while exact values win", () => {
   const monitoring = lowerBoundKpis.find((item) => item.id === "monitoring_pr");
   const completed = lowerBoundKpis.find((item) => item.id === "completed");
   assert.deepEqual(
-    { value: active.value, suffix: active.suffix, stale: active.stale },
-    { value: 1, suffix: " confirmed", stale: true },
+    { value: active.value, suffix: active.suffix, hint: active.hint, stale: active.stale },
+    { value: 1, suffix: undefined, hint: undefined, stale: true },
   );
   assert.deepEqual(
-    { value: monitoring.value, suffix: monitoring.suffix },
-    { value: 0, suffix: " confirmed" },
+    { value: monitoring.value, suffix: monitoring.suffix, hint: monitoring.hint },
+    { value: 0, suffix: undefined, hint: undefined },
   );
-  assert.match(active.hint, /exact metric count is incomplete/);
-  assert.match(completed.hint, /last 24h/);
-  assert.match(completed.hint, /exact metric count is incomplete/);
+  assert.equal(completed.hint, "last 24h");
+  assert.doesNotMatch(String(completed.hint ?? ""), /confirmed|lower bound|incomplete/i);
   assert.equal(lowerBounds.counts.active, null);
 
   const exactPayload = summaryWithCountEvidence({
@@ -386,8 +347,9 @@ test("confirmed KPI lower bounds stay qualified while exact values win", () => {
     {
       value: exactKpis.find((item) => item.id === "active").value,
       suffix: exactKpis.find((item) => item.id === "active").suffix,
+      hint: exactKpis.find((item) => item.id === "active").hint,
     },
-    { value: 1, suffix: undefined },
+    { value: 1, suffix: undefined, hint: undefined },
   );
   assert.deepEqual(
     {
@@ -398,7 +360,7 @@ test("confirmed KPI lower bounds stay qualified while exact values win", () => {
   );
 });
 
-test("confirmed KPI hints describe metric gaps when every workflow status is known", () => {
+test("confirmed KPI path keeps only baseHints without lower-bound wording", () => {
   const summary = parseDashboardSummary(
     summaryWithCountEvidence({ total: 1, known: 1, unknown: 0, confirmed: { active: 1 } }),
   );
@@ -413,10 +375,16 @@ test("confirmed KPI hints describe metric gaps when every workflow status is kno
     showCapacity: false,
     includeSummary: true,
   });
-  for (const id of ["active", "completed"]) {
-    const hint = kpis.find((item) => item.id === id).hint;
-    assert.match(hint, /exact metric count is incomplete/);
-    assert.doesNotMatch(hint, /project total is incomplete/);
+  const active = kpis.find((item) => item.id === "active");
+  const completed = kpis.find((item) => item.id === "completed");
+  assert.equal(active.hint, undefined);
+  assert.equal(completed.hint, "last 24h");
+  for (const item of [active, completed]) {
+    assert.equal(item.suffix, undefined);
+    assert.doesNotMatch(
+      `${item.value}${item.suffix ?? ""}${item.hint ?? ""}`,
+      /confirmed|lower bound|partial coverage|coverage unknown|workflow statuses known/i,
+    );
   }
 });
 
@@ -439,30 +407,6 @@ test("missing count evidence keeps null KPIs as honest dashes", () => {
   assert.deepEqual(
     { value: queued.value, suffix: queued.suffix, hint: queued.hint },
     { value: "—", suffix: undefined, hint: undefined },
-  );
-});
-
-test("coverage notice quantifies statuses without hiding other evidence gaps", () => {
-  const parsed = parseDashboardSummary(
-    summaryWithCountEvidence({ total: 1, known: 1, unknown: 0 }),
-  );
-  assert.ok(parsed);
-  parsed.coverage.notes = ["terminal_timestamp_unavailable", "attention_evidence_unavailable"];
-  assert.equal(
-    formatDashboardCoverageNotice(parsed.coverage, parsed.count_evidence),
-    "partial coverage — 1 of 1 workflow statuses known; 0 unknown; terminal timestamp unavailable; attention evidence unavailable",
-  );
-  assert.equal(
-    formatDashboardCoverageNotice(
-      { status: "unknown", notes: ["provider_lag"] },
-      {
-        total_workspaces: 29,
-        status_known_workspaces: 24,
-        status_unknown_workspaces: 5,
-        confirmed_counts: zeroConfirmedCounts(),
-      },
-    ),
-    "coverage unknown — 24 of 29 workflow statuses known; 5 unknown; provider lag",
   );
 });
 

--- a/apps/console/lib/console-dashboard-summary.ts
+++ b/apps/console/lib/console-dashboard-summary.ts
@@ -1,7 +1,6 @@
 import { capacityUtilizationPct } from "./format.ts";
 import type {
   ConsoleBackendKind,
-  ConsoleDashboardCountEvidence,
   ConsoleDashboardCounts,
   ConsoleDashboardSummary,
   ResourceSaturationSummary,
@@ -134,8 +133,11 @@ function countRelationshipsAreValid(counts: Record<DashboardCountKey, number | n
   return true;
 }
 
-const CONFIRMED_COUNT_HINT = "confirmed lower bound; exact metric count is incomplete";
-
+/**
+ * Plain numeric presentation: exact counts win; otherwise confirmed evidence
+ * (including evidenced zero). No "confirmed" suffix or lower-bound hint copy —
+ * incomplete coverage stays a backend field, not strip chrome.
+ */
 function displayCount(
   exact: number | null | undefined,
   confirmed: number | null | undefined,
@@ -145,57 +147,10 @@ function displayCount(
     return { value: exact, hint: baseHint };
   }
   if (confirmed != null) {
-    return {
-      value: confirmed,
-      suffix: " confirmed",
-      hint: baseHint ? `${baseHint} · ${CONFIRMED_COUNT_HINT}` : CONFIRMED_COUNT_HINT,
-    };
+    return { value: confirmed, hint: baseHint };
   }
   // Null ≠ zero: incomplete/unknown counts without evidence render as an em dash.
   return { value: DASH };
-}
-
-const COVERAGE_NOTE_LABELS: Record<string, string> = {
-  queued_count_unavailable: "queued count unavailable",
-  no_prior_successful_snapshot: "no prior successful snapshot",
-};
-
-function formatCoverageNote(note: string): string {
-  const known = COVERAGE_NOTE_LABELS[note];
-  if (known) {
-    return known;
-  }
-  const trimmed = note.trim();
-  if (!trimmed) {
-    return "";
-  }
-  return trimmed.replaceAll("_", " ");
-}
-
-/**
- * Operator-facing incomplete-coverage notice for an HTTP 200 summary.
- * Null when coverage is missing or complete — request errors stay a separate banner.
- */
-export function formatDashboardCoverageNotice(
-  coverage: { status: string; notes?: readonly string[] | null } | null | undefined,
-  countEvidence?: ConsoleDashboardCountEvidence | null,
-): string | null {
-  if (!coverage || (coverage.status !== "partial" && coverage.status !== "unknown")) {
-    return null;
-  }
-  const notes = (coverage.notes ?? [])
-    .map((note) => formatCoverageNote(note))
-    .filter((note) => note.length > 0);
-  if (countEvidence) {
-    notes.unshift(
-      `${countEvidence.status_known_workspaces} of ${countEvidence.total_workspaces} workflow statuses known; ${countEvidence.status_unknown_workspaces} unknown`,
-    );
-  }
-  const headline = coverage.status === "partial" ? "partial coverage" : "coverage unknown";
-  if (notes.length === 0) {
-    return `${headline} — some counts are incomplete`;
-  }
-  return `${headline} — ${notes.join("; ")}`;
 }
 
 export function fleetKpisFromDashboardSummary(options: {

--- a/apps/console/tests/dashboard-summary-kpis.spec.ts
+++ b/apps/console/tests/dashboard-summary-kpis.spec.ts
@@ -56,6 +56,62 @@ function hostedCountEvidenceSummary(): ConsoleDashboardSummary {
   };
 }
 
+function localExactCountSummary(): ConsoleDashboardSummary {
+  return localDashboardSummary({
+    counts: {
+      active: 9,
+      executing: 3,
+      monitoring_pr: 2,
+      awaiting_operator: 1,
+      awaiting_human: 1,
+      retrying: 1,
+      queued: 2,
+      completed_last_window: 3,
+      cancelled_last_window: 1,
+      failed_last_window: 2,
+    },
+  });
+}
+
+/** Exact counts win; confirmed evidence fills only null exact fields. */
+function mixedExactAndConfirmedSummary(): ConsoleDashboardSummary {
+  return localDashboardSummary({
+    coverage: {
+      status: "partial",
+      notes: ["some_statuses_unknown"],
+    },
+    counts: {
+      active: 5,
+      executing: null,
+      monitoring_pr: 2,
+      awaiting_operator: null,
+      awaiting_human: 0,
+      retrying: null,
+      queued: 1,
+      completed_last_window: null,
+      cancelled_last_window: null,
+      failed_last_window: 0,
+    },
+    count_evidence: {
+      total_workspaces: 12,
+      status_known_workspaces: 8,
+      status_unknown_workspaces: 4,
+      confirmed_counts: {
+        active: 99,
+        executing: 3,
+        monitoring_pr: 99,
+        awaiting_operator: 1,
+        awaiting_human: 99,
+        retrying: 0,
+        queued: 99,
+        completed_last_window: 4,
+        cancelled_last_window: 0,
+        failed_last_window: 99,
+      },
+    },
+  });
+}
+
 async function assertNoCoverageChrome(page: Page) {
   await expect(page.getByTestId("dashboard-summary-coverage")).toHaveCount(0);
   await expect(page.getByTestId("dashboard-summary-error")).toHaveCount(0);
@@ -146,44 +202,104 @@ test("unknown dashboard coverage stays silent without a request error", async ({
   await assertNoCoverageChrome(page);
 });
 
-for (const viewport of [
+const VIEWPORTS = [
   { name: "desktop", width: 1280, height: 900 },
   { name: "mobile-390", width: 390, height: 844 },
   { name: "mobile-375", width: 375, height: 812 },
-]) {
-  test(`count evidence renders plain numbers on ${viewport.name}`, async ({ page }) => {
-    await page.setViewportSize({ width: viewport.width, height: viewport.height });
-    await mockAwfConsoleApi(page, {
-      mode: "hosted",
-      dashboardSummary: hostedCountEvidenceSummary(),
+] as const;
+
+type CountScenario = {
+  name: string;
+  mode: "local" | "hosted";
+  summary: () => ConsoleDashboardSummary;
+  assertKpis: (page: Page) => Promise<void>;
+};
+
+const COUNT_SCENARIOS: CountScenario[] = [
+  {
+    name: "hosted-confirmed",
+    mode: "hosted",
+    summary: hostedCountEvidenceSummary,
+    assertKpis: async (page) => {
+      // Unknown workflow statuses leave exact counts null; confirmed evidence still shows
+      // plain numbers (including evidenced zeros) — never "N confirmed" or lower-bound copy.
+      await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("1");
+      await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("0");
+      await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("1");
+      await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("0");
+      await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("0");
+      await expect(kpi(page, "Completed")).toContainText("last 24h");
+      await expect(kpi(page, "Completed")).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
+      await expect(kpi(page, "Running")).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
+    },
+  },
+  {
+    name: "local-exact",
+    mode: "local",
+    summary: localExactCountSummary,
+    assertKpis: async (page) => {
+      await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("9");
+      await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("3");
+      await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("2");
+      await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("1");
+      await expect(kpi(page, "Awaiting human").locator(".kpi-value")).toHaveText("1");
+      await expect(kpi(page, "Auto-retrying").locator(".kpi-value")).toHaveText("1");
+      await expect(kpi(page, "Queued").locator(".kpi-value")).toHaveText("2");
+      await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("3");
+      await expect(kpi(page, "Cancelled").locator(".kpi-value")).toHaveText("1");
+      await expect(kpi(page, "Failed").locator(".kpi-value")).toHaveText("2");
+      await expect(kpi(page, "Completed")).toContainText("last 24h");
+      await expect(kpi(page, "Completed")).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
+    },
+  },
+  {
+    name: "mixed-exact-confirmed",
+    mode: "local",
+    summary: mixedExactAndConfirmedSummary,
+    assertKpis: async (page) => {
+      // Exact wins when both present; confirmed fills nulls; evidenced zeros stay plain.
+      await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("5");
+      await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("3");
+      await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("2");
+      await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("1");
+      await expect(kpi(page, "Awaiting human").locator(".kpi-value")).toHaveText("0");
+      await expect(kpi(page, "Auto-retrying").locator(".kpi-value")).toHaveText("0");
+      await expect(kpi(page, "Queued").locator(".kpi-value")).toHaveText("1");
+      await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("4");
+      await expect(kpi(page, "Cancelled").locator(".kpi-value")).toHaveText("0");
+      await expect(kpi(page, "Failed").locator(".kpi-value")).toHaveText("0");
+      await expect(kpi(page, "Completed")).toContainText("last 24h");
+      await expect(kpi(page, "Active")).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
+      await expect(kpi(page, "Running")).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
+    },
+  },
+];
+
+for (const viewport of VIEWPORTS) {
+  for (const scenario of COUNT_SCENARIOS) {
+    test(`${scenario.name} renders plain numbers on ${viewport.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await mockAwfConsoleApi(page, {
+        mode: scenario.mode,
+        dashboardSummary: scenario.summary(),
+      });
+
+      await page.goto("/");
+      await waitForConsoleReady(page);
+      await scenario.assertKpis(page);
+      await assertNoCoverageChrome(page);
+
+      const hasHorizontalOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      );
+      expect(hasHorizontalOverflow).toBe(false);
+
+      await page.screenshot({
+        path: `test-results/dashboard-summary-kpis-${scenario.name}-${viewport.name}.png`,
+        fullPage: true,
+      });
     });
-
-    await page.goto("/");
-    await waitForConsoleReady(page);
-
-    // Unknown workflow statuses leave exact counts null; confirmed evidence still shows
-    // plain numbers (including evidenced zeros) — never "N confirmed" or lower-bound copy.
-    await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("1");
-    await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("0");
-    await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("1");
-    await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("0");
-    await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("0");
-    await expect(kpi(page, "Completed")).toContainText("last 24h");
-    await expect(kpi(page, "Completed")).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
-    await expect(kpi(page, "Running")).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
-
-    await assertNoCoverageChrome(page);
-
-    const hasHorizontalOverflow = await page.evaluate(
-      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
-    );
-    expect(hasHorizontalOverflow).toBe(false);
-
-    await page.screenshot({
-      path: `test-results/dashboard-summary-kpis-count-evidence-${viewport.name}.png`,
-      fullPage: true,
-    });
-  });
+  }
 }
 
 test("status counters stay consistent for escalation/retry/terminal fixtures", async ({ page }) => {

--- a/apps/console/tests/dashboard-summary-kpis.spec.ts
+++ b/apps/console/tests/dashboard-summary-kpis.spec.ts
@@ -75,13 +75,16 @@ function localExactCountSummary(): ConsoleDashboardSummary {
 
 /** Exact counts win; confirmed evidence fills only null exact fields. */
 function mixedExactAndConfirmedSummary(): ConsoleDashboardSummary {
+  // Parser invariants: unknown statuses must be 0 when any exact count is
+  // non-null, and every non-null exact value must equal confirmed_counts.
+  // Null exact fields remain so confirmed fallback is still exercised.
   return localDashboardSummary({
     coverage: {
       status: "partial",
-      notes: ["some_statuses_unknown"],
+      notes: ["some_counts_unavailable"],
     },
     counts: {
-      active: 5,
+      active: 7,
       executing: null,
       monitoring_pr: 2,
       awaiting_operator: null,
@@ -93,20 +96,20 @@ function mixedExactAndConfirmedSummary(): ConsoleDashboardSummary {
       failed_last_window: 0,
     },
     count_evidence: {
-      total_workspaces: 12,
-      status_known_workspaces: 8,
-      status_unknown_workspaces: 4,
+      total_workspaces: 11,
+      status_known_workspaces: 11,
+      status_unknown_workspaces: 0,
       confirmed_counts: {
-        active: 99,
+        active: 7,
         executing: 3,
-        monitoring_pr: 99,
+        monitoring_pr: 2,
         awaiting_operator: 1,
-        awaiting_human: 99,
+        awaiting_human: 0,
         retrying: 0,
-        queued: 99,
+        queued: 1,
         completed_last_window: 4,
         cancelled_last_window: 0,
-        failed_last_window: 99,
+        failed_last_window: 0,
       },
     },
   });
@@ -274,7 +277,7 @@ const COUNT_SCENARIOS: CountScenario[] = [
     summary: mixedExactAndConfirmedSummary,
     assertKpis: async (page) => {
       // Exact wins when both present; confirmed fills nulls; evidenced zeros stay plain.
-      await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("5");
+      await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("7");
       await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("3");
       await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("2");
       await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("1");

--- a/apps/console/tests/dashboard-summary-kpis.spec.ts
+++ b/apps/console/tests/dashboard-summary-kpis.spec.ts
@@ -12,6 +12,9 @@ async function waitForConsoleReady(page: Page) {
 const kpi = (page: Page, label: string) =>
   page.getByText(label, { exact: true }).locator("..").filter({ has: page.locator(".kpi-value") });
 
+const COVERAGE_OR_CONFIRMED_COPY =
+  /confirmed|lower bound|partial coverage|coverage unknown|workflow statuses known/i;
+
 function hostedCountEvidenceSummary(): ConsoleDashboardSummary {
   const base = hostedDashboardSummary() as ConsoleDashboardSummary;
   return {
@@ -33,8 +36,9 @@ function hostedCountEvidenceSummary(): ConsoleDashboardSummary {
       failed_last_window: null,
     },
     count_evidence: {
-      total_workspaces: 30,
-      status_known_workspaces: 25,
+      // Production-shaped acceptance fixture: 29 total / 24 known / 5 unknown.
+      total_workspaces: 29,
+      status_known_workspaces: 24,
       status_unknown_workspaces: 5,
       confirmed_counts: {
         active: 1,
@@ -50,6 +54,13 @@ function hostedCountEvidenceSummary(): ConsoleDashboardSummary {
       },
     },
   };
+}
+
+async function assertNoCoverageChrome(page: Page) {
+  await expect(page.getByTestId("dashboard-summary-coverage")).toHaveCount(0);
+  await expect(page.getByTestId("dashboard-summary-error")).toHaveCount(0);
+  const strip = page.getByLabel("Fleet health");
+  await expect(strip).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
 }
 
 test("KPI values come from dashboard-summary when saturation absent", async ({ page }) => {
@@ -76,10 +87,10 @@ test("KPI values come from dashboard-summary when saturation absent", async ({ p
   await expect(kpi(page, "Capacity")).toHaveCount(0);
 
   expect(requested.some((path) => path.includes("/metrics/resources/saturation"))).toBe(false);
-  await expect(page.getByTestId("dashboard-summary-coverage")).toHaveCount(0);
+  await assertNoCoverageChrome(page);
 });
 
-test("null dashboard counts render as dash not zero", async ({ page }) => {
+test("null dashboard counts render as dash not zero without coverage banner", async ({ page }) => {
   await mockAwfConsoleApi(page, {
     dashboardSummary: localDashboardSummary({
       coverage: { status: "partial", notes: ["queued_count_unavailable"] },
@@ -105,16 +116,11 @@ test("null dashboard counts render as dash not zero", async ({ page }) => {
   await expect(kpi(page, "Failed").locator(".kpi-value")).toHaveText("0");
   await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("3");
 
-  // HTTP 200 clears the request error; partial coverage must still be explicit.
-  const coverage = page.getByTestId("dashboard-summary-coverage");
-  await expect(coverage).toBeVisible();
-  await expect(coverage).toContainText("partial coverage");
-  await expect(coverage).toContainText("queued count unavailable");
-  await expect(coverage).toContainText("last complete 2026-09-06T17:00:00Z");
-  await expect(page.getByTestId("dashboard-summary-error")).toHaveCount(0);
+  // HTTP 200 clears the request error; partial coverage alone must not surface a banner.
+  await assertNoCoverageChrome(page);
 });
 
-test("unknown dashboard coverage renders an explicit notice without a request error", async ({ page }) => {
+test("unknown dashboard coverage stays silent without a request error", async ({ page }) => {
   await mockAwfConsoleApi(page, {
     dashboardSummary: localDashboardSummary({
       coverage: { status: "unknown", notes: ["provider_lag"] },
@@ -137,18 +143,15 @@ test("unknown dashboard coverage renders an explicit notice without a request er
   await waitForConsoleReady(page);
   await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("3");
   await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("—");
-  const coverage = page.getByTestId("dashboard-summary-coverage");
-  await expect(coverage).toBeVisible();
-  await expect(coverage).toContainText("coverage unknown");
-  await expect(coverage).toContainText("provider lag");
-  await expect(page.getByTestId("dashboard-summary-error")).toHaveCount(0);
+  await assertNoCoverageChrome(page);
 });
 
 for (const viewport of [
   { name: "desktop", width: 1280, height: 900 },
-  { name: "mobile", width: 390, height: 844 },
+  { name: "mobile-390", width: 390, height: 844 },
+  { name: "mobile-375", width: 375, height: 812 },
 ]) {
-  test(`count evidence stays qualified and readable on ${viewport.name}`, async ({ page }) => {
+  test(`count evidence renders plain numbers on ${viewport.name}`, async ({ page }) => {
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
     await mockAwfConsoleApi(page, {
       mode: "hosted",
@@ -158,37 +161,28 @@ for (const viewport of [
     await page.goto("/");
     await waitForConsoleReady(page);
 
-    // Unknown workflow statuses make every exact count unproven, so the fixture
-    // exposes only explicitly qualified lower bounds, including zero.
-    await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("1 confirmed");
-    await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("0 confirmed");
-    await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("1 confirmed");
-    await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("0 confirmed");
-    await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("0 confirmed");
-    await expect(kpi(page, "Running")).toContainText("exact metric count is incomplete");
+    // Unknown workflow statuses leave exact counts null; confirmed evidence still shows
+    // plain numbers (including evidenced zeros) — never "N confirmed" or lower-bound copy.
+    await expect(kpi(page, "Active").locator(".kpi-value")).toHaveText("1");
+    await expect(kpi(page, "Awaiting operator").locator(".kpi-value")).toHaveText("0");
+    await expect(kpi(page, "Running").locator(".kpi-value")).toHaveText("1");
+    await expect(kpi(page, "Monitoring PR").locator(".kpi-value")).toHaveText("0");
+    await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("0");
     await expect(kpi(page, "Completed")).toContainText("last 24h");
-    await expect(kpi(page, "Completed")).toContainText("exact metric count is incomplete");
+    await expect(kpi(page, "Completed")).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
+    await expect(kpi(page, "Running")).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
 
-    const coverage = page.getByTestId("dashboard-summary-coverage");
-    await expect(coverage).toContainText("25 of 30 workflow statuses known; 5 unknown");
-    await expect(coverage).toContainText("terminal timestamp unavailable");
-    await expect(coverage).toContainText("attention evidence unavailable");
-    await expect(page.getByTestId("dashboard-summary-error")).toHaveCount(0);
+    await assertNoCoverageChrome(page);
 
-    for (const label of ["Active", "Running", "Monitoring PR", "Awaiting operator", "Completed"]) {
-      const card = kpi(page, label);
-      const valueBox = await card.locator(".kpi-value").boundingBox();
-      const hintBox = await card.getByText(/exact metric count is incomplete/).boundingBox();
-      expect(valueBox, `${label} value is measurable`).not.toBeNull();
-      expect(hintBox, `${label} incomplete-metric hint is measurable`).not.toBeNull();
-      expect(valueBox!.y + valueBox!.height, `${label} value does not overlap its hint`).toBeLessThanOrEqual(
-        hintBox!.y + 1,
-      );
-    }
     const hasHorizontalOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
     );
     expect(hasHorizontalOverflow).toBe(false);
+
+    await page.screenshot({
+      path: `test-results/dashboard-summary-kpis-count-evidence-${viewport.name}.png`,
+      fullPage: true,
+    });
   });
 }
 
@@ -217,5 +211,7 @@ test("status counters stay consistent for escalation/retry/terminal fixtures", a
   await expect(kpi(page, "Awaiting human").locator(".kpi-value")).toHaveText("1");
   await expect(kpi(page, "Auto-retrying").locator(".kpi-value")).toHaveText("1");
   await expect(kpi(page, "Completed").locator(".kpi-value")).toHaveText("3");
+  await expect(kpi(page, "Completed")).toContainText("last 24h");
+  await assertNoCoverageChrome(page);
   await page.screenshot({ path: "test-results/dashboard-summary-kpis-desktop.png", fullPage: true });
 });

--- a/apps/console/tests/dashboard-summary-kpis.spec.ts
+++ b/apps/console/tests/dashboard-summary-kpis.spec.ts
@@ -119,6 +119,22 @@ async function assertNoCoverageChrome(page: Page) {
   await expect(strip).not.toContainText(COVERAGE_OR_CONFIRMED_COPY);
 }
 
+/** Page + Fleet health strip must not overflow on any count-selection fixture. */
+async function assertNoHorizontalOverflow(page: Page) {
+  const overflow = await page.evaluate(() => {
+    const root = document.documentElement;
+    const body = document.body;
+    const viewport = window.innerWidth;
+    const amount = Math.max(root.scrollWidth, body.scrollWidth) - viewport;
+    const strip = document.querySelector('[aria-label="Fleet health"]');
+    const stripOverflow =
+      strip instanceof HTMLElement ? strip.scrollWidth > strip.clientWidth + 1 : false;
+    return { amount, stripOverflow, viewport };
+  });
+  expect(overflow.amount, JSON.stringify(overflow)).toBeLessThanOrEqual(1);
+  expect(overflow.stripOverflow, JSON.stringify(overflow)).toBe(false);
+}
+
 test("KPI values come from dashboard-summary when saturation absent", async ({ page }) => {
   const requested: string[] = [];
   await mockAwfConsoleApi(page, {
@@ -288,11 +304,7 @@ for (const viewport of VIEWPORTS) {
       await waitForConsoleReady(page);
       await scenario.assertKpis(page);
       await assertNoCoverageChrome(page);
-
-      const hasHorizontalOverflow = await page.evaluate(
-        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
-      );
-      expect(hasHorizontalOverflow).toBe(false);
+      await assertNoHorizontalOverflow(page);
 
       await page.screenshot({
         path: `test-results/dashboard-summary-kpis-${scenario.name}-${viewport.name}.png`,


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_2eee6a4b01774c6aa263a576` (agent: `cursor`, model: `auto`).


### Task
Environment: /workspace is the AWF Core repository. Use its existing .awf/workspace.yml and normal validation; auth and services are supplied by AWF. This is a small shared-console presentation correction requested explicitly by the user, not a new dashboard design.

User acceptance target: the hosted console fleet strip should look like the existing local console: normal labels (Active, Running, Monitoring PR, Awaiting operator, Auto-retrying, Awaiting human, Queued, Completed, Cancelled, Failed) and plain numeric values; retain the existing last 24h hint on terminal counters. The user explicitly REJECTED explanatory scope captions, unknown-count badges, coverage banners, repeated confirmed/lower-bound wording and replacement info controls. Do not introduce any.

Code evidence: apps/console/lib/console-dashboard-summary.ts displayCount adds suffix " confirmed" and CONFIRMED_COUNT_HINT ("confirmed lower bound; exact metric count is incomplete"). formatDashboardCoverageNotice constructs the yellow coverage message. apps/console/components/console-dashboard-overview.tsx FleetHealthStrip displays it, with props passed from console-dashboard.tsx. Relevant existing tests are lib/console-dashboard-summary.test.mjs and tests/dashboard-summary-kpis.spec.ts.

Implement with strict TDD:
1. Update focused unit/browser assertions first and prove the old UI fails the new requirement.
2. Remove the routine partial/unknown coverage banner and the confirmed suffix / lower-bound hints from the shared presentation. Remove unused coverage formatter/prop wiring if no other consumers need it. Do not hide it with CSS.
3. Preserve current numeric selection: a validated exact count takes precedence, otherwise use the existing validated confirmed_counts observation as the displayed number, including evidenced zero. If neither is recorded keep the existing dash; NEVER fabricate zero or derive project totals from the loaded workspace page. Preserve backend coverage/count_evidence fields, validation, auth/tenant scope and aggregate semantics unchanged. This is an explicit presentation decision, not permission to mark unknown backend records known.
4. Keep genuine request errors and existing stale/last-success behavior. Unknown coverage in a successful response must not become an outage warning. No new labels/badges/tooltips/explanatory copy. Local complete-data presentation stays visually unchanged.
5. Verify both local and hosted fixture modes at desktop and mobile widths (375/390), including the production-shaped 29 total /24 known /5 unknown response, plain zero and nonzero observed values, mixed exact values, no evidence -> dash, terminal last24h, failed refresh and stale snapshot. Assert no routine coverage/confirmed/lower-bound text or replacement UI and no horizontal overflow. Keep validation of malformed/cross-tenant/contradictory responses intact. Use bounded Playwright parallelism and screenshots plus existing unit/lint/typecheck/build commands.

Allowed scope: the shared fleet summary formatter, FleetHealthStrip rendering, removal of now-unused call-site props, and their directly related unit/browser tests. No new dependencies, package/lock/profile/CI changes, Python/backend/REST/MCP schema changes, lifecycle/admission/telemetry/cost work, runtime panel redesign, pagination changes, or unrelated refactors. Do not broaden the task because of unrelated existing review topics. Preserve coverage and normal repo validation; do not skip/disable tests or lower gates. Follow AGENTS.md local plan/validation discipline; never stage plans/*_PLAN.md or plans/*_VALIDATION.md.

Optimize for the smallest direct change and screenshot parity with the local counters, not a new abstraction. Git is functional in /workspace: commit the finished change before exiting. Do not push; AWF handles push, PR creation and monitoring.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Console-only presentation and test updates; count selection and backend parsing/validation are unchanged.
> 
> **Overview**
> Restores the fleet health strip to **plain numeric KPIs** (matching local console), without coverage banners or “confirmed / lower bound” copy on partial or hosted summaries.
> 
> **Presentation:** Removes the yellow partial/unknown **coverage notice** from `FleetHealthStrip` and drops `formatDashboardCoverageNotice` plus related props (`coverageStatus`, `coverageNotes`, `countEvidence`). `displayCount` still prefers exact counts, then `confirmed_counts` (including zero), then `—`; it no longer adds a `" confirmed"` suffix or incomplete-metric hints—only base hints like **last 24h** on terminal counters remain.
> 
> **Tests:** Unit and Playwright specs now assert no coverage chrome, plain numbers across hosted/local/mixed fixtures (including 29/24/5 evidence), and no horizontal overflow on desktop/mobile viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b33234fcd7b3b28aebdf074d8d510552573bb8ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->